### PR TITLE
perf(storage): pipeline WAL append with the manifest body PUT

### DIFF
--- a/crates/namidb-storage/src/ingest.rs
+++ b/crates/namidb-storage/src/ingest.rs
@@ -471,17 +471,32 @@ impl WriterSession {
         let last_lsn = self.pending.last_lsn();
         let records = self.pending.records.len();
 
-        let segment_path = self.wal_store.append_segment(&self.pending).await?;
-
+        // The WAL segment path is fully determined by `seq`, so we can
+        // build the next manifest body before the WAL PUT lands and
+        // pipeline the two writes. That turns the per-commit critical
+        // path from `WAL + manifest body + pointer CAS` (three round
+        // trips) into `max(WAL, manifest body) + pointer CAS` (two).
+        // If the WAL append fails, the body PUT is harmless: the
+        // pointer never moves, the next manifest commit overwrites
+        // the reference, and the janitor sweeps the orphan.
+        let segment_path = self.wal_store.paths().wal_segment(seq);
         let mut next = self.current.manifest.next_version(self.fence.writer_id);
         next.wal_segments.push(WalSegmentDescriptor {
             seq,
             path: segment_path.as_ref().to_string(),
             last_lsn,
         });
+
+        let (wal_result, body_result) = tokio::join!(
+            self.wal_store.append_segment(&self.pending),
+            self.manifest_store
+                .put_body(&self.fence, &self.current, &next),
+        );
+        let _wal_path = wal_result?;
+        let pointer = body_result?;
         let new_current = self
             .manifest_store
-            .commit(&self.fence, &self.current, next)
+            .cas_pointer(&self.fence, &self.current, next, pointer)
             .await?;
 
         // Durability achieved. Drain the queued payloads into the

--- a/crates/namidb-storage/src/manifest.rs
+++ b/crates/namidb-storage/src/manifest.rs
@@ -424,6 +424,11 @@ impl ManifestStore {
     ///
     /// On a lost CAS race we return [`Error::ManifestCommitCas`]; the caller
     /// must reload, fence-check, and retry from a fresh base.
+    ///
+    /// Callers that need to overlap the body PUT with another
+    /// independent object-store write (e.g. the WAL segment that the
+    /// manifest will reference) can instead drive the two phases
+    /// directly through [`Self::put_body`] + [`Self::cas_pointer`].
     #[instrument(
  skip(self, fence, new_manifest, base),
  fields(
@@ -438,6 +443,26 @@ impl ManifestStore {
         base: &LoadedManifest,
         new_manifest: Manifest,
     ) -> Result<LoadedManifest> {
+        let pointer = self.put_body(fence, base, &new_manifest).await?;
+        self.cas_pointer(fence, base, new_manifest, pointer).await
+    }
+
+    /// Phase 1 of [`Self::commit`]: PUT the immutable manifest body.
+    /// Returns the [`ManifestPointer`] the caller will later CAS into
+    /// place via [`Self::cas_pointer`].
+    ///
+    /// Splitting the commit lets `WriterSession::commit_batch`
+    /// pipeline the body PUT against the independent WAL segment PUT;
+    /// in the common case that turns two serial round-trips into one.
+    /// If the WAL append fails after this method succeeded, the body
+    /// stays orphaned but harmless — the pointer never moved, and the
+    /// next manifest version will overwrite the reference.
+    pub async fn put_body(
+        &self,
+        fence: &WriterFence,
+        base: &LoadedManifest,
+        new_manifest: &Manifest,
+    ) -> Result<ManifestPointer> {
         fence.assert_alive(base.manifest.epoch)?;
         if new_manifest.version != base.manifest.version + 1 {
             return Err(Error::invariant(format!(
@@ -456,7 +481,7 @@ impl ManifestStore {
         let manifest_path = self.paths.manifest_version(new_manifest.version);
         debug!(path = %manifest_path, "writing immutable manifest body");
         match self
-            .put_create(&manifest_path, serde_json::to_vec(&new_manifest)?.into())
+            .put_create(&manifest_path, serde_json::to_vec(new_manifest)?.into())
             .await
         {
             Ok(_) => {}
@@ -481,11 +506,23 @@ impl ManifestStore {
             Err(other) => return Err(other),
         }
 
-        let pointer = ManifestPointer {
+        Ok(ManifestPointer {
             version: new_manifest.version,
             epoch: new_manifest.epoch,
             manifest_path: manifest_path.as_ref().to_string(),
-        };
+        })
+    }
+
+    /// Phase 2 of [`Self::commit`]: CAS the pointer to point at the
+    /// body previously written by [`Self::put_body`]. Returns the
+    /// freshly-loaded manifest on success.
+    pub async fn cas_pointer(
+        &self,
+        fence: &WriterFence,
+        base: &LoadedManifest,
+        new_manifest: Manifest,
+        pointer: ManifestPointer,
+    ) -> Result<LoadedManifest> {
         let opts = PutOptions::from(PutMode::Update(UpdateVersion {
             e_tag: base.pointer_etag.clone(),
             version: base.pointer_version.clone(),


### PR DESCRIPTION
## Summary

- \`ManifestStore::commit\` now splits into \`put_body\` (PUT immutable manifest body) and \`cas_pointer\` (PUT pointer under CAS). The existing \`commit\` is preserved as a thin wrapper, so every other caller is unchanged.
- \`WriterSession::commit_batch\` runs \`wal_store.append_segment\` and \`manifest_store.put_body\` under a single \`tokio::join!\`, then \`cas_pointer\` once both are durable. The critical path drops from three round-trips (WAL, body, pointer) to two (\`max(WAL, body)\`, pointer).
- The WAL segment path is fully determined by \`seq\`, which the writer already knows pre-PUT, so the body content can be built before the WAL is durable. If the WAL append fails after the body succeeds, the body is orphaned harmlessly — the pointer never moves and the janitor sweeps it like any other failed-commit object.

## Test plan

- [x] \`cargo test -p namidb-storage --lib\` (254 passing, no regressions)
- [x] \`cargo test --workspace --lib --tests --exclude namidb-py\` (no regressions)
- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy --workspace --lib --tests --exclude namidb-py -- -D warnings -A clippy::doc_lazy_continuation\`