### PR TITLE
feat(core): Value::List / Value::Map round-trip through __overflow_json

### DIFF
--- a/crates/namidb-core/src/value.rs
+++ b/crates/namidb-core/src/value.rs
@@ -4,6 +4,8 @@
 //! to give a friendly Rust-native shape to ad-hoc insertions and to feed the
 //! ingest path before columnarisation.
 
+use std::collections::BTreeMap;
+
 use serde::de::{self, MapAccess, Visitor};
 use serde::ser::SerializeMap;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
@@ -14,6 +16,13 @@ use serde::{Deserialize, Deserializer, Serialize, Serializer};
 const TAG_DATE: &str = "$date";
 /// Same idea for [`Value::DateTime`].
 const TAG_DATETIME: &str = "$datetime";
+/// Tag for `Value::List(...)` — keeps the array shape from being
+/// silently re-decoded as `Vec<f32>` and lets the deserializer recover
+/// the heterogeneous element types.
+const TAG_LIST: &str = "$list";
+/// Tag for `Value::Map(...)` — disambiguates from the `{}` shape that
+/// Date / DateTime already use.
+const TAG_MAP: &str = "$map";
 
 /// A single property value. Loose, JSON-ish.
 #[derive(Debug, Clone, PartialEq)]
@@ -34,6 +43,15 @@ pub enum Value {
     /// `Timestamp(Microsecond, UTC)`. Tagged as `{"$datetime": <us>}`
     /// in JSON for the same reason as [`Value::Date`].
     DateTime(i64),
+    /// Heterogeneous list of values. Stored only through
+    /// `__overflow_json` (declared properties stay in their typed
+    /// column); the JSON shape is `{"$list": [v0, v1, ...]}` so a
+    /// plain array can keep round-tripping as `Vec<f32>`.
+    List(Vec<Value>),
+    /// String-keyed map of values. JSON shape is
+    /// `{"$map": {"k": v, ...}}` to keep `{}` reserved for the
+    /// existing date/datetime tags.
+    Map(BTreeMap<String, Value>),
 }
 
 impl Value {
@@ -109,6 +127,16 @@ impl Serialize for Value {
             Value::DateTime(us) => {
                 let mut m = s.serialize_map(Some(1))?;
                 m.serialize_entry(TAG_DATETIME, us)?;
+                m.end()
+            }
+            Value::List(items) => {
+                let mut m = s.serialize_map(Some(1))?;
+                m.serialize_entry(TAG_LIST, items)?;
+                m.end()
+            }
+            Value::Map(entries) => {
+                let mut m = s.serialize_map(Some(1))?;
+                m.serialize_entry(TAG_MAP, entries)?;
                 m.end()
             }
         }
@@ -193,7 +221,24 @@ impl<'de> Deserialize<'de> for Value {
                         }
                         Ok(Value::DateTime(us))
                     }
-                    other => Err(de::Error::unknown_field(other, &[TAG_DATE, TAG_DATETIME])),
+                    TAG_LIST => {
+                        let items: Vec<Value> = map.next_value()?;
+                        if map.next_key::<String>()?.is_some() {
+                            return Err(de::Error::custom("$list map must have exactly one key"));
+                        }
+                        Ok(Value::List(items))
+                    }
+                    TAG_MAP => {
+                        let entries: BTreeMap<String, Value> = map.next_value()?;
+                        if map.next_key::<String>()?.is_some() {
+                            return Err(de::Error::custom("$map map must have exactly one key"));
+                        }
+                        Ok(Value::Map(entries))
+                    }
+                    other => Err(de::Error::unknown_field(
+                        other,
+                        &[TAG_DATE, TAG_DATETIME, TAG_LIST, TAG_MAP],
+                    )),
                 }
             }
         }
