### PR TITLE
feat(query): accept $param as the properties slot of a pattern

### DIFF
--- a/crates/namidb-query/src/exec/writer.rs
+++ b/crates/namidb-query/src/exec/writer.rs
@@ -342,6 +342,47 @@ fn execute_write_inner<'a>(
 
 // ──────────────────────────── CREATE ─────────────────────────────────
 
+/// Evaluate a `properties_spread` expression and merge its entries
+/// into the `core_props` / `runtime_props` accumulators of a CREATE.
+///
+/// The expression must evaluate to a `Map`; anything else is an error
+/// (most commonly the caller passed `$x` where `$x` is not a map).
+/// `_id` keys are extracted into `explicit_id` rather than treated as
+/// stored properties so the `CREATE (n:L $params)` idiom can still
+/// pin a NodeId through the spread map.
+fn apply_spread_properties(
+    spread_expr: &Expression,
+    row: &Row,
+    params: &Params,
+    core_props: &mut BTreeMap<String, CoreValue>,
+    runtime_props: &mut BTreeMap<String, RuntimeValue>,
+    explicit_id: &mut Option<NodeId>,
+) -> Result<(), ExecError> {
+    let value = evaluate(spread_expr, row, params)?;
+    let map = match value {
+        RuntimeValue::Map(m) => m,
+        other => {
+            return Err(ExecError::Runtime(format!(
+                "properties spread expects a MAP, got {}",
+                other.type_name()
+            )));
+        }
+    };
+    for (k, v) in map {
+        if k == "_id" {
+            *explicit_id = Some(crate::exec::walker::node_id_from_value(
+                &v,
+                spread_expr.span,
+            )?);
+            continue;
+        }
+        let core = runtime_to_core(&v, spread_expr).map_err(ExecError::Runtime)?;
+        core_props.insert(k.clone(), core);
+        runtime_props.insert(k, v);
+    }
+    Ok(())
+}
+
 fn apply_create(
     elements: &[CreateElement],
     mut row: Row,
@@ -355,6 +396,7 @@ fn apply_create(
                 alias,
                 label,
                 properties,
+                properties_spread,
             } => {
                 // Back-reference: don't create if already bound.
                 if row.get(alias).is_some() {
@@ -363,6 +405,20 @@ fn apply_create(
                 let mut core_props = BTreeMap::new();
                 let mut runtime_props = BTreeMap::new();
                 let mut explicit_id: Option<NodeId> = None;
+                // `properties_spread` is the runtime-evaluated map for
+                // the `CREATE (n:L $params)` idiom. Apply it first so
+                // explicit `properties` overwrite collisions, matching
+                // the conventional spread semantics.
+                if let Some(spread_expr) = properties_spread {
+                    apply_spread_properties(
+                        spread_expr,
+                        &row,
+                        params,
+                        &mut core_props,
+                        &mut runtime_props,
+                        &mut explicit_id,
+                    )?;
+                }
                 for (k, expr) in properties {
                     let v = evaluate(expr, &row, params)?;
                     if k == "_id" {
@@ -403,6 +459,7 @@ fn apply_create(
                 target_alias,
                 direction,
                 properties,
+                properties_spread,
             } => {
                 let src_id = expect_node_id(&row, source_alias)?;
                 let dst_id = expect_node_id(&row, target_alias)?;
@@ -417,6 +474,24 @@ fn apply_create(
                 };
                 let mut core_props = BTreeMap::new();
                 let mut runtime_props = BTreeMap::new();
+                if let Some(spread_expr) = properties_spread {
+                    // `_id` only applies to node creates; edges have no
+                    // user-visible id slot.
+                    let mut ignored_id: Option<NodeId> = None;
+                    apply_spread_properties(
+                        spread_expr,
+                        &row,
+                        params,
+                        &mut core_props,
+                        &mut runtime_props,
+                        &mut ignored_id,
+                    )?;
+                    if ignored_id.is_some() {
+                        return Err(ExecError::Runtime(
+                            "_id is not valid on a relationship CREATE".into(),
+                        ));
+                    }
+                }
                 for (k, expr) in properties {
                     let v = evaluate(expr, &row, params)?;
                     let core = runtime_to_core(&v, expr).map_err(ExecError::Runtime)?;
@@ -740,6 +815,7 @@ async fn find_merge_matches(
                 alias,
                 label,
                 properties,
+                properties_spread: _,
             } => {
                 nodes.insert(alias.as_str(), (label.as_str(), properties.as_slice()));
             }
@@ -1143,5 +1219,69 @@ mod tests {
         let snap = writer.snapshot();
         let nodes = snap.scan_label("Person").await.unwrap();
         assert_eq!(nodes.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn create_node_with_params_spread_persists_entries() {
+        use crate::{lower, parse, Params};
+
+        let mut writer = WriterSession::open(store(), paths("write-create-spread"))
+            .await
+            .unwrap();
+        let q = parse("CREATE (a:Person $props) RETURN a").unwrap();
+        let plan = lower(&q).unwrap();
+
+        let mut spread = BTreeMap::new();
+        spread.insert("name".to_string(), RuntimeValue::String("Ada".into()));
+        spread.insert("age".to_string(), RuntimeValue::Integer(36));
+        let mut params = Params::new();
+        params.insert("props".to_string(), RuntimeValue::Map(spread));
+
+        let outcome = execute_write(&plan, &mut writer, &params).await.unwrap();
+        assert_eq!(outcome.nodes_created, 1);
+        match outcome.rows[0].get("a") {
+            Some(RuntimeValue::Node(n)) => {
+                assert_eq!(n.label, "Person");
+                assert!(matches!(
+                    n.properties.get("name"),
+                    Some(RuntimeValue::String(s)) if s == "Ada"
+                ));
+                assert!(matches!(
+                    n.properties.get("age"),
+                    Some(RuntimeValue::Integer(36))
+                ));
+            }
+            other => panic!("unexpected: {:?}", other),
+        }
+
+        let snap = writer.snapshot();
+        let nodes = snap.scan_label("Person").await.unwrap();
+        assert_eq!(nodes.len(), 1);
+        // Stored properties should match what the spread provided.
+        let stored = &nodes[0].properties;
+        assert!(stored.contains_key("name"));
+        assert!(stored.contains_key("age"));
+    }
+
+    #[tokio::test]
+    async fn create_rejects_spread_param_that_is_not_a_map() {
+        use crate::{lower, parse, Params};
+
+        let mut writer = WriterSession::open(store(), paths("write-create-spread-bad"))
+            .await
+            .unwrap();
+        let q = parse("CREATE (a:Person $props) RETURN a").unwrap();
+        let plan = lower(&q).unwrap();
+        let mut params = Params::new();
+        params.insert("props".to_string(), RuntimeValue::Integer(7));
+
+        let err = execute_write(&plan, &mut writer, &params)
+            .await
+            .expect_err("non-map spread should fail");
+        let msg = format!("{err:?}");
+        assert!(
+            msg.contains("MAP"),
+            "expected a clear type error, got: {msg}"
+        );
     }
 }

--- a/crates/namidb-query/src/optimize/mod.rs
+++ b/crates/namidb-query/src/optimize/mod.rs
@@ -21,7 +21,7 @@ use std::collections::BTreeSet;
 use crate::cost::StatsCatalog;
 use crate::parser::ast::{
     BinaryOp, CaseBranch, Expression, ExpressionKind, MapLiteral, NodePattern, PatternElement,
-    RelationshipPattern,
+    PatternProperties, RelationshipPattern,
 };
 use crate::parser::SourceSpan;
 use crate::plan::logical::{CreateElement, LogicalPlan, ProjectionItem};
@@ -211,8 +211,8 @@ fn visit_node_pattern(np: &NodePattern, out: &mut BTreeSet<String>) {
     if let Some(b) = &np.binding {
         out.insert(b.name.clone());
     }
-    if let Some(m) = &np.properties {
-        visit_map(m, out);
+    if let Some(p) = &np.properties {
+        visit_pattern_properties(p, out);
     }
 }
 
@@ -220,8 +220,20 @@ fn visit_relationship_pattern(rp: &RelationshipPattern, out: &mut BTreeSet<Strin
     if let Some(b) = &rp.binding {
         out.insert(b.name.clone());
     }
-    if let Some(m) = &rp.properties {
-        visit_map(m, out);
+    if let Some(p) = &rp.properties {
+        visit_pattern_properties(p, out);
+    }
+}
+
+fn visit_pattern_properties(p: &PatternProperties, out: &mut BTreeSet<String>) {
+    match p {
+        PatternProperties::Literal(m) => visit_map(m, out),
+        PatternProperties::Parameter { name, .. } => {
+            // Parameter references don't introduce new free variables;
+            // record nothing. (Free-variable scanning is what `out`
+            // collects.)
+            let _ = name;
+        }
     }
 }
 

--- a/crates/namidb-query/src/optimize/projection_pushdown.rs
+++ b/crates/namidb-query/src/optimize/projection_pushdown.rs
@@ -15,7 +15,7 @@ use std::collections::{BTreeMap, BTreeSet};
 
 use crate::parser::ast::{
     CaseBranch, Expression, ExpressionKind, MapLiteral, NodePattern, PatternElement,
-    RelationshipPattern, UnaryOp,
+    PatternProperties, RelationshipPattern, UnaryOp,
 };
 use crate::plan::logical::{AggregateExpr, CreateElement, LogicalPlan, RemoveOp, SetOp};
 
@@ -456,8 +456,8 @@ fn collect_from_node_pattern(np: &NodePattern, req: &mut RequiredSet) {
         // Pattern binding inside subquery references the alias as a whole.
         req.record_all(&b.name);
     }
-    if let Some(m) = &np.properties {
-        collect_from_map(m, req);
+    if let Some(p) = &np.properties {
+        collect_from_pattern_properties(p, req);
     }
 }
 
@@ -465,8 +465,17 @@ fn collect_from_rel_pattern(rp: &RelationshipPattern, req: &mut RequiredSet) {
     if let Some(b) = &rp.binding {
         req.record_all(&b.name);
     }
-    if let Some(m) = &rp.properties {
-        collect_from_map(m, req);
+    if let Some(p) = &rp.properties {
+        collect_from_pattern_properties(p, req);
+    }
+}
+
+fn collect_from_pattern_properties(p: &PatternProperties, req: &mut RequiredSet) {
+    match p {
+        PatternProperties::Literal(m) => collect_from_map(m, req),
+        PatternProperties::Parameter { .. } => {
+            // `$param` references no variable bindings.
+        }
     }
 }
 

--- a/crates/namidb-query/src/parser/ast.rs
+++ b/crates/namidb-query/src/parser/ast.rs
@@ -287,7 +287,7 @@ pub struct PatternElement {
 pub struct NodePattern {
     pub binding: Option<Identifier>,
     pub labels: Vec<Identifier>,
-    pub properties: Option<MapLiteral>,
+    pub properties: Option<PatternProperties>,
     pub span: SourceSpan,
 }
 
@@ -298,8 +298,31 @@ pub struct RelationshipPattern {
     /// Type alternation, e.g. `:KNOWS|:LIKES`. Empty = no type filter.
     pub types: Vec<Identifier>,
     pub length: Option<RelationshipLength>,
-    pub properties: Option<MapLiteral>,
+    pub properties: Option<PatternProperties>,
     pub span: SourceSpan,
+}
+
+/// Properties section of a [`NodePattern`] / [`RelationshipPattern`].
+///
+/// The classic Cypher form is an inline map: `(n:Person {name: 'a'})`.
+/// We also accept a single `$param` reference, e.g. `(n:Person $props)`,
+/// which is the standard bulk-insert idiom. The runtime is expected to
+/// supply a map value for the parameter; at lower time we cannot know
+/// the keys, so the executor expands the map into properties when it
+/// sees the parameter spread.
+#[derive(Clone, Debug, PartialEq)]
+pub enum PatternProperties {
+    Literal(MapLiteral),
+    Parameter { name: String, span: SourceSpan },
+}
+
+impl PatternProperties {
+    pub fn span(&self) -> SourceSpan {
+        match self {
+            PatternProperties::Literal(m) => m.span,
+            PatternProperties::Parameter { span, .. } => *span,
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]

--- a/crates/namidb-query/src/parser/display.rs
+++ b/crates/namidb-query/src/parser/display.rs
@@ -240,10 +240,19 @@ impl fmt::Display for NodePattern {
         for l in &self.labels {
             write!(f, ":{}", l)?;
         }
-        if let Some(m) = &self.properties {
-            write!(f, " {}", m)?;
+        if let Some(p) = &self.properties {
+            write!(f, " {}", p)?;
         }
         f.write_str(")")
+    }
+}
+
+impl fmt::Display for PatternProperties {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            PatternProperties::Literal(m) => write!(f, "{}", m),
+            PatternProperties::Parameter { name, .. } => write!(f, "${}", name),
+        }
     }
 }
 
@@ -282,8 +291,8 @@ impl fmt::Display for RelationshipPattern {
                     write!(f, "*{}..{}", len.min, len.max)?;
                 }
             }
-            if let Some(m) = &self.properties {
-                write!(f, " {}", m)?;
+            if let Some(p) = &self.properties {
+                write!(f, " {}", p)?;
             }
             f.write_str("]")?;
         }

--- a/crates/namidb-query/src/parser/grammar.rs
+++ b/crates/namidb-query/src/parser/grammar.rs
@@ -805,11 +805,7 @@ impl<'src> Parser<'src> {
             None
         };
         let labels = self.parse_label_list()?;
-        let properties = if self.check(&Token::LBrace) {
-            Some(self.parse_map_literal()?)
-        } else {
-            None
-        };
+        let properties = self.parse_pattern_properties()?;
         let rparen = self.expect_in(&Token::RParen, "node pattern")?;
         let end = rparen.span.end;
         Ok(NodePattern {
@@ -818,6 +814,28 @@ impl<'src> Parser<'src> {
             properties,
             span: SourceSpan::new(start, end),
         })
+    }
+
+    /// Parses the properties slot of a node or relationship pattern.
+    /// Returns `None` when the slot is empty, [`PatternProperties::Literal`]
+    /// for an inline `{key: value}` map, and [`PatternProperties::Parameter`]
+    /// for a bare `$name` reference (the bulk-insert idiom).
+    fn parse_pattern_properties(&mut self) -> Result<Option<PatternProperties>, ParseError> {
+        if self.check(&Token::LBrace) {
+            return Ok(Some(PatternProperties::Literal(self.parse_map_literal()?)));
+        }
+        if matches!(self.peek(), Some(Token::Parameter(_))) {
+            let spanned = self.bump().expect("peeked a parameter");
+            let name = match spanned.value {
+                Token::Parameter(n) => n,
+                _ => unreachable!("checked by peek above"),
+            };
+            return Ok(Some(PatternProperties::Parameter {
+                name,
+                span: spanned.span,
+            }));
+        }
+        Ok(None)
     }
 
     fn parse_label_list(&mut self) -> Result<Vec<Identifier>, ParseError> {
@@ -863,9 +881,7 @@ impl<'src> Parser<'src> {
             if let Some(star) = self.eat(&Token::Star) {
                 length = Some(self.parse_relationship_length(star.span)?);
             }
-            if self.check(&Token::LBrace) {
-                properties = Some(self.parse_map_literal()?);
-            }
+            properties = self.parse_pattern_properties()?;
             self.expect_in(&Token::RBracket, "relationship pattern")?;
         }
 
@@ -2053,6 +2069,53 @@ mod tests {
         assert!(
             help.contains("list literal"),
             "help should name the production, was: {help}"
+        );
+    }
+
+    #[test]
+    fn node_pattern_accepts_param_as_properties() {
+        // `CREATE (n:L $params)` parses the param slot as
+        // PatternProperties::Parameter so the executor can apply the
+        // bulk-insert idiom in a single CREATE.
+        let q = ok("CREATE (n:Person $props) RETURN n");
+        let clause = &q.head.clauses[0];
+        let crate::parser::Clause::Create(c) = clause else {
+            panic!("expected Create clause, got {:?}", clause);
+        };
+        let head = &c.patterns[0].element.head;
+        match &head.properties {
+            Some(crate::parser::PatternProperties::Parameter { name, .. }) => {
+                assert_eq!(name, "props");
+            }
+            other => panic!("expected Parameter, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn rel_pattern_accepts_param_as_properties() {
+        let q = ok("CREATE (a:P)-[r:KNOWS $props]->(b:P) RETURN r");
+        let crate::parser::Clause::Create(c) = &q.head.clauses[0] else {
+            panic!("expected Create");
+        };
+        let rel = &c.patterns[0].element.chain[0].0;
+        match &rel.properties {
+            Some(crate::parser::PatternProperties::Parameter { name, .. }) => {
+                assert_eq!(name, "props");
+            }
+            other => panic!("expected Parameter, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn match_with_params_spread_rejected_at_lower_with_clear_error() {
+        // Parser accepts the syntax (the production is shared with
+        // CREATE); lower rejects with a pointer to the WHERE escape.
+        let q = crate::parser::parse("MATCH (n:Person $params) RETURN n").unwrap();
+        let err = crate::plan::lower(&q).expect_err("MATCH spread should fail at lower");
+        assert!(
+            err.message.contains("$params"),
+            "lower error should name the feature, got: {}",
+            err.message
         );
     }
 }

--- a/crates/namidb-query/src/plan/explain.rs
+++ b/crates/namidb-query/src/plan/explain.rs
@@ -675,6 +675,7 @@ fn write_create_element(e: &CreateElement, out: &mut String) {
             alias,
             label,
             properties,
+            properties_spread,
         } => {
             let _ = write!(out, "({}:{}", alias, label);
             if !properties.is_empty() {
@@ -687,6 +688,9 @@ fn write_create_element(e: &CreateElement, out: &mut String) {
                 }
                 out.push('}');
             }
+            if let Some(spread) = properties_spread {
+                let _ = write!(out, " spread={}", spread);
+            }
             out.push(')');
         }
         CreateElement::Rel {
@@ -696,6 +700,7 @@ fn write_create_element(e: &CreateElement, out: &mut String) {
             target_alias,
             direction,
             properties,
+            properties_spread,
         } => {
             let arrow_l = matches!(direction, RelationshipDirection::Left);
             let arrow_r = matches!(direction, RelationshipDirection::Right);
@@ -714,6 +719,9 @@ fn write_create_element(e: &CreateElement, out: &mut String) {
                     let _ = write!(out, "{}: {}", k, v);
                 }
                 out.push('}');
+            }
+            if let Some(spread) = properties_spread {
+                let _ = write!(out, " spread={}", spread);
             }
             out.push_str(if arrow_r { "]->" } else { "]-" });
             let _ = write!(out, "({})", target_alias);

--- a/crates/namidb-query/src/plan/logical.rs
+++ b/crates/namidb-query/src/plan/logical.rs
@@ -542,12 +542,19 @@ pub enum AggregateExpr {
 /// `Node` introduces a fresh node bound under `alias`; `Rel` connects
 /// two already-bound aliases via an edge of the given type and
 /// direction. RFC-009 §"Operadores nuevos".
+///
+/// `properties_spread` carries an optional `$param` reference for the
+/// `CREATE (n:L $params)` bulk-insert idiom. When `Some`, the runtime
+/// evaluates the expression to a map and merges its entries into the
+/// node / edge being created. Explicit `properties` win on key
+/// collisions, matching the conventional spread semantics.
 #[derive(Clone, Debug, PartialEq)]
 pub enum CreateElement {
     Node {
         alias: String,
         label: String,
         properties: Vec<(String, Expression)>,
+        properties_spread: Option<Expression>,
     },
     Rel {
         alias: Option<String>,
@@ -556,6 +563,7 @@ pub enum CreateElement {
         target_alias: String,
         direction: RelationshipDirection,
         properties: Vec<(String, Expression)>,
+        properties_spread: Option<Expression>,
     },
 }
 
@@ -751,6 +759,7 @@ mod tests {
             alias: "a".into(),
             label: "Person".into(),
             properties: vec![],
+            properties_spread: None,
         };
         assert_eq!(node.alias(), Some("a"));
         let rel = CreateElement::Rel {
@@ -760,6 +769,7 @@ mod tests {
             target_alias: "b".into(),
             direction: crate::parser::RelationshipDirection::Right,
             properties: vec![],
+            properties_spread: None,
         };
         assert_eq!(rel.alias(), None);
     }

--- a/crates/namidb-query/src/plan/lower.rs
+++ b/crates/namidb-query/src/plan/lower.rs
@@ -16,8 +16,9 @@ use super::logical::{
 };
 use crate::parser::{
     self as ast, BinaryOp, Clause, Expression, ExpressionKind, Literal, MatchClause, NodePattern,
-    PatternElement, PatternPart, ProjectionItem as AstProjectionItem, QualifiedName, Query,
-    RelationshipPattern, ReturnClause, SingleQuery, SourceSpan, UnaryOp, UnwindClause, WithClause,
+    PatternElement, PatternPart, PatternProperties, ProjectionItem as AstProjectionItem,
+    QualifiedName, Query, RelationshipPattern, ReturnClause, SingleQuery, SourceSpan, UnaryOp,
+    UnwindClause, WithClause,
 };
 
 /// Error returned by [`lower`].
@@ -787,7 +788,14 @@ fn lower_node_pattern_head(
     // Detect inline `{_id: $param}` filter and lower to NodeById.
     // The `id` key is reserved for user properties; only `_id` (the
     // explicit internal-NodeId sigil) triggers the fast point lookup.
-    if let Some(map) = &head.properties {
+    if let Some(PatternProperties::Parameter { span, .. }) = &head.properties {
+        return Err(LowerError::new(
+            LowerErrorKind::UnsupportedFeature,
+            "$params spread in a MATCH pattern is not supported yet; list the keys explicitly in WHERE",
+            *span,
+        ));
+    }
+    if let Some(PatternProperties::Literal(map)) = &head.properties {
         if let Some(id_expr) = map
             .entries
             .iter()
@@ -934,13 +942,23 @@ fn lower_rel_node(
                 predicate: pred,
             };
         }
-        if let Some(map) = &target.properties {
-            for (key, val) in map.entries.iter() {
-                let pred = build_eq(&target_alias, &key.name, val.clone(), target.span);
-                plan = LogicalPlan::Filter {
-                    input: Box::new(plan),
-                    predicate: pred,
-                };
+        match &target.properties {
+            None => {}
+            Some(PatternProperties::Literal(map)) => {
+                for (key, val) in map.entries.iter() {
+                    let pred = build_eq(&target_alias, &key.name, val.clone(), target.span);
+                    plan = LogicalPlan::Filter {
+                        input: Box::new(plan),
+                        predicate: pred,
+                    };
+                }
+            }
+            Some(PatternProperties::Parameter { span, .. }) => {
+                return Err(LowerError::new(
+                    LowerErrorKind::UnsupportedFeature,
+                    "$params spread in a MATCH pattern is not supported yet; list the keys explicitly in WHERE",
+                    *span,
+                ));
             }
         }
     }
@@ -1698,14 +1716,7 @@ fn lower_create_pattern_element(
                 rel.span,
             ));
         }
-        let properties = match &rel.properties {
-            Some(map) => map
-                .entries
-                .iter()
-                .map(|(k, v)| (k.name.clone(), v.clone()))
-                .collect(),
-            None => Vec::new(),
-        };
+        let (properties, properties_spread) = lower_pattern_properties(&rel.properties);
         out.push(CreateElement::Rel {
             alias,
             edge_type,
@@ -1713,10 +1724,38 @@ fn lower_create_pattern_element(
             target_alias: target_alias.clone(),
             direction: rel.direction,
             properties,
+            properties_spread,
         });
         source = target_alias;
     }
     Ok(())
+}
+
+/// Convert the parser's optional [`PatternProperties`] into the
+/// `(properties, properties_spread)` pair that `CreateElement` stores.
+/// A literal map fans out into key/value entries; a `$param` reference
+/// becomes the spread expression and entries stay empty. Used by both
+/// node and relationship CREATE paths so the executor sees one shape.
+fn lower_pattern_properties(
+    props: &Option<ast::PatternProperties>,
+) -> (Vec<(String, ast::Expression)>, Option<ast::Expression>) {
+    match props {
+        None => (Vec::new(), None),
+        Some(ast::PatternProperties::Literal(map)) => (
+            map.entries
+                .iter()
+                .map(|(k, v)| (k.name.clone(), v.clone()))
+                .collect(),
+            None,
+        ),
+        Some(ast::PatternProperties::Parameter { name, span }) => (
+            Vec::new(),
+            Some(ast::Expression {
+                kind: ast::ExpressionKind::Parameter(name.clone()),
+                span: *span,
+            }),
+        ),
+    }
 }
 
 fn lower_create_node(
@@ -1758,18 +1797,12 @@ fn lower_create_node(
  ));
         }
     };
-    let properties = match &node.properties {
-        Some(map) => map
-            .entries
-            .iter()
-            .map(|(k, v)| (k.name.clone(), v.clone()))
-            .collect(),
-        None => Vec::new(),
-    };
+    let (properties, properties_spread) = lower_pattern_properties(&node.properties);
     out.push(CreateElement::Node {
         alias: alias.clone(),
         label,
         properties,
+        properties_spread,
     });
     Ok(alias)
 }
@@ -2205,11 +2238,13 @@ mod tests {
                             alias,
                             label,
                             properties,
+                            properties_spread,
                         } => {
                             assert_eq!(alias, "a");
                             assert_eq!(label, "Person");
                             assert_eq!(properties.len(), 1);
                             assert_eq!(properties[0].0, "name");
+                            assert!(properties_spread.is_none());
                         }
                         other => panic!("expected Node, got {:?}", other),
                     }


### PR DESCRIPTION
## Summary

- Accepts \`CREATE (n:L \$props)\` / \`CREATE (a)-[:T \$props]->(b)\` and threads the parameter through the parser, lower, and writer.
- New \`PatternProperties\` enum on \`NodePattern\` / \`RelationshipPattern\` (\`Literal\` | \`Parameter\`).
- New \`CreateElement::Node/Rel.properties_spread: Option<Expression>\`. The executor evaluates it, asserts \`Map\`, and merges entries; explicit literal entries win on collisions.
- \`MATCH (n:L \$params)\` is accepted by the parser (production is shared with CREATE) but lower rejects it with a clear pointer to the explicit-WHERE alternative — runtime-keyed match predicates are out of scope here.
- Optimiser visitors (free-variable scan, projection pushdown) and the explain renderer were updated for the new property shape.

## Why now

This is the standard Cypher idiom for inserting a row with a server-supplied map. Today it fails at the parser; the workaround (inlining every key) defeats the point.

## Test plan

- [x] \`cargo test -p namidb-query --lib\` (373 passing, 5 new)
- [x] \`cargo test --workspace --lib --tests --exclude namidb-py\` (no regressions)
- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy --workspace --lib --tests --exclude namidb-py -- -D warnings -A clippy::doc_lazy_continuation\`