### PR TITLE
feat(query): profile_query_tree decorates ExplainNode with real timings

### DIFF
--- a/crates/namidb-query/src/lib.rs
+++ b/crates/namidb-query/src/lib.rs
@@ -21,8 +21,10 @@ pub mod optimize;
 pub mod pagination;
 pub mod parser;
 pub mod plan;
+pub mod profile;
 
 pub use pagination::{next_cursor, paginate_plan, Cursor, CursorError};
+pub use profile::{profile_query_tree, ProfileError};
 
 pub use cost::{
     estimate, BindingMeta, Cardinality, EdgeTypeStats, LabelStats, PropStats, StatsCatalog,
@@ -38,6 +40,7 @@ pub use plan::{
     explain_query_raw_tree_verbose, explain_query_raw_verbose, explain_query_tree,
     explain_query_tree_verbose, explain_query_verbose, explain_tree, explain_tree_verbose,
     explain_verbose, lower, AggregateExpr, ExplainNode, LogicalPlan, LowerError, LowerErrorKind,
+    RuntimeStats,
 };
 
 /// Lower + optimize. The convenience entry point that the executor and

--- a/crates/namidb-query/src/plan/explain.rs
+++ b/crates/namidb-query/src/plan/explain.rs
@@ -46,7 +46,26 @@ pub struct ExplainNode {
     /// operator's label / edge type. Lets callers warn the user.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub no_stats: Option<bool>,
+    /// Real measurements from a PROFILE run. Only populated on the
+    /// root node — the executor is `Vec<Row>`-eager, so per-operator
+    /// timings would require a streaming refactor that is out of
+    /// scope here. Callers comparing `estimated_rows` (estimate) to
+    /// `profile.rows_returned` (actual) get the gap they need today.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub profile: Option<RuntimeStats>,
     pub children: Vec<ExplainNode>,
+}
+
+/// Real runtime measurements captured by `profile_query_tree`. Lives
+/// on the root [`ExplainNode`] so the cloud worker can expose a single
+/// PROFILE endpoint without inventing its own shape.
+#[derive(Debug, Clone, Serialize, PartialEq)]
+pub struct RuntimeStats {
+    /// Rows the executor returned to the caller for this query.
+    pub rows_returned: u64,
+    /// Wall-clock elapsed time for the whole query (lower + optimize
+    /// + execute), in microseconds.
+    pub elapsed_us: u64,
 }
 
 /// Render `plan` as an indented tree string. Each operator takes one
@@ -175,6 +194,7 @@ fn node_to_tree(plan: &LogicalPlan) -> ExplainNode {
         estimated_total_work: None,
         join_candidate: None,
         no_stats: None,
+        profile: None,
         children,
     }
 }
@@ -228,6 +248,7 @@ fn node_to_tree_verbose(
         estimated_total_work: None,
         join_candidate,
         no_stats,
+        profile: None,
         children,
     }
 }

--- a/crates/namidb-query/src/plan/mod.rs
+++ b/crates/namidb-query/src/plan/mod.rs
@@ -16,7 +16,7 @@ pub use explain::{
     explain, explain_query, explain_query_raw, explain_query_raw_tree,
     explain_query_raw_tree_verbose, explain_query_raw_verbose, explain_query_tree,
     explain_query_tree_verbose, explain_query_verbose, explain_tree, explain_tree_verbose,
-    explain_verbose, ExplainNode,
+    explain_verbose, ExplainNode, RuntimeStats,
 };
 pub use logical::{AggregateExpr, LogicalPlan, OrderKey, ProjectionItem, ShortestMode};
 pub use lower::{lower, LowerError, LowerErrorKind};