@@ -247,5 +292,46 @@ mod tests {
         assert_eq!(s, r#"{"$date":5}"#);
         let s = serde_json::to_string(&Value::DateTime(42)).unwrap();
         assert_eq!(s, r#"{"$datetime":42}"#);
+    }
+
+    #[test]
+    fn value_list_roundtrips_through_json() {
+        let v = Value::List(vec![
+            Value::I64(1),
+            Value::Str("two".into()),
+            Value::Bool(true),
+            Value::List(vec![Value::I64(3), Value::I64(4)]),
+        ]);
+        assert_eq!(round(&v), v);
+        // Ensure the tag is present so a plain array does not
+        // accidentally re-decode this list as `Vec<f32>`.
+        let s = serde_json::to_string(&v).unwrap();
+        assert!(s.starts_with(r#"{"$list":"#), "got {s}");
+    }
+
+    #[test]
+    fn value_map_roundtrips_through_json() {
+        let mut m = BTreeMap::new();
+        m.insert("name".to_string(), Value::Str("Ada".into()));
+        m.insert("age".to_string(), Value::I64(36));
+        m.insert(
+            "tags".to_string(),
+            Value::List(vec![Value::Str("rust".into())]),
+        );
+        let v = Value::Map(m);
+        assert_eq!(round(&v), v);
+        let s = serde_json::to_string(&v).unwrap();
+        assert!(s.starts_with(r#"{"$map":"#), "got {s}");
+    }
+
+    #[test]
+    fn value_plain_array_still_decodes_as_vec() {
+        // Vec<f32> stays untagged so legacy JSON keeps round-tripping
+        // without the `$list` marker. The deserializer's visit_seq
+        // path is exercised by writing a bare array and reading it
+        // back.
+        let json = "[0.5, 1.5, 2.5]";
+        let v: Value = serde_json::from_str(json).unwrap();
+        assert_eq!(v, Value::Vec(vec![0.5, 1.5, 2.5]));
     }
 }

--- a/crates/namidb-py/src/lib.rs
+++ b/crates/namidb-py/src/lib.rs
@@ -702,6 +702,20 @@ fn value_to_py(py: Python<'_>, v: &Value) -> PyResult<Py<PyAny>> {
                 .unwrap_or_else(|| Utc.timestamp_opt(0, 0).unwrap());
             dt.into_py(py)
         }
+        Value::List(items) => {
+            let list = PyList::empty_bound(py);
+            for item in items {
+                list.append(value_to_py(py, item)?)?;
+            }
+            list.into_any().unbind()
+        }
+        Value::Map(entries) => {
+            let dict = PyDict::new_bound(py);
+            for (k, val) in entries {
+                dict.set_item(k, value_to_py(py, val)?)?;
+            }
+            dict.into_any().unbind()
+        }
     })
 }
 

--- a/crates/namidb-query/src/exec/value.rs
+++ b/crates/namidb-query/src/exec/value.rs
@@ -128,6 +128,15 @@ impl From<CoreValue> for RuntimeValue {
             CoreValue::Vec(v) => RuntimeValue::Vector(v),
             CoreValue::Date(d) => RuntimeValue::Date(d),
             CoreValue::DateTime(m) => RuntimeValue::DateTime(m),
+            CoreValue::List(items) => {
+                RuntimeValue::List(items.into_iter().map(RuntimeValue::from).collect())
+            }
+            CoreValue::Map(entries) => RuntimeValue::Map(
+                entries
+                    .into_iter()
+                    .map(|(k, v)| (k, RuntimeValue::from(v)))
+                    .collect(),
+            ),
         }
     }
 }

--- a/crates/namidb-query/src/exec/writer.rs
+++ b/crates/namidb-query/src/exec/writer.rs
@@ -941,8 +941,25 @@ fn runtime_to_core(v: &RuntimeValue, expr: &Expression) -> Result<CoreValue, Str
         RuntimeValue::Vector(v) => Ok(CoreValue::Vec(v.clone())),
         RuntimeValue::Date(d) => Ok(CoreValue::Date(*d)),
         RuntimeValue::DateTime(m) => Ok(CoreValue::DateTime(*m)),
+        RuntimeValue::List(items) => {
+            // Lists store through the `__overflow_json` stream as a
+            // tagged JSON object; the writer cannot route them into a
+            // declared columnar property yet.
+            let mut out = Vec::with_capacity(items.len());
+            for item in items {
+                out.push(runtime_to_core(item, expr)?);
+            }
+            Ok(CoreValue::List(out))
+        }
+        RuntimeValue::Map(entries) => {
+            let mut out = BTreeMap::new();
+            for (k, v) in entries {
+                out.insert(k.clone(), runtime_to_core(v, expr)?);
+            }
+            Ok(CoreValue::Map(out))
+        }
         other => Err(format!(
-            "property value at `{}` is {} — only scalars are storable in v0",
+            "property value at `{}` is {} — only scalars, lists, and string-keyed maps are storable",
             expr,
             other.type_name()
         )),
