### PR TITLE
feat(query): LogicalPlan + AST serialise / deserialise round-trip

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2085,6 +2085,7 @@ dependencies = [
  "object_store 0.13.2",
  "proptest",
  "serde",
+ "serde_json",
  "thiserror",
  "tokio",
  "tokio-test",

--- a/crates/namidb-query/Cargo.toml
+++ b/crates/namidb-query/Cargo.toml
@@ -29,3 +29,4 @@ proptest = { workspace = true }
 object_store = { workspace = true }
 tokio = { workspace = true, features = ["full", "macros", "rt-multi-thread"] }
 chrono = { workspace = true }
+serde_json = { workspace = true }

--- a/crates/namidb-query/src/parser/ast.rs
+++ b/crates/namidb-query/src/parser/ast.rs
@@ -7,6 +7,8 @@
 //! The shapes follow openCypher 9 with the GQL ISO/IEC 39075:2024 naming
 //! where the two diverge. The v0 subset is declared in RFC-004.
 
+use serde::{Deserialize, Serialize};
+
 use super::error::SourceSpan;
 
 // ────────────────────────────────────────────────────────────────────
@@ -22,7 +24,7 @@ use super::error::SourceSpan;
 /// estimates from the [`StatsCatalog`] (RFC-010).
 ///
 /// [`StatsCatalog`]: crate::cost::StatsCatalog
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Query {
     pub head: SingleQuery,
     pub tail: Vec<UnionPart>,
@@ -36,7 +38,7 @@ pub struct Query {
     pub span: SourceSpan,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct UnionPart {
     pub all: bool,
     pub query: SingleQuery,
@@ -44,7 +46,7 @@ pub struct UnionPart {
 }
 
 /// A linear sequence of clauses sharing one scope chain.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct SingleQuery {
     pub clauses: Vec<Clause>,
     pub span: SourceSpan,
@@ -54,7 +56,7 @@ pub struct SingleQuery {
 // Clauses
 // ────────────────────────────────────────────────────────────────────
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum Clause {
     Match(MatchClause),
     Return(ReturnClause),
@@ -85,7 +87,7 @@ impl Clause {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MatchClause {
     pub optional: bool,
     pub patterns: Vec<PatternPart>,
@@ -93,7 +95,7 @@ pub struct MatchClause {
     pub span: SourceSpan,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ReturnClause {
     pub distinct: bool,
     pub items: Vec<ProjectionItem>,
@@ -103,7 +105,7 @@ pub struct ReturnClause {
     pub span: SourceSpan,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct WithClause {
     pub distinct: bool,
     pub items: Vec<ProjectionItem>,
@@ -117,52 +119,52 @@ pub struct WithClause {
 /// Free-standing `WHERE` is illegal in Cypher — `WHERE` lives inside `MATCH`
 /// or `WITH`. We keep `WhereClause` only to centralise the lowered form once
 /// hits; the parser never emits it directly.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct WhereClause {
     pub predicate: Expression,
     pub span: SourceSpan,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct UnwindClause {
     pub list: Expression,
     pub alias: Identifier,
     pub span: SourceSpan,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct CreateClause {
     pub patterns: Vec<PatternPart>,
     pub span: SourceSpan,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MergeClause {
     pub pattern: PatternPart,
     pub actions: Vec<MergeAction>,
     pub span: SourceSpan,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MergeAction {
     pub on: MergeTrigger,
     pub sets: Vec<SetItem>,
     pub span: SourceSpan,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum MergeTrigger {
     Match,
     Create,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct SetClause {
     pub items: Vec<SetItem>,
     pub span: SourceSpan,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum SetItem {
     /// `a.prop = value`
     Property {
@@ -201,13 +203,13 @@ impl SetItem {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct RemoveClause {
     pub items: Vec<RemoveItem>,
     pub span: SourceSpan,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum RemoveItem {
     Property(PropertyAccess),
     Labels {
@@ -217,7 +219,7 @@ pub enum RemoveItem {
     },
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct DeleteClause {
     pub detach: bool,
     pub targets: Vec<Expression>,
@@ -228,21 +230,21 @@ pub struct DeleteClause {
 // Projection
 // ────────────────────────────────────────────────────────────────────
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ProjectionItem {
     pub expression: Expression,
     pub alias: Option<Identifier>,
     pub span: SourceSpan,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct OrderItem {
     pub expression: Expression,
     pub direction: OrderDirection,
     pub span: SourceSpan,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum OrderDirection {
     Asc,
     Desc,
@@ -254,7 +256,7 @@ pub enum OrderDirection {
 
 /// A pattern part is one chain `(a)-[r]->(b)-[s]->(c) ...` optionally bound
 /// to a path variable: `p = (a)-[r]->(b)`.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct PatternPart {
     pub binding: Option<Identifier>,
     pub element: PatternElement,
@@ -267,7 +269,7 @@ pub struct PatternPart {
 }
 
 /// Shortest-path variant a [`PatternPart`] was wrapped in.
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ShortestPathMode {
     /// `shortestPath(...)` — one path per (source, target) pair.
     First,
@@ -276,14 +278,14 @@ pub enum ShortestPathMode {
 }
 
 /// A pattern element starts with a node and alternates relationship→node.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct PatternElement {
     pub head: NodePattern,
     pub chain: Vec<(RelationshipPattern, NodePattern)>,
     pub span: SourceSpan,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct NodePattern {
     pub binding: Option<Identifier>,
     pub labels: Vec<Identifier>,
@@ -291,7 +293,7 @@ pub struct NodePattern {
     pub span: SourceSpan,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct RelationshipPattern {
     pub direction: RelationshipDirection,
     pub binding: Option<Identifier>,
@@ -310,7 +312,7 @@ pub struct RelationshipPattern {
 /// supply a map value for the parameter; at lower time we cannot know
 /// the keys, so the executor expands the map into properties when it
 /// sees the parameter spread.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum PatternProperties {
     Literal(MapLiteral),
     Parameter { name: String, span: SourceSpan },
@@ -325,7 +327,7 @@ impl PatternProperties {
     }
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum RelationshipDirection {
     /// `-->`
     Right,
@@ -337,7 +339,7 @@ pub enum RelationshipDirection {
 
 /// `*1..3` — variable-length range. Bounds are inclusive; both required by
 /// RFC-004 (no unbounded `*` or `*1..`).
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub struct RelationshipLength {
     pub min: u32,
     pub max: u32,
@@ -347,13 +349,13 @@ pub struct RelationshipLength {
 // Expressions
 // ────────────────────────────────────────────────────────────────────
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct Expression {
     pub kind: ExpressionKind,
     pub span: SourceSpan,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum ExpressionKind {
     Literal(Literal),
     Variable(Identifier),
@@ -414,21 +416,21 @@ pub enum ExpressionKind {
     Star,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct PropertyAccess {
     pub target: Expression,
     pub key: Identifier,
     pub span: SourceSpan,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct CaseBranch {
     pub when: Expression,
     pub then: Expression,
     pub span: SourceSpan,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ListComprehension {
     pub variable: Identifier,
     pub list: Expression,
@@ -437,7 +439,7 @@ pub struct ListComprehension {
     pub span: SourceSpan,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct PatternComprehension {
     pub binding: Option<Identifier>,
     pub pattern: PatternElement,
@@ -446,7 +448,7 @@ pub struct PatternComprehension {
     pub span: SourceSpan,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum Literal {
     Integer(i64),
     Float(f64),
@@ -455,19 +457,19 @@ pub enum Literal {
     Null,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct MapLiteral {
     pub entries: Vec<(Identifier, Expression)>,
     pub span: SourceSpan,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum UnaryOp {
     Neg,
     Not,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum BinaryOp {
     Add,
     Sub,
@@ -487,7 +489,7 @@ pub enum BinaryOp {
     RegexMatch,
 }
 
-#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Serialize, Deserialize)]
 pub enum StringOp {
     StartsWith,
     EndsWith,
@@ -498,7 +500,7 @@ pub enum StringOp {
 // Identifier
 // ────────────────────────────────────────────────────────────────────
 
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct Identifier {
     pub name: String,
     pub span: SourceSpan,
@@ -527,7 +529,7 @@ impl Identifier {
 /// A name with optional namespace, e.g. `count`, `date.truncate`. Used for
 /// function calls. v0 keeps the namespace open-ended; the grammar only
 /// recognises `name` and `name.name`.
-#[derive(Clone, Debug, PartialEq, Eq, Hash)]
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct QualifiedName {
     pub segments: Vec<Identifier>,
     pub span: SourceSpan,

--- a/crates/namidb-query/src/parser/error.rs
+++ b/crates/namidb-query/src/parser/error.rs
@@ -4,8 +4,15 @@
 
 use std::fmt;
 
+use serde::{Deserialize, Serialize};
+
 /// Byte-range in the source string. Half-open `[start, end)`.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+///
+/// Carries `Serialize` + `Deserialize` so the lowered `LogicalPlan`,
+/// which threads `SourceSpan` through every expression for diagnostic
+/// spans, can round-trip through a cross-process plan cache without
+/// stripping the source coordinates.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub struct SourceSpan {
     pub start: usize,
     pub end: usize,

--- a/crates/namidb-query/src/plan/logical.rs
+++ b/crates/namidb-query/src/plan/logical.rs
@@ -3,12 +3,13 @@
 //! See [`docs/rfc/008-logical-plan-ir.md`](../../../../docs/rfc/008-logical-plan-ir.md).
 
 use namidb_storage::sst::predicates::ScanPredicate;
+use serde::{Deserialize, Serialize};
 
 use crate::parser::{Expression, OrderDirection, RelationshipDirection, RelationshipLength};
 
 /// Shortest-path variant attached to [`LogicalPlan::Expand`]. See
 /// RFC-023.
-#[derive(Clone, Copy, Debug, PartialEq, Eq, Default)]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub enum ShortestMode {
     /// Regular variable-length traversal — emit every reachable
     /// row.
@@ -25,7 +26,7 @@ pub enum ShortestMode {
 
 /// Tree of relational/graph operators produced by lowering the AST and
 /// consumed by the executor. See RFC-008.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum LogicalPlan {
     /// Scan all nodes carrying `label`. `predicates` is the list of
     /// single-column conjunctive predicates pushed by `optimize`
@@ -333,7 +334,7 @@ pub enum LogicalPlan {
 /// (RFC-024). Carries the alias the executor binds, the optional
 /// label that scopes its NodeScan, and any predicates harvested from
 /// `Filter` nodes the detection pass folded into the join.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct NodeBinding {
     pub alias: String,
     pub label: Option<String>,
@@ -352,7 +353,7 @@ pub struct NodeBinding {
 /// would be `O(observed_types * deg)` and the cost model has no way
 /// to bound it. Cypher alternation `[:A|:B|:C]` populates the vector
 /// with all listed types in source order.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct EdgeConstraint {
     pub from_idx: usize,
     pub to_idx: usize,
@@ -485,7 +486,7 @@ impl LogicalPlan {
     }
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct ProjectionItem {
     pub expression: Expression,
     pub alias: String,
@@ -497,20 +498,20 @@ pub struct ProjectionItem {
 /// compute the hash key; `probe_side` is evaluated on each probe row
 /// to look up matches. Each expression references only aliases
 /// produced by its respective subtree.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct JoinKey {
     pub build_side: Expression,
     pub probe_side: Expression,
 }
 
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct OrderKey {
     pub expression: Expression,
     pub direction: OrderDirection,
 }
 
 /// Aggregate function applied inside an `Aggregate` operator.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum AggregateExpr {
     /// `count(*)` if `arg = None`; `count(expr)` otherwise.
     Count {
@@ -548,7 +549,7 @@ pub enum AggregateExpr {
 /// evaluates the expression to a map and merges its entries into the
 /// node / edge being created. Explicit `properties` win on key
 /// collisions, matching the conventional spread semantics.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum CreateElement {
     Node {
         alias: String,
@@ -577,7 +578,7 @@ impl CreateElement {
 }
 
 /// One `SET` operation. RFC-009 §"Operadores nuevos".
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum SetOp {
     Property {
         target_alias: String,
@@ -610,7 +611,7 @@ impl SetOp {
 }
 
 /// One `REMOVE` operation. RFC-009 §"Operadores nuevos".
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum RemoveOp {
     Property {
         target_alias: String,

--- a/crates/namidb-query/src/plan_cache.rs
+++ b/crates/namidb-query/src/plan_cache.rs
@@ -170,4 +170,36 @@ mod tests {
             .expect_err("garbage must not plan");
         assert!(matches!(err, PlanError::Parse(_)));
     }
+
+    #[test]
+    fn logical_plan_round_trips_through_serde_json() {
+        // The new `Serialize` / `Deserialize` derives on LogicalPlan
+        // (and every type it transitively contains) let the cloud
+        // worker stash a plan in a cross-process cache (Redis, R2,
+        // Supabase) and recover it bit-for-bit on a hit. This test
+        // pins that contract.
+        let plan = parse_lower_optimize(
+            "MATCH (a:Person) WHERE a.age >= 18 RETURN a.name AS name ORDER BY name LIMIT 10",
+            &StatsCatalog::empty(),
+        )
+        .expect("a representative plan");
+        let json = serde_json::to_string(&plan).expect("plan serializes");
+        let back: LogicalPlan = serde_json::from_str(&json).expect("plan deserializes");
+        assert_eq!(plan, back);
+    }
+
+    #[test]
+    fn logical_plan_round_trips_with_create_clause() {
+        // CREATE plans carry CreateElement / SetOp / RemoveOp; the
+        // round-trip must cover those variants too, not just the
+        // read-only operators above.
+        let plan = parse_lower_optimize(
+            "CREATE (a:Person {name: 'Ada'}) RETURN a",
+            &StatsCatalog::empty(),
+        )
+        .expect("a create plan");
+        let json = serde_json::to_string(&plan).expect("create plan serializes");
+        let back: LogicalPlan = serde_json::from_str(&json).expect("create plan deserializes");
+        assert_eq!(plan, back);
+    }
 }

--- a/crates/namidb-storage/src/sst/predicates.rs
+++ b/crates/namidb-storage/src/sst/predicates.rs
@@ -16,6 +16,8 @@
 
 use std::cmp::Ordering;
 
+use serde::{Deserialize, Serialize};
+
 use namidb_core::Value;
 
 use super::stats::{PropertyColumnStats, StatScalar};
@@ -23,7 +25,7 @@ use super::stats::{PropertyColumnStats, StatScalar};
 /// A single-column predicate pushable to the SST reader. Each variant
 /// references a property column by its declared name (not by Parquet
 /// leaf path); the reader resolves the leaf index at scan time.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub enum ScanPredicate {
     /// `column == value`.
     Eq { column: String, value: StatScalar },


### PR DESCRIPTION
## Summary

- \`LogicalPlan\` and every transitively-contained type now derive \`Serialize\` + \`Deserialize\`. A cached plan can survive a Redis / R2 / Supabase hop and re-materialise byte-for-byte.
- Touched files:
  - \`crates/namidb-query/src/plan/logical.rs\` (LogicalPlan, AggregateExpr, CreateElement, SetOp, RemoveOp, ShortestMode, OrderKey, ...).
  - \`crates/namidb-query/src/parser/ast.rs\` (Expression / Literal / MapLiteral / PatternProperties / NodePattern / RelationshipPattern / ...).
  - \`crates/namidb-query/src/parser/error.rs\` (\`SourceSpan\`).
  - \`crates/namidb-storage/src/sst/predicates.rs\` (\`ScanPredicate\`, was missing the derives).
- Tests in \`plan_cache.rs\` exercise the round-trip for a MATCH/WHERE/RETURN plan and a CREATE plan.

## Why now

PR #34 landed \`query_text_hash\` + \`parse_lower_optimize\` and called out cross-process caching as the next piece of work. This finishes the missing piece: the cached value can now travel through serde-aware stores without losing fidelity.

## Cache wiring reminder

\`\`\`rust
let key = format!(\"{ENGINE_VERSION}:{}\", query_text_hash(text));
if let Some(json) = cache.get(&key) {
    let plan: LogicalPlan = serde_json::from_str(&json)?;
    return execute(&plan, ...);
}
let plan = parse_lower_optimize(text, &catalog)?;
cache.insert(key, serde_json::to_string(&plan)?);
\`\`\`

The engine version in the key remains mandatory — different optimisers can produce different plans for the same input.

## Test plan

- [x] \`cargo test -p namidb-query --lib plan_cache\` (9 passing, 2 new)
- [x] \`cargo test --workspace --lib --tests --exclude namidb-py\` clean
- [x] \`cargo fmt --all -- --check\`
- [x] \`cargo clippy --workspace --lib --tests --exclude namidb-py -- -D warnings -A clippy::doc_lazy_continuation\`