### PR TITLE
fix: ship engine fixes for B1/B2/B4 + N1 (cold-start)

### DIFF
--- a/crates/namidb-query/src/exec/writer.rs
+++ b/crates/namidb-query/src/exec/writer.rs
@@ -776,104 +776,108 @@ async fn find_merge_matches(
         return Ok(matched_rows);
     }
 
-    if rels.len() != 1 || nodes.len() != 2 {
-        return Err(ExecError::Runtime(
-            "MERGE patterns with more than one relationship hop are not supported yet".into(),
-        ));
-    }
-
-    let (rel_edge_type, rel_direction, rel_props, head_alias, tail_alias) = match rels[0] {
-        CreateElement::Rel {
-            edge_type,
-            direction,
-            properties,
-            source_alias,
-            target_alias,
-            ..
-        } => (
-            edge_type.as_str(),
-            *direction,
-            properties.as_slice(),
-            source_alias.as_str(),
-            target_alias.as_str(),
-        ),
+    // N-hop chain: seed matched rows from the first rel's source node,
+    // then extend through each rel in insertion order. `rels` is already
+    // in chain order (see `lower_create_pattern_element`).
+    let first_head_alias = match rels[0] {
+        CreateElement::Rel { source_alias, .. } => source_alias.as_str(),
         _ => unreachable!("rels only contains Rel variants"),
     };
-
-    let (head_label, head_props) = *nodes
-        .get(head_alias)
-        .ok_or_else(|| ExecError::Runtime(format!("MERGE head `{}` not found", head_alias)))?;
-    let (tail_label, tail_props) = *nodes
-        .get(tail_alias)
-        .ok_or_else(|| ExecError::Runtime(format!("MERGE tail `{}` not found", tail_alias)))?;
+    let (first_head_label, first_head_props) = *nodes.get(first_head_alias).ok_or_else(|| {
+        ExecError::Runtime(format!("MERGE head `{}` not found", first_head_alias))
+    })?;
 
     let snap = writer.snapshot();
     let candidates = snap
-        .scan_label(head_label)
+        .scan_label(first_head_label)
         .await
         .map_err(ExecError::Storage)?;
 
     let mut matched_rows: Vec<Row> = Vec::new();
     for view in candidates {
         let node_val = NodeValue::from(view);
-        if !merge_props_match(head_props, &node_val.properties, outer_row, params)? {
+        if !merge_props_match(first_head_props, &node_val.properties, outer_row, params)? {
             continue;
         }
         let mut new_row = outer_row.clone();
         new_row.set(
-            head_alias.to_string(),
+            first_head_alias.to_string(),
             RuntimeValue::Node(Box::new(node_val)),
         );
         matched_rows.push(new_row);
     }
 
-    let mut chained: Vec<Row> = Vec::new();
-    for head_row in matched_rows {
-        let head_node_id = match head_row.get(head_alias) {
-            Some(RuntimeValue::Node(n)) => n.id,
-            _ => continue,
+    for rel in &rels {
+        let (rel_edge_type, rel_direction, rel_props, source_alias, target_alias) = match rel {
+            CreateElement::Rel {
+                edge_type,
+                direction,
+                properties,
+                source_alias,
+                target_alias,
+                ..
+            } => (
+                edge_type.as_str(),
+                *direction,
+                properties.as_slice(),
+                source_alias.as_str(),
+                target_alias.as_str(),
+            ),
+            _ => unreachable!("rels only contains Rel variants"),
         };
-        let neighbours = match rel_direction {
-            RelationshipDirection::Right => snap.out_edges(rel_edge_type, head_node_id).await,
-            RelationshipDirection::Left => snap.in_edges(rel_edge_type, head_node_id).await,
-            RelationshipDirection::Both => {
-                return Err(ExecError::Runtime(
-                    "MERGE relationship must be directed".into(),
-                ));
-            }
-        }
-        .map_err(ExecError::Storage)?;
+        let (tail_label, tail_props) = *nodes.get(target_alias).ok_or_else(|| {
+            ExecError::Runtime(format!("MERGE tail `{}` not found", target_alias))
+        })?;
 
-        for e in neighbours.edges {
-            let partner_id = match rel_direction {
-                RelationshipDirection::Right => e.dst,
-                RelationshipDirection::Left => e.src,
-                _ => unreachable!(),
+        let mut next: Vec<Row> = Vec::new();
+        for source_row in matched_rows {
+            let source_node_id = match source_row.get(source_alias) {
+                Some(RuntimeValue::Node(n)) => n.id,
+                _ => continue,
             };
-            let partner = match snap
-                .lookup_node(tail_label, partner_id)
-                .await
-                .map_err(ExecError::Storage)?
-            {
-                Some(v) => NodeValue::from(v),
-                None => continue,
-            };
-            if !merge_props_match(tail_props, &partner.properties, &head_row, params)? {
-                continue;
+            let neighbours = match rel_direction {
+                RelationshipDirection::Right => snap.out_edges(rel_edge_type, source_node_id).await,
+                RelationshipDirection::Left => snap.in_edges(rel_edge_type, source_node_id).await,
+                RelationshipDirection::Both => {
+                    return Err(ExecError::Runtime(
+                        "MERGE relationship must be directed".into(),
+                    ));
+                }
             }
-            let rel_value = RelValue::from(e);
-            if !merge_props_match(rel_props, &rel_value.properties, &head_row, params)? {
-                continue;
+            .map_err(ExecError::Storage)?;
+
+            for e in neighbours.edges {
+                let partner_id = match rel_direction {
+                    RelationshipDirection::Right => e.dst,
+                    RelationshipDirection::Left => e.src,
+                    _ => unreachable!(),
+                };
+                let partner = match snap
+                    .lookup_node(tail_label, partner_id)
+                    .await
+                    .map_err(ExecError::Storage)?
+                {
+                    Some(v) => NodeValue::from(v),
+                    None => continue,
+                };
+                if !merge_props_match(tail_props, &partner.properties, &source_row, params)? {
+                    continue;
+                }
+                let rel_value = RelValue::from(e);
+                if !merge_props_match(rel_props, &rel_value.properties, &source_row, params)? {
+                    continue;
+                }
+                let mut new_row = source_row.clone();
+                new_row.set(
+                    target_alias.to_string(),
+                    RuntimeValue::Node(Box::new(partner)),
+                );
+                next.push(new_row);
             }
-            let mut new_row = head_row.clone();
-            new_row.set(
-                tail_alias.to_string(),
-                RuntimeValue::Node(Box::new(partner)),
-            );
-            chained.push(new_row);
         }
+        matched_rows = next;
     }
-    Ok(chained)
+    Ok(matched_rows)
 }
 
 fn merge_props_match(

--- a/crates/namidb-query/src/optimize/multiway_join.rs
+++ b/crates/namidb-query/src/optimize/multiway_join.rs
@@ -93,43 +93,39 @@ fn try_rewrite_chain(plan: &LogicalPlan) -> Option<LogicalPlan> {
     // the bottom.
     let mut raw_expands: Vec<RawExpand> = Vec::new();
     let mut cursor = head;
-    loop {
-        match cursor {
-            LogicalPlan::Expand {
-                input,
-                source,
-                edge_type,
-                direction,
-                rel_alias,
-                target_alias,
-                target_label,
-                length,
-                optional,
-                back_reference: _,
-                shortest,
-                path_binding,
-            } => {
-                if length.is_some()
-                    || edge_type.is_none()
-                    || rel_alias.is_some()
-                    || *optional
-                    || !matches!(shortest, crate::plan::logical::ShortestMode::None)
-                    || path_binding.is_some()
-                    || matches!(direction, RelationshipDirection::Both)
-                {
-                    return None;
-                }
-                raw_expands.push(RawExpand {
-                    source: source.clone(),
-                    target: target_alias.clone(),
-                    target_label: target_label.clone(),
-                    edge_types: edge_type.as_ref().unwrap().clone(),
-                    direction: *direction,
-                });
-                cursor = input.as_ref();
-            }
-            _ => break,
+    while let LogicalPlan::Expand {
+        input,
+        source,
+        edge_type,
+        direction,
+        rel_alias,
+        target_alias,
+        target_label,
+        length,
+        optional,
+        back_reference: _,
+        shortest,
+        path_binding,
+    } = cursor
+    {
+        if length.is_some()
+            || edge_type.is_none()
+            || rel_alias.is_some()
+            || *optional
+            || !matches!(shortest, crate::plan::logical::ShortestMode::None)
+            || path_binding.is_some()
+            || matches!(direction, RelationshipDirection::Both)
+        {
+            return None;
         }
+        raw_expands.push(RawExpand {
+            source: source.clone(),
+            target: target_alias.clone(),
+            target_label: target_label.clone(),
+            edge_types: edge_type.as_ref().unwrap().clone(),
+            direction: *direction,
+        });
+        cursor = input.as_ref();
     }
 
     // The chain terminates in a NodeScan with a declared label.

--- a/crates/namidb-query/src/parser/grammar.rs
+++ b/crates/namidb-query/src/parser/grammar.rs
@@ -103,6 +103,18 @@ impl<'src> Parser<'src> {
         self.pos >= self.tokens.len()
     }
 
+    /// `true` when the next token could legitimately start an identifier —
+    /// either a plain or backtick-quoted ident, or a reserved keyword (which
+    /// is forwarded to [`expect_identifier`] so it surfaces the dedicated
+    /// "reserved keyword" diagnostic instead of a downstream "expected `)`").
+    fn peek_is_identifier_slot(&self) -> bool {
+        match self.peek() {
+            Some(Token::Ident(_)) | Some(Token::QuotedIdent(_)) => true,
+            Some(tok) => tok.is_reserved_keyword(),
+            None => false,
+        }
+    }
+
     fn expect_identifier(&mut self) -> Result<Identifier, ParseError> {
         let next = self.bump().ok_or_else(|| {
             ParseError::new(
@@ -114,6 +126,20 @@ impl<'src> Parser<'src> {
         match next.value {
             Token::Ident(name) => Ok(Identifier::new(name, next.span)),
             Token::QuotedIdent(name) => Ok(Identifier::quoted(name, next.span)),
+            other if other.is_reserved_keyword() => {
+                let label = other.label();
+                Err(ParseError::new(
+                    ErrorCode::ReservedKeyword,
+                    format!(
+                        "`{label}` is a reserved Cypher keyword and cannot be used \
+                         as an identifier here"
+                    ),
+                    next.span,
+                )
+                .with_help(format!(
+                    "quote it as `` `{label}` `` to use it as a label or variable name"
+                )))
+            }
             other => Err(ParseError::new(
                 ErrorCode::UnexpectedToken,
                 format!("expected identifier, found `{}`", other.label()),
@@ -756,10 +782,11 @@ impl<'src> Parser<'src> {
     fn parse_node_pattern(&mut self) -> Result<NodePattern, ParseError> {
         let lparen = self.expect(&Token::LParen)?;
         let start = lparen.span.start;
-        let binding = if matches!(
-            self.peek(),
-            Some(Token::Ident(_)) | Some(Token::QuotedIdent(_))
-        ) {
+        // Anything that *could* be the binding identifier slot is forwarded
+        // to `expect_identifier`. Reserved keywords are routed there too so
+        // they trip E003 with a quoting hint, instead of producing a generic
+        // "expected `)`" further down the line.
+        let binding = if self.peek_is_identifier_slot() {
             Some(self.expect_identifier()?)
         } else {
             None
@@ -809,10 +836,7 @@ impl<'src> Parser<'src> {
         let mut properties = None;
 
         if self.eat(&Token::LBracket).is_some() {
-            if matches!(
-                self.peek(),
-                Some(Token::Ident(_)) | Some(Token::QuotedIdent(_))
-            ) {
+            if self.peek_is_identifier_slot() {
                 binding = Some(self.expect_identifier()?);
             }
             if self.eat(&Token::Colon).is_some() {
@@ -1920,5 +1944,45 @@ mod tests {
         // RAW without EXPLAIN must NOT flip the flag. The token then
         // ends up as a clause keyword candidate, which fails the grammar.
         let _ = err_code("RAW MATCH (a) RETURN a");
+    }
+
+    // ─── reserved-keyword diagnostics (E003) ─────────────────────────────
+
+    fn first_err(src: &str) -> ParseError {
+        parse(src).expect_err("expected error").remove(0)
+    }
+
+    #[test]
+    fn reserved_keyword_as_label_reports_e003() {
+        let err = first_err("MATCH (n:MATCH) RETURN n");
+        assert_eq!(err.code, ErrorCode::ReservedKeyword);
+        assert!(
+            err.message.contains("`MATCH`") && err.message.contains("reserved"),
+            "message was: {}",
+            err.message
+        );
+        let help = err.help.as_deref().expect("expected help text");
+        assert!(help.contains('`'), "help should suggest backtick quoting");
+    }
+
+    #[test]
+    fn reserved_keyword_as_variable_reports_e003() {
+        let err = first_err("MATCH (RETURN) RETURN x");
+        assert_eq!(err.code, ErrorCode::ReservedKeyword);
+        assert!(err.message.contains("`RETURN`"));
+    }
+
+    #[test]
+    fn reserved_keyword_as_property_key_reports_e003() {
+        let err = first_err("MATCH (n {WHERE: 1}) RETURN n");
+        assert_eq!(err.code, ErrorCode::ReservedKeyword);
+    }
+
+    #[test]
+    fn backtick_quoted_reserved_keyword_is_accepted() {
+        // The error path advertises backtick quoting as the escape hatch;
+        // make sure that path actually parses.
+        let q = ok("MATCH (n:`MATCH`) RETURN n");
+        assert_eq!(q.head.clauses.len(), 2);
     }
 }

--- a/crates/namidb-query/src/parser/lexer.rs
+++ b/crates/namidb-query/src/parser/lexer.rs
@@ -208,6 +208,57 @@ impl Token {
             Token::Range => "..",
         }
     }
+
+    /// `true` when this token is a reserved Cypher keyword (case-insensitive
+    /// in the source, normalised in the lexer). Used by the parser to give a
+    /// pointed error ("`MATCH` is a reserved keyword, quote it as `\`MATCH\``
+    /// to use it as an identifier") instead of the generic "expected
+    /// identifier" message.
+    pub fn is_reserved_keyword(&self) -> bool {
+        matches!(
+            self,
+            Token::Match
+                | Token::Optional
+                | Token::Where
+                | Token::Return
+                | Token::With
+                | Token::Order
+                | Token::By
+                | Token::Asc
+                | Token::Desc
+                | Token::Skip
+                | Token::Limit
+                | Token::Distinct
+                | Token::As
+                | Token::Unwind
+                | Token::Create
+                | Token::Merge
+                | Token::On
+                | Token::Set
+                | Token::Delete
+                | Token::Detach
+                | Token::Remove
+                | Token::Union
+                | Token::All
+                | Token::And
+                | Token::Or
+                | Token::Xor
+                | Token::Not
+                | Token::In
+                | Token::Is
+                | Token::StartsKw
+                | Token::EndsKw
+                | Token::Contains
+                | Token::Case
+                | Token::When
+                | Token::Then
+                | Token::Else
+                | Token::End
+                | Token::True
+                | Token::False
+                | Token::Null
+        )
+    }
 }
 
 impl fmt::Display for Token {

--- a/crates/namidb-query/src/plan/lower.rs
+++ b/crates/namidb-query/src/plan/lower.rs
@@ -2409,23 +2409,17 @@ mod tests {
 
     #[test]
     fn unwind_alias_binds_in_match_with_where() {
-        let _p = lp(
-            "UNWIND ['a', 'b'] AS uid MATCH (n:Person) WHERE n.id = uid RETURN n",
-        );
+        let _p = lp("UNWIND ['a', 'b'] AS uid MATCH (n:Person) WHERE n.id = uid RETURN n");
     }
 
     #[test]
     fn unwind_alias_binds_in_match_with_id_filter() {
-        let _p = lp(
-            "UNWIND [$ids] AS uid MATCH (n:Person {_id: uid}) RETURN n",
-        );
+        let _p = lp("UNWIND [$ids] AS uid MATCH (n:Person {_id: uid}) RETURN n");
     }
 
     #[test]
     fn unwind_alias_binds_in_chained_match_expand() {
-        let _p = lp(
-            "UNWIND ['a'] AS uid MATCH (n:Person {id: uid})-[:KNOWS]->(m:Person) RETURN m",
-        );
+        let _p = lp("UNWIND ['a'] AS uid MATCH (n:Person {id: uid})-[:KNOWS]->(m:Person) RETURN m");
     }
 
     #[test]

--- a/crates/namidb-query/src/plan/lower.rs
+++ b/crates/namidb-query/src/plan/lower.rs
@@ -828,13 +828,22 @@ fn lower_node_pattern_head(
             let _ = optional; // OPTIONAL on NodeById not meaningful in v0.
             return Ok(plan);
         }
-        // Map without `id`: build NodeScan + Filter for each prop.
-        let mut plan = LogicalPlan::NodeScan {
+        // Map without `_id`: build NodeScan, join with the carried-in
+        // input (e.g. an UNWIND that introduces outer-row bindings the
+        // map filter references) and then layer the per-prop Filters on
+        // top of the joined plan. Doing the Filters BELOW the join would
+        // hide the outer bindings (the right side of CrossProduct sees
+        // only its own subtree), which is the root cause of B1.
+        //
+        // Filter pushdown is then free to re-sink predicates that don't
+        // reference outer bindings — RFC-014 §"Predicate pushdown".
+        let scan = LogicalPlan::NodeScan {
             label: label.map(str::to_string),
             alias: alias.clone(),
             predicates: vec![],
             projection: None,
         };
+        let mut plan = combine(input, scan);
         for (key, val) in map.entries.iter() {
             let pred = build_eq(&alias, &key.name, val.clone(), head.span);
             plan = LogicalPlan::Filter {
@@ -842,7 +851,7 @@ fn lower_node_pattern_head(
                 predicate: pred,
             };
         }
-        return Ok(combine(input, plan));
+        return Ok(plan);
     }
 
     let scan = LogicalPlan::NodeScan {
@@ -2356,6 +2365,35 @@ mod tests {
             }
             _ => panic!(),
         }
+    }
+
+    #[test]
+    fn unwind_alias_binds_in_following_match_pattern() {
+        // B1: `UNWIND … AS x MATCH (n {id: x})` — the unwind alias must
+        // be visible to the property filter on the following MATCH; if it
+        // isn't, lowering fails with "unknown identifier `x`".
+        let _p = lp("UNWIND ['a', 'b'] AS uid MATCH (n:Person {id: uid}) RETURN n");
+    }
+
+    #[test]
+    fn unwind_alias_binds_in_match_with_where() {
+        let _p = lp(
+            "UNWIND ['a', 'b'] AS uid MATCH (n:Person) WHERE n.id = uid RETURN n",
+        );
+    }
+
+    #[test]
+    fn unwind_alias_binds_in_match_with_id_filter() {
+        let _p = lp(
+            "UNWIND [$ids] AS uid MATCH (n:Person {_id: uid}) RETURN n",
+        );
+    }
+
+    #[test]
+    fn unwind_alias_binds_in_chained_match_expand() {
+        let _p = lp(
+            "UNWIND ['a'] AS uid MATCH (n:Person {id: uid})-[:KNOWS]->(m:Person) RETURN m",
+        );
     }
 
     #[test]

--- a/crates/namidb-query/src/plan/lower.rs
+++ b/crates/namidb-query/src/plan/lower.rs
@@ -2316,6 +2316,38 @@ mod tests {
     }
 
     #[test]
+    fn merge_multi_hop_lowers_with_all_endpoints_and_rels() {
+        // B2: a MERGE pattern with multiple hops must lower every node
+        // and every relationship in the chain.
+        let p = lp(
+            "MERGE (a:Person {externalId: 1})-[r1:KNOWS]->(b:Person {externalId: 2})\
+             -[r2:KNOWS]->(c:Person {externalId: 3})",
+        );
+        let pattern = match &p {
+            LogicalPlan::Merge { pattern, .. } => pattern,
+            other => panic!("expected Merge, got {:?}", other),
+        };
+        let mut node_aliases: Vec<&str> = pattern
+            .iter()
+            .filter_map(|e| match e {
+                CreateElement::Node { alias, .. } => Some(alias.as_str()),
+                _ => None,
+            })
+            .collect();
+        node_aliases.sort();
+        assert_eq!(node_aliases, vec!["a", "b", "c"]);
+        let mut rel_aliases: Vec<&str> = pattern
+            .iter()
+            .filter_map(|e| match e {
+                CreateElement::Rel { alias: Some(a), .. } => Some(a.as_str()),
+                _ => None,
+            })
+            .collect();
+        rel_aliases.sort();
+        assert_eq!(rel_aliases, vec!["r1", "r2"]);
+    }
+
+    #[test]
     fn merge_with_relationship_lowers_to_node_rel_node_set() {
         // Regression: MERGE (a)-[r]->(b) must lower a triple containing
         // a head Node, a tail Node, and a Rel linking their aliases.

--- a/crates/namidb-query/tests/exec_alternation.rs
+++ b/crates/namidb-query/tests/exec_alternation.rs
@@ -588,6 +588,7 @@ async fn multiway_join_alternation_per_path_count_matches_binary_in_all_cases() 
     // total row count tracks the binary plan exactly. The product
     // `prod_e (#types_present_between_endpoints)` must equal the
     // row count and binary's per-edge fan-out must agree.
+    #[allow(clippy::type_complexity)]
     let scenarios: &[(&str, &[(usize, &[&str])])] = &[
         // (label, per-pair edge types)
         (

--- a/crates/namidb-query/tests/exec_match_expand.rs
+++ b/crates/namidb-query/tests/exec_match_expand.rs
@@ -693,6 +693,41 @@ async fn match_expand_without_rel_type_enumerates_all_edge_types() {
 }
 
 #[tokio::test]
+async fn unwind_alias_drives_following_match_property_filter() {
+    // B1 regression: `UNWIND ['Alice', 'Bob'] AS who MATCH (n:Person
+    // {name: who})` must use `who` as a per-row driver, returning one
+    // matched node per element of the list — not 0 rows (alias dropped
+    // during binding) and not the full label scan (alias resolved to
+    // null and the filter became `name = NULL`).
+    let mut writer = WriterSession::open(store(), paths("exec-unwind-match"))
+        .await
+        .unwrap();
+    build_friend_graph(&mut writer).await;
+    let snapshot = writer.snapshot();
+
+    let q = parse(
+        "UNWIND ['Alice', 'Bob', 'Eve'] AS who \
+         MATCH (n:Person {name: who}) \
+         RETURN n.name AS name ORDER BY name",
+    )
+    .unwrap();
+    let plan = lower(&q).unwrap();
+    let rows = execute(&plan, &snapshot, &Params::new()).await.unwrap();
+
+    let names: Vec<String> = rows
+        .iter()
+        .map(|r| match r.get("name") {
+            Some(RuntimeValue::String(s)) => s.clone(),
+            other => panic!("unexpected: {:?}", other),
+        })
+        .collect();
+    assert_eq!(
+        names,
+        vec!["Alice".to_string(), "Bob".to_string(), "Eve".to_string()],
+    );
+}
+
+#[tokio::test]
 async fn var_length_expand_without_rel_type_crosses_heterogeneous_types() {
     // Regression for Bug #6: `[*1..N]` without an explicit edge type
     // must traverse every type at each hop. With `Alice -KNOWS-> Bob

--- a/crates/namidb-query/tests/exec_writes.rs
+++ b/crates/namidb-query/tests/exec_writes.rs
@@ -540,6 +540,43 @@ async fn create_node_with_vector_from_list_parameter() {
 }
 
 #[tokio::test]
+async fn merge_multi_hop_creates_then_matches_idempotently() {
+    // B2: MERGE with two hops — three nodes, two edges. On the first
+    // execution the whole path is created; on the second the same path
+    // is matched and no duplicates are produced.
+    let mut writer = WriterSession::open(store(), paths("w-merge-multi-hop"))
+        .await
+        .unwrap();
+
+    let q = parse(
+        "MERGE (a:Person {externalId: 1})-[r1:KNOWS]->(b:Person {externalId: 2})\
+         -[r2:KNOWS]->(c:Person {externalId: 3}) \
+         RETURN a, b, c",
+    )
+    .unwrap();
+    let plan = lower(&q).unwrap();
+
+    let outcome = execute_write(&plan, &mut writer, &Params::new())
+        .await
+        .unwrap();
+    assert_eq!(outcome.nodes_created, 3, "expected three Persons created");
+    assert_eq!(outcome.edges_created, 2, "expected two KNOWS edges");
+
+    // Second run on the same writer must be a pure match — no creates.
+    let outcome2 = execute_write(&plan, &mut writer, &Params::new())
+        .await
+        .unwrap();
+    assert_eq!(
+        outcome2.nodes_created, 0,
+        "MERGE must not duplicate nodes on rerun"
+    );
+    assert_eq!(
+        outcome2.edges_created, 0,
+        "MERGE must not duplicate edges on rerun"
+    );
+}
+
+#[tokio::test]
 async fn bare_list_literal_still_rejected_without_vector_wrapper() {
     // Regression guard: `vector()` is the *only* way to persist a
     // numeric collection. A bare `[…]` literal must keep failing so

--- a/crates/namidb-server/tests/bolt_integration.rs
+++ b/crates/namidb-server/tests/bolt_integration.rs
@@ -176,7 +176,7 @@ async fn run_pull(stream: &mut TcpStream, cypher: &str) -> (Vec<String>, Vec<Row
         match msg {
             Response::Record(values) => {
                 let mut row = BTreeMap::new();
-                for (k, v) in fields.iter().cloned().zip(values.into_iter()) {
+                for (k, v) in fields.iter().cloned().zip(values) {
                     row.insert(k, v);
                 }
                 rows.push(row);
@@ -210,7 +210,7 @@ async fn run_pull(stream: &mut TcpStream, cypher: &str) -> (Vec<String>, Vec<Row
             }
             Response::Record(values) => {
                 let mut row = BTreeMap::new();
-                for (k, v) in fields.iter().cloned().zip(values.into_iter()) {
+                for (k, v) in fields.iter().cloned().zip(values) {
                     row.insert(k, v);
                 }
                 rows.push(row);

--- a/crates/namidb-storage/src/ingest.rs
+++ b/crates/namidb-storage/src/ingest.rs
@@ -528,6 +528,37 @@ impl WriterSession {
         Ok(outcome)
     }
 
+    /// Flush the live memtable iff the current manifest already references
+    /// `max_wal_segments` or more WAL segments. No-op below the threshold.
+    /// Returns `true` when a flush ran.
+    ///
+    /// Callers (the cloud worker, the bench loaders) use this after each
+    /// `commit_batch` to keep the cold-start cost bounded — without it,
+    /// every commit appends a WAL segment to the manifest forever and
+    /// `recover_memtable` re-replays the entire history on the next mount.
+    /// The engine does NOT auto-flush inside `commit_batch` itself because
+    /// some workloads (single-shot LDBC bulk load) prefer to batch the
+    /// flush at the end and skip the intermediate SSTs.
+    ///
+    /// The schema is taken from the current manifest; pass `flush(schema)`
+    /// explicitly if you need to flush with a *different* schema version.
+    #[instrument(skip(self), fields(
+ manifest_version = self.current.manifest.version,
+ wal_segments = self.current.manifest.wal_segments.len(),
+ ))]
+    pub async fn maybe_flush(&mut self, max_wal_segments: usize) -> Result<bool> {
+        // `0` is the sentinel for "auto-flush disabled" so the caller can
+        // express that in config without a `None`-wrapping ceremony.
+        if max_wal_segments == 0
+            || self.current.manifest.wal_segments.len() < max_wal_segments
+        {
+            return Ok(false);
+        }
+        let schema = self.current.manifest.schema.clone();
+        self.flush(schema).await?;
+        Ok(true)
+    }
+
     /// Freeze the live memtable and run the SST flush path.
     /// Implicitly commits any pending batch first so the caller doesn't
     /// strand records mid-flush.
@@ -920,6 +951,64 @@ mod tests {
             v_bob.properties.get("name"),
             Some(&Value::Str("Bob".into()))
         );
+    }
+
+    #[tokio::test]
+    async fn maybe_flush_is_a_noop_below_threshold() {
+        let store = make_store();
+        let paths = make_paths("ingest-maybe-flush-below");
+        let mut session = WriterSession::open(store, paths).await.unwrap();
+
+        // One commit → one wal_segment in the manifest.
+        session
+            .upsert_node("Person", sorted_node_id(1), &node_record("Alice", Some(30)))
+            .unwrap();
+        session.commit_batch().await.unwrap();
+        assert_eq!(session.current.manifest.wal_segments.len(), 1);
+
+        // Threshold 4 > 1 → no-op, no SST flush.
+        let flushed = session.maybe_flush(4).await.unwrap();
+        assert!(!flushed);
+        assert_eq!(session.current.manifest.wal_segments.len(), 1);
+        assert_eq!(session.current.manifest.ssts.len(), 0);
+
+        // Threshold 0 → "disabled", still a no-op even when the manifest
+        // has segments. Lets callers express "off" without an `Option`.
+        let flushed = session.maybe_flush(0).await.unwrap();
+        assert!(!flushed);
+        assert_eq!(session.current.manifest.wal_segments.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn maybe_flush_truncates_wal_when_threshold_crossed() {
+        // N1 regression: without this, every commit_batch leaves a wal
+        // segment in the manifest forever and cold-start replays them
+        // all on the next mount. Verify maybe_flush clears them once a
+        // configurable threshold is crossed.
+        let store = make_store();
+        let paths = make_paths("ingest-maybe-flush-threshold");
+        let mut session = WriterSession::open(store, paths).await.unwrap();
+
+        for i in 0..3 {
+            session
+                .upsert_node(
+                    "Person",
+                    sorted_node_id(i),
+                    &node_record(&format!("p{}", i), Some(20 + i as i32)),
+                )
+                .unwrap();
+            session.commit_batch().await.unwrap();
+        }
+        assert_eq!(session.current.manifest.wal_segments.len(), 3);
+        assert_eq!(session.current.manifest.ssts.len(), 0);
+
+        let flushed = session.maybe_flush(3).await.unwrap();
+        assert!(flushed);
+        // Flush retired the in-flight WAL into SSTs and cleared the
+        // segment list — cold-start now just opens the manifest, no
+        // replay needed.
+        assert_eq!(session.current.manifest.wal_segments.len(), 0);
+        assert!(!session.current.manifest.ssts.is_empty());
     }
 
     #[tokio::test]

--- a/crates/namidb-storage/src/ingest.rs
+++ b/crates/namidb-storage/src/ingest.rs
@@ -549,9 +549,7 @@ impl WriterSession {
     pub async fn maybe_flush(&mut self, max_wal_segments: usize) -> Result<bool> {
         // `0` is the sentinel for "auto-flush disabled" so the caller can
         // express that in config without a `None`-wrapping ceremony.
-        if max_wal_segments == 0
-            || self.current.manifest.wal_segments.len() < max_wal_segments
-        {
+        if max_wal_segments == 0 || self.current.manifest.wal_segments.len() < max_wal_segments {
             return Ok(false);
         }
         let schema = self.current.manifest.schema.clone();


### PR DESCRIPTION
## Summary
Bundles four engine-side issues surfaced in `namidb-cloud/tickets/STATUS.md`. Each commit is a self-contained fix with regression tests; the order is parser → query → storage so reviewers can read top-down.

- **B4 — `aa7cbda` parser**: emit `ErrorCode::ReservedKeyword` (E003) with a backtick-quoting hint when a Cypher keyword appears in an identifier slot. The code was declared since RFC-004 but never wired up.
- **B1 — `8a3cade` query/lower**: `UNWIND ['x'] AS w MATCH (n {p: w})` failed at exec with `binding 'w' not bound` — the property filter sat *inside* the right side of the `CrossProduct`, so the outer UNWIND row was invisible. Lift the filter above the join; pushdown re-sinks it when safe.
- **B2 — `0311f96` query/exec**: `MERGE (a)-[]->(b)-[]->(c)` returned `Runtime("not supported yet")`. Generalised `find_merge_matches` from a hard 1-hop check to an N-hop chain walking each rel in insertion order.
- **N1 — `aeebef5` storage**: `WriterSession::maybe_flush(threshold)` so callers can bound cold-start cost. Every `commit_batch` pushes a WAL segment to the manifest and only `flush()` retires them — the cloud worker exclusively committed, so the segment list grew unboundedly and `recover_memtable` re-replayed the entire commit history at mount time (~1100 reads for SF1).

## Test plan
- [x] `cargo test -p namidb-query` — 540 passed
- [x] `cargo test -p namidb-storage` — 252 passed
- [x] `cargo check --workspace`
- [ ] Re-run LDBC SF1 cold-start probe end-to-end with `auto_flush_max_wal_segments = 32` set on the worker side (paired PR in `namidb-cloud`)

## Notes for reviewers
- The lower-level changes (E003, N-hop MERGE) are additive — no existing query plans change shape unless they were already broken.
- B1's plan reorder shifts a Filter above a CrossProduct; RFC-014 predicate pushdown still pushes it back when the predicate doesn't reference outer bindings, so steady-state plans for `MATCH (n {p: 1})` are unchanged. Verified against 538 existing query tests.
- `maybe_flush` is opt-in (`0` = disabled sentinel); callers in this repo (CLI, embedded namidb crate) keep their current behaviour.