### PR TITLE
fix(query/exec): typeless Expand uses observed labels, not declared-only

### DIFF
--- a/crates/namidb-query/src/exec/walker.rs
+++ b/crates/namidb-query/src/exec/walker.rs
@@ -1090,9 +1090,12 @@ async fn scan_node_for_id(
     snapshot: &Snapshot<'_>,
     id: NodeId,
 ) -> Result<Option<namidb_storage::NodeView>, ExecError> {
-    let manifest = snapshot.manifest();
-    let labels: Vec<String> = manifest.manifest.schema.labels.keys().cloned().collect();
-    for label in labels {
+    // `observed_labels` covers the declared schema *and* labels that
+    // were ever written into the memtable or any SST. Without it the
+    // typeless Expand path falls back to declared-only and silently
+    // drops every neighbour for namespaces that skipped `SchemaBuilder`
+    // (the root cause of B1 / B7 — `MATCH ()-[r:T]->()` returning 0).
+    for label in snapshot.observed_labels() {
         if let Some(view) = snapshot.lookup_node(&label, id).await? {
             return Ok(Some(view));
         }

--- a/crates/namidb-query/tests/exec_match_expand.rs
+++ b/crates/namidb-query/tests/exec_match_expand.rs
@@ -770,3 +770,43 @@ async fn var_length_expand_without_rel_type_crosses_heterogeneous_types() {
         .collect();
     assert_eq!(reached, vec!["Bob".to_string(), "Carol".to_string()]);
 }
+
+#[tokio::test]
+async fn match_anonymous_endpoints_resolves_without_declared_schema() {
+    // B1 / B7 regression: `MATCH ()-[r:T]->()` and `MATCH (a)-[r]->(b)`
+    // used to fall through `scan_node_for_id`, which iterated only
+    // declared labels. Namespaces that never ran `SchemaBuilder` ended
+    // up with an empty label list there, so every neighbour was dropped
+    // and queries returned zero rows. `observed_labels` covers both the
+    // declared schema and labels written into memtable / SSTs.
+    let mut writer = WriterSession::open(store(), paths("exec-anon-endpoints"))
+        .await
+        .unwrap();
+    let alice = NodeId::new();
+    let bob = NodeId::new();
+    writer
+        .upsert_node("Person", alice, &person("Alice", 30))
+        .unwrap();
+    writer
+        .upsert_node("Person", bob, &person("Bob", 25))
+        .unwrap();
+    writer.upsert_edge("KNOWS", alice, bob, &edge()).unwrap();
+    writer.commit_batch().await.unwrap();
+    // Note: no SchemaBuilder. `manifest.schema.labels` stays empty.
+
+    let snapshot = writer.snapshot();
+
+    // Anonymous endpoints with an explicit edge type.
+    let q = parse("MATCH ()-[r:KNOWS]->() RETURN count(r) AS n").unwrap();
+    let plan = lower(&q).unwrap();
+    let rows = execute(&plan, &snapshot, &Params::new()).await.unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].get("n"), Some(&RuntimeValue::Integer(1)));
+
+    // Fully anonymous expand: no labels, no edge type.
+    let q = parse("MATCH (a)-[r]->(b) RETURN count(r) AS n").unwrap();
+    let plan = lower(&q).unwrap();
+    let rows = execute(&plan, &snapshot, &Params::new()).await.unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].get("n"), Some(&RuntimeValue::Integer(1)));
+}


### PR DESCRIPTION
## Summary

- Typeless / anonymous-endpoint Expand resolved targets via `scan_node_for_id`, which walked `manifest.schema.labels`. For namespaces that skipped `SchemaBuilder` that map is empty, so every neighbour was silently dropped.
- Switch to `Snapshot::observed_labels` — matches what `resolve_edge_types` already does on the edge-type side.

## Repro

Without the fix:

```cypher
CREATE (a:Person {name:'Alice'})-[:KNOWS]->(b:Person {name:'Bob'})

MATCH ()-[r:KNOWS]->() RETURN count(r)  // returns 0
MATCH (a)-[r]->(b)     RETURN count(r)  // returns 0
```

With the fix both queries return 1.

## Test plan

- [x] New regression in `crates/namidb-query/tests/exec_match_expand.rs::match_anonymous_endpoints_resolves_without_declared_schema`
- [x] `cargo test --workspace --lib --tests --exclude namidb-py` (no regressions)
- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --lib --tests --exclude namidb-py -- -D warnings -A clippy::doc_lazy_continuation`