@@ -954,44 +971,48 @@ fn node_runtime_props_to_core(
 ) -> Result<BTreeMap<String, CoreValue>, ExecError> {
     let mut out = BTreeMap::new();
     for (k, v) in props {
-        match v {
-            RuntimeValue::Null => {
-                out.insert(k.clone(), CoreValue::Null);
-            }
-            RuntimeValue::Bool(b) => {
-                out.insert(k.clone(), CoreValue::Bool(*b));
-            }
-            RuntimeValue::Integer(n) => {
-                out.insert(k.clone(), CoreValue::I64(*n));
-            }
-            RuntimeValue::Float(f) => {
-                out.insert(k.clone(), CoreValue::F64(*f));
-            }
-            RuntimeValue::String(s) => {
-                out.insert(k.clone(), CoreValue::Str(s.clone()));
-            }
-            RuntimeValue::Bytes(b) => {
-                out.insert(k.clone(), CoreValue::Bytes(b.clone()));
-            }
-            RuntimeValue::Vector(v) => {
-                out.insert(k.clone(), CoreValue::Vec(v.clone()));
-            }
-            RuntimeValue::Date(d) => {
-                out.insert(k.clone(), CoreValue::Date(*d));
-            }
-            RuntimeValue::DateTime(m) => {
-                out.insert(k.clone(), CoreValue::DateTime(*m));
-            }
-            other => {
-                return Err(ExecError::Runtime(format!(
-                    "property `{}` is {} — non-scalar values cannot round-trip through storage in v0",
-                    k,
-                    other.type_name()
-                )));
-            }
-        }
+        let core = runtime_value_to_core(v).map_err(|msg| {
+            ExecError::Runtime(format!("property `{k}` cannot round-trip: {msg}"))
+        })?;
+        out.insert(k.clone(), core);
     }
     Ok(out)
+}
+
+/// Variant of [`runtime_to_core`] without an `Expression` to anchor
+/// the error to. Used when re-serialising a previously-bound node /
+/// rel's properties back to the writer (SET applied to a property
+/// that came from a Node value).
+fn runtime_value_to_core(v: &RuntimeValue) -> Result<CoreValue, String> {
+    match v {
+        RuntimeValue::Null => Ok(CoreValue::Null),
+        RuntimeValue::Bool(b) => Ok(CoreValue::Bool(*b)),
+        RuntimeValue::Integer(n) => Ok(CoreValue::I64(*n)),
+        RuntimeValue::Float(f) => Ok(CoreValue::F64(*f)),
+        RuntimeValue::String(s) => Ok(CoreValue::Str(s.clone())),
+        RuntimeValue::Bytes(b) => Ok(CoreValue::Bytes(b.clone())),
+        RuntimeValue::Vector(v) => Ok(CoreValue::Vec(v.clone())),
+        RuntimeValue::Date(d) => Ok(CoreValue::Date(*d)),
+        RuntimeValue::DateTime(m) => Ok(CoreValue::DateTime(*m)),
+        RuntimeValue::List(items) => {
+            let mut out = Vec::with_capacity(items.len());
+            for item in items {
+                out.push(runtime_value_to_core(item)?);
+            }
+            Ok(CoreValue::List(out))
+        }
+        RuntimeValue::Map(entries) => {
+            let mut out = BTreeMap::new();
+            for (k, v) in entries {
+                out.insert(k.clone(), runtime_value_to_core(v)?);
+            }
+            Ok(CoreValue::Map(out))
+        }
+        other => Err(format!(
+            "{} is not storable (only scalars, lists, and string-keyed maps round-trip)",
+            other.type_name()
+        )),
+    }
 }
 
 #[cfg(test)]

--- a/crates/namidb-query/tests/exec_writes.rs
+++ b/crates/namidb-query/tests/exec_writes.rs
@@ -577,22 +577,107 @@ async fn merge_multi_hop_creates_then_matches_idempotently() {
 }
 
 #[tokio::test]