--- a/crates/namidb-query/src/profile.rs
+++ b/crates/namidb-query/src/profile.rs
@@ -1,0 +1,132 @@
+//! Run a query against a snapshot and return its [`ExplainNode`] tree
+//! decorated with real measurements (`profile`).
+//!
+//! For now this is the "stop-watch around `execute`" version: we time
+//! the whole query and report `rows_returned` + `elapsed_us` on the
+//! root node. Per-operator timings need a streaming executor we do
+//! not have yet — see the [`RuntimeStats`] doc for the trade-off.
+
+use namidb_storage::Snapshot;
+
+use crate::cost::StatsCatalog;
+use crate::exec::{execute, ExecError, Params};
+use crate::optimize::optimize;
+use crate::parser::Query;
+use crate::plan::{explain_tree_verbose, ExplainNode, RuntimeStats};
+use crate::plan::{lower, LowerError};
+
+/// Error surfaced by [`profile_query_tree`].
+#[derive(Debug, thiserror::Error)]
+pub enum ProfileError {
+    #[error("lowering failed: {0}")]
+    Lower(#[from] LowerError),
+    #[error("execution failed: {0}")]
+    Exec(#[from] ExecError),
+}
+
+/// Lower, optimise, execute, and decorate the resulting verbose
+/// `ExplainNode` with real runtime measurements. The cloud worker's
+/// `/v1/cypher/profile` endpoint can hand the returned tree straight
+/// back to the caller — it already carries both estimates and
+/// actuals.
+pub async fn profile_query_tree(
+    query: &Query,
+    snapshot: &Snapshot<'_>,
+    params: &Params,
+    catalog: &StatsCatalog,
+) -> Result<ExplainNode, ProfileError> {
+    let plan = optimize(lower(query)?, catalog);
+    let start = std::time::Instant::now();
+    let rows = execute(&plan, snapshot, params).await?;
+    let elapsed_us = u64::try_from(start.elapsed().as_micros()).unwrap_or(u64::MAX);
+    let mut tree = explain_tree_verbose(&plan, catalog);
+    tree.profile = Some(RuntimeStats {
+        rows_returned: rows.len() as u64,
+        elapsed_us,
+    });
+    Ok(tree)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use namidb_core::id::{NamespaceId, NodeId};
+    use namidb_storage::{NamespacePaths, NodeWriteRecord, WriterSession};
+    use object_store::memory::InMemory;
+    use object_store::ObjectStore;
+
+    use super::*;
+    use crate::parser::parse;
+
+    fn store() -> Arc<dyn ObjectStore> {
+        Arc::new(InMemory::new())
+    }
+
+    fn paths(name: &str) -> NamespacePaths {
+        NamespacePaths::new("tenants", NamespaceId::new(name).unwrap())
+    }
+
+    #[tokio::test]
+    async fn profile_root_carries_rows_returned_and_elapsed() {
+        use namidb_core::value::Value as CoreValue;
+        use std::collections::BTreeMap;
+
+        let mut writer = WriterSession::open(store(), paths("profile-basic"))
+            .await
+            .unwrap();
+        let alice = NodeId::new();
+        let mut p = BTreeMap::new();
+        p.insert("name".into(), CoreValue::Str("Alice".into()));
+        writer
+            .upsert_node(
+                "Person",
+                alice,
+                &NodeWriteRecord {
+                    properties: p,
+                    schema_version: 1,
+                },
+            )
+            .unwrap();
+        writer.commit_batch().await.unwrap();
+        let snap = writer.snapshot();
+
+        let q = parse("MATCH (a:Person) RETURN a.name AS name").unwrap();
+        let catalog = StatsCatalog::empty();
+        let tree = profile_query_tree(&q, &snap, &Params::new(), &catalog)
+            .await
+            .unwrap();
+        let profile = tree.profile.expect("expected profile on root");
+        assert_eq!(profile.rows_returned, 1);
+        // Elapsed is a positive integer; we cannot assert an upper
+        // bound because CI runners vary, but any successful call must
+        // have spent a few microseconds at minimum.
+        assert!(
+            profile.elapsed_us < 60_000_000,
+            "elapsed should be sub-minute"
+        );
+    }
+
+    #[tokio::test]
+    async fn profile_returns_zero_rows_for_empty_match() {
+        let writer = WriterSession::open(store(), paths("profile-empty"))
+            .await
+            .unwrap();
+        let snap = writer.snapshot();
+        let q = parse("MATCH (a:Nonexistent) RETURN a").unwrap();
+        let catalog = StatsCatalog::empty();
+        let tree = profile_query_tree(&q, &snap, &Params::new(), &catalog)
+            .await
+            .unwrap();
+        assert_eq!(tree.profile.as_ref().unwrap().rows_returned, 0);
+        // Children still carry estimates from explain_tree_verbose; no
+        // child carries a profile (per-op timings out of scope).
+        fn assert_no_child_profile(node: &ExplainNode) {
+            for c in &node.children {
+                assert!(c.profile.is_none());
+                assert_no_child_profile(c);
+            }
+        }
+        assert_no_child_profile(&tree);
+    }
+}


### PR DESCRIPTION
## Summary

- New \`profile_query_tree(query, snapshot, params, catalog)\` — lowers, optimises, executes, and times the query. Returns a verbose \`ExplainNode\` with the root decorated by \`RuntimeStats { rows_returned, elapsed_us }\`.
- New \`RuntimeStats\` re-exported at the crate root.
- New \`ExplainNode.profile: Option<RuntimeStats>\` field. \`#[serde(skip)]\` when \`None\`, so today's EXPLAIN payloads are byte-compatible.

## Why now

Cloud agent needs two endpoints (\`/v1/cypher/explain\` and \`/v1/cypher/profile\`) and was unsure of the shape. Both return the same \`ExplainNode\`; PROFILE just calls this function instead of \`explain_query_tree*\`. Single struct, single SDK type.

## Out of scope

Per-operator timings — needs a streaming executor we do not have yet. Documented in the module doc so the next iteration knows the size of the work involved.

## Test plan

- [x] \`cargo test -p namidb-query --lib profile\` (2 new)
- [x] \`cargo test --workspace --lib --tests --exclude namidb-py\` clean
- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy --workspace --lib --tests --exclude namidb-py -- -D warnings -A clippy::doc_lazy_continuation\`