-async fn bare_list_literal_still_rejected_without_vector_wrapper() {
-    // Regression guard: `vector()` is the *only* way to persist a
-    // numeric collection. A bare `[…]` literal must keep failing so
-    // users do not silently get a List stored as something else.
+async fn bare_list_literal_now_persists_as_list() {
+    // Previously bare `[v, ...]` literals failed with
+    // "only scalars are storable in v0" because the writer rejected
+    // `RuntimeValue::List`. With Value::List landing in core and
+    // round-tripping through __overflow_json, bare lists now persist
+    // and re-decode as the same shape.
     let mut writer = WriterSession::open(store(), paths("w-bare-list"))
         .await
         .unwrap();
-    let q = parse("CREATE (d:Doc {emb: [0.1, 0.2, 0.3]}) RETURN d").unwrap();
+    let q = parse("CREATE (d:Doc {emb: [0.1, 0.2, 0.3]}) RETURN d.emb AS emb").unwrap();
     let plan = lower(&q).unwrap();
-    let err = execute_write(&plan, &mut writer, &Params::new())
+    let outcome = execute_write(&plan, &mut writer, &Params::new())
         .await
-        .expect_err("bare list literal must not be storable in v0");
-    let msg = format!("{:?}", err);
-    assert!(
-        msg.contains("only scalars are storable"),
-        "unexpected error: {}",
-        msg
-    );
+        .unwrap();
+    assert_eq!(outcome.nodes_created, 1);
+    match outcome.rows[0].get("emb") {
+        Some(RuntimeValue::List(items)) => {
+            assert_eq!(items.len(), 3);
+            assert!(matches!(
+                &items[0],
+                RuntimeValue::Float(_) | RuntimeValue::Integer(_)
+            ));
+        }
+        other => panic!("expected list, got {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn create_node_with_list_property_round_trips() {
+    let mut writer = WriterSession::open(store(), paths("w-create-list"))
+        .await
+        .unwrap();
+    // No SchemaBuilder run; `tags` falls into __overflow_json on the
+    // storage side. The new Value::List variant survives the JSON
+    // round-trip and re-materialises as RuntimeValue::List.
+    let q = parse(
+        "CREATE (a:Person {name: 'Ada', tags: ['rust', 'ssh']}) \
+         RETURN a.tags AS tags",
+    )
+    .unwrap();
+    let plan = lower(&q).unwrap();
+    let outcome = execute_write(&plan, &mut writer, &Params::new())
+        .await
+        .unwrap();
+    assert_eq!(outcome.nodes_created, 1);
+    match outcome.rows[0].get("tags") {
+        Some(RuntimeValue::List(items)) => {
+            assert_eq!(items.len(), 2);
+            assert!(
+                matches!(&items[0], RuntimeValue::String(s) if s == "rust"),
+                "got {:?}",
+                items[0]
+            );
+        }
+        other => panic!("expected list, got {:?}", other),
+    }
+
+    // Snapshot read goes through the overflow JSON column and must
+    // give back the same list shape.
+    let snap = writer.snapshot();
+    let nodes = snap.scan_label("Person").await.unwrap();
+    assert_eq!(nodes.len(), 1);
+    match nodes[0].properties.get("tags") {
+        Some(CoreValue::List(items)) => {
+            assert_eq!(items.len(), 2);
+            assert!(matches!(&items[0], CoreValue::Str(s) if s == "rust"));
+        }
+        other => panic!("expected list, got {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn create_node_with_map_property_round_trips() {
+    let mut writer = WriterSession::open(store(), paths("w-create-map"))
+        .await
+        .unwrap();
+    let q = parse(
+        "CREATE (a:Doc {title: 'Hello', meta: {source: 'cli', version: 3}}) \
+         RETURN a.meta AS meta",
+    )
+    .unwrap();
+    let plan = lower(&q).unwrap();
+    let outcome = execute_write(&plan, &mut writer, &Params::new())
+        .await
+        .unwrap();
+    assert_eq!(outcome.nodes_created, 1);
+    match outcome.rows[0].get("meta") {
+        Some(RuntimeValue::Map(m)) => {
+            assert!(matches!(m.get("source"), Some(RuntimeValue::String(s)) if s == "cli"));
+            assert!(matches!(m.get("version"), Some(RuntimeValue::Integer(3))));
+        }
+        other => panic!("expected map, got {:?}", other),
+    }
+
+    let snap = writer.snapshot();
+    let nodes = snap.scan_label("Doc").await.unwrap();
+    assert_eq!(nodes.len(), 1);
+    match nodes[0].properties.get("meta") {
+        Some(CoreValue::Map(m)) => {
+            assert!(matches!(m.get("source"), Some(CoreValue::Str(s)) if s == "cli"));
+        }
+        other => panic!("expected map, got {:?}", other),
+    }
 }


### PR DESCRIPTION
## Summary

- New \`Value::List(Vec<Value>)\` and \`Value::Map(BTreeMap<String, Value>)\` variants in \`namidb-core\`, tagged on the JSON wire as \`{\"\$list\": [...]}\` / \`{\"\$map\": {...}}\` so they don't collide with the existing \`Vec<f32>\` (plain array) or \`Date\` / \`DateTime\` (one-key object) encodings.
- Executor accepts list / map runtime values and round-trips them through \`__overflow_json\`. Undeclared properties already flow through that column, so flush + scan_label work without new SST schema variants.
- namidb-py exposes the new variants as Python lists / dicts.

## Repro before / after

\`\`\`cypher
CREATE (a:Person {name: 'Ada', tags: ['rust', 'ssh']}) RETURN a.tags
-- before: \"only scalars are storable in v0\"
-- after: returns RuntimeValue::List([\"rust\", \"ssh\"])
\`\`\`

## Out of scope

Declared columns whose \`DataType\` is scalar still reject List / Map at flush. Supporting declared list / map columns needs Arrow schema changes and a separate RFC.

## Test plan

- [x] \`cargo test -p namidb-core --lib value\` (7 new / existing)
- [x] \`cargo test -p namidb-query --test exec_writes\` (17 passing, 3 new, 1 rewritten)
- [x] \`cargo test --workspace --lib --tests --exclude namidb-py\` clean
- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy --workspace --lib --tests --exclude namidb-py -- -D warnings -A clippy::doc_lazy_continuation\`