### PR TITLE
feat(query): LIMIT-pushdown — early-terminate Expand/NodeScan for bare LIMIT

### DIFF
--- a/crates/namidb-query/src/exec/walker.rs
+++ b/crates/namidb-query/src/exec/walker.rs
@@ -326,8 +326,21 @@ pub(crate) fn execute_inner_with_routing<'a>(
                 skip,
                 limit,
             } => {
-                let mut rows =
-                    execute_inner_with_routing(input, snapshot, params, outer, routing).await?;
+                // LIMIT-pushdown: with no ORDER BY (keys empty) and a finite
+                // limit, the child only needs its first `skip + limit` rows.
+                // Run it under a row budget (`execute_capped`) so an
+                // Expand/NodeScan can stop early instead of materialising its
+                // full output before we truncate. Any plan shape the budget
+                // can't safely cross falls back to full execution inside
+                // `execute_capped`, so the worst case equals today's
+                // behaviour. The sort/skip/take below are unchanged — they
+                // still truncate the (possibly over-shooting) result exactly.
+                let mut rows = if keys.is_empty() && *limit != u64::MAX {
+                    let cap = (*skip as usize).saturating_add(*limit as usize);
+                    execute_capped(input, snapshot, params, outer, routing, cap).await?
+                } else {
+                    execute_inner_with_routing(input, snapshot, params, outer, routing).await?
+                };
                 if !keys.is_empty() {
                     sort_rows(&mut rows, keys, params)?;
                 }
@@ -600,6 +613,7 @@ pub(crate) fn execute_inner_with_routing<'a>(
                         *length,
                         *back_reference,
                     ),
+                    None,
                 )
                 .await
             }
@@ -639,6 +653,123 @@ pub(crate) fn execute_inner_with_routing<'a>(
     .boxed()
 }
 
+/// Execute `plan` under an order-insensitive row budget `cap`, used ONLY
+/// by the `TopN`-with-empty-keys path (a bare `LIMIT`/`SKIP`, no
+/// `ORDER BY`). It honours the cap in the three operators where a prefix
+/// of the output is a valid prefix of the full result:
+///   * non-`DISTINCT` `Project` — 1:1, order-preserving → pass cap through;
+///   * `Expand` — 1:N, order-preserving → run its own input UNCAPPED (a
+///     zero-edge seed yields no rows and must not starve the budget) and
+///     stop the expansion at a seed boundary once `out.len() >= cap`;
+///   * `NodeScan` — leaf → stop after `cap` rows (counter is global across
+///     labels; predicates are pre-applied so truncation is safe).
+/// EVERY other operator drops, reorders, dedups, expands-by-data, or
+/// aggregates rows, so a prefix would be wrong — the catch-all delegates
+/// to the uncapped [`execute_inner_with_routing`], which makes
+/// "worst case == identical to today" true by construction. The budget is
+/// valid only because no order is imposed; it is dropped the instant any
+/// order-imposing / cardinality-altering operator is crossed (the
+/// catch-all enforces this — nothing not whitelisted keeps the cap).
+fn execute_capped<'a>(
+    plan: &'a LogicalPlan,
+    snapshot: &'a Snapshot<'_>,
+    params: &'a Params,
+    outer: Option<&'a Row>,
+    routing: &'a PlanRouting,
+    cap: usize,
+) -> BoxFuture<'a, Result<Vec<Row>, ExecError>> {
+    async move {
+        match plan {
+            LogicalPlan::Project {
+                input,
+                items,
+                distinct: false,
+                discard_input_bindings,
+            } => {
+                let rows = execute_capped(input, snapshot, params, outer, routing, cap).await?;
+                project_rows(&rows, items, *discard_input_bindings, params)
+            }
+
+            LogicalPlan::Expand {
+                input,
+                source,
+                edge_type,
+                direction,
+                rel_alias,
+                target_alias,
+                target_label,
+                length,
+                optional,
+                back_reference,
+                shortest,
+                path_binding,
+            } => {
+                let rows =
+                    execute_inner_with_routing(input, snapshot, params, outer, routing).await?;
+                execute_expand(
+                    rows,
+                    source,
+                    edge_type.as_deref(),
+                    *direction,
+                    rel_alias.as_deref(),
+                    target_alias,
+                    target_label.as_deref(),
+                    *length,
+                    *optional,
+                    *back_reference,
+                    *shortest,
+                    path_binding.as_deref(),
+                    snapshot,
+                    routing.needs_properties(rel_alias.as_deref()),
+                    should_skip_target_materialize(
+                        snapshot,
+                        routing,
+                        target_alias,
+                        edge_type.as_deref(),
+                        *direction,
+                        target_label.as_deref(),
+                        *length,
+                        *back_reference,
+                    ),
+                    Some(cap),
+                )
+                .await
+            }
+
+            LogicalPlan::NodeScan {
+                label,
+                alias,
+                predicates,
+                projection,
+            } => {
+                let labels = resolve_node_labels(snapshot, label.as_deref());
+                let mut rows: Vec<Row> = Vec::new();
+                'scan: for label_name in &labels {
+                    let nodes = snapshot
+                        .scan_label_with_predicates_and_projection(
+                            label_name,
+                            predicates,
+                            projection.as_deref(),
+                        )
+                        .await?;
+                    for n in nodes {
+                        if rows.len() >= cap {
+                            break 'scan;
+                        }
+                        let value = RuntimeValue::Node(Box::new(NodeValue::from(n)));
+                        rows.push(Row::new().with(alias.clone(), value));
+                    }
+                }
+                Ok(rows)
+            }
+
+            // Cap unsafe to push through this operator — run it in full.
+            other => execute_inner_with_routing(other, snapshot, params, outer, routing).await,
+        }
+    }
+    .boxed()
+}
+
 // ───────────────────────── Expand ────────────────────────────────────
 
 #[allow(clippy::too_many_arguments)]
@@ -658,6 +789,7 @@ async fn execute_expand(
     snapshot: &Snapshot<'_>,
     want_properties: bool,
     skip_target_materialize: bool,
+    cap: Option<usize>,
 ) -> Result<Vec<Row>, ExecError> {
     namidb_core::profile_scope!("walker::execute_expand");
     let edge_types = resolve_edge_types(snapshot, edge_type);
@@ -666,6 +798,16 @@ async fn execute_expand(
 
     let mut out = Vec::new();
     for row in rows {
+        // LIMIT-pushdown budget (set only via `execute_capped`, never on
+        // the normal path). Checked at the seed boundary BEFORE processing
+        // the next input row, so every consumed seed contributes its
+        // COMPLETE edge set and `out` stays an order-preserving prefix of
+        // the uncapped result. `cap == Some(0)` returns empty immediately.
+        if let Some(cap) = cap {
+            if out.len() >= cap {
+                break;
+            }
+        }
         let starting = match row.get(source) {
             Some(RuntimeValue::Node(n)) => n.id,
             _ => {

--- a/crates/namidb-query/tests/exec_limit_pushdown.rs
+++ b/crates/namidb-query/tests/exec_limit_pushdown.rs
@@ -1,0 +1,222 @@
+//! LIMIT-pushdown correctness tests for the flat executor.
+//!
+//! A bare `LIMIT` (no `ORDER BY`) lowers to `TopN { keys: [] }`, whose
+//! child is run under a row budget (`execute_capped`) so `Expand` /
+//! `NodeScan` stop early instead of materialising their full output. These
+//! tests pin the CORRECTNESS contract: the capped result must equal the
+//! uncapped baseline truncated to the same window, the budget must never
+//! under-fill (zero-edge source rows force more input than `limit`), and
+//! it must be suppressed whenever an order-imposing / cardinality-altering
+//! operator sits between the limit and the scan.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use namidb_core::id::{NamespaceId, NodeId};
+use namidb_core::value::Value as CoreValue;
+use namidb_storage::{EdgeWriteRecord, NamespacePaths, NodeWriteRecord, WriterSession};
+use object_store::memory::InMemory;
+use object_store::ObjectStore;
+
+use namidb_query::{execute_flat_path, lower, parse, Params, Row, RuntimeValue};
+
+fn store() -> Arc<dyn ObjectStore> {
+    Arc::new(InMemory::new())
+}
+
+fn paths(name: &str) -> NamespacePaths {
+    NamespacePaths::new("tenants", NamespaceId::new(name).unwrap())
+}
+
+fn node_with(prop: &str, v: i64) -> NodeWriteRecord {
+    let mut props: BTreeMap<String, CoreValue> = BTreeMap::new();
+    props.insert(prop.into(), CoreValue::I64(v));
+    NodeWriteRecord {
+        properties: props,
+        schema_version: 1,
+    }
+}
+
+fn edge() -> EdgeWriteRecord {
+    EdgeWriteRecord {
+        properties: BTreeMap::new(),
+        schema_version: 1,
+    }
+}
+
+/// 6 Users, 3 Movies. Only U3/U4/U5 have RATED edges (U0/U1/U2 are
+/// edge-less) → to gather K edges the Expand MUST consume more than K
+/// source rows, exercising the "uncap the Expand's own input" rule. 6
+/// RATED edges total: U3→{M0,M1}, U4→{M0,M1,M2}, U5→{M0}.
+async fn build_graph(writer: &mut WriterSession) {
+    let users: Vec<NodeId> = (0..6).map(|_| NodeId::new()).collect();
+    for (i, id) in users.iter().enumerate() {
+        writer
+            .upsert_node("User", *id, &node_with("uid", i as i64))
+            .unwrap();
+    }
+    let movies: Vec<NodeId> = (0..3).map(|_| NodeId::new()).collect();
+    for (i, id) in movies.iter().enumerate() {
+        writer
+            .upsert_node("Movie", *id, &node_with("mid", i as i64))
+            .unwrap();
+    }
+    let rated = [(3usize, 0usize), (3, 1), (4, 0), (4, 1), (4, 2), (5, 0)];
+    for (u, m) in rated {
+        writer
+            .upsert_edge("RATED", users[u], movies[m], &edge())
+            .unwrap();
+    }
+    writer.commit_batch().await.unwrap();
+}
+
+async fn run(name: &str, query: &str) -> Vec<Row> {
+    let mut writer = WriterSession::open(store(), paths(name)).await.unwrap();
+    build_graph(&mut writer).await;
+    let snapshot = writer.snapshot();
+    let q = parse(query).unwrap();
+    let plan = lower(&q).unwrap();
+    execute_flat_path(&plan, &snapshot, &Params::new())
+        .await
+        .unwrap()
+}
+
+/// Project the `(ua, mb)` pair columns into comparable tuples.
+fn pairs(rows: &[Row]) -> Vec<(i64, i64)> {
+    rows.iter()
+        .map(|r| match (r.get("ua"), r.get("mb")) {
+            (Some(RuntimeValue::Integer(a)), Some(RuntimeValue::Integer(b))) => (*a, *b),
+            other => panic!("unexpected row shape: {other:?}"),
+        })
+        .collect()
+}
+
+const PAIR_RETURN: &str = "RETURN a.uid AS ua, b.mid AS mb";
+
+#[tokio::test]
+async fn capped_limit_is_a_correct_prefix_of_the_full_result() {
+    // The capped LIMIT result must equal the uncapped baseline truncated
+    // to the same length — the budget only stops early, it never reorders.
+    let full = pairs(
+        &run(
+            "lp-prefix-full",
+            &format!("MATCH (a:User)-[r:RATED]->(b:Movie) {PAIR_RETURN}"),
+        )
+        .await,
+    );
+    assert_eq!(full.len(), 6, "fixture has 6 RATED edges");
+
+    let capped = pairs(
+        &run(
+            "lp-prefix-cap",
+            &format!("MATCH (a:User)-[r:RATED]->(b:Movie) {PAIR_RETURN} LIMIT 3"),
+        )
+        .await,
+    );
+    assert_eq!(
+        capped,
+        &full[..3],
+        "LIMIT 3 must be the first 3 baseline rows"
+    );
+}
+
+#[tokio::test]
+async fn cap_never_underfills_past_zero_edge_sources() {
+    // U0/U1/U2 have no RATED edges. A naive cap on the NodeScan would scan
+    // only `limit` users (some/all edge-less) and return < limit rows. The
+    // correct design uncaps the Expand's input, so LIMIT 3 returns exactly 3.
+    let rows = run(
+        "lp-zero-edge",
+        &format!("MATCH (a:User)-[r:RATED]->(b:Movie) {PAIR_RETURN} LIMIT 3"),
+    )
+    .await;
+    assert_eq!(
+        rows.len(),
+        3,
+        "must fill the limit despite leading zero-edge users"
+    );
+}
+
+#[tokio::test]
+async fn limit_zero_returns_no_rows() {
+    let rows = run(
+        "lp-zero",
+        &format!("MATCH (a:User)-[r:RATED]->(b:Movie) {PAIR_RETURN} LIMIT 0"),
+    )
+    .await;
+    assert!(
+        rows.is_empty(),
+        "LIMIT 0 must produce nothing, got {}",
+        rows.len()
+    );
+}
+
+#[tokio::test]
+async fn skip_plus_limit_slices_the_baseline() {
+    // cap = saturating(skip + limit); TopN still applies skip after, so the
+    // window must match baseline[skip..skip+limit].
+    let full = pairs(
+        &run(
+            "lp-skip-full",
+            &format!("MATCH (a:User)-[r:RATED]->(b:Movie) {PAIR_RETURN}"),
+        )
+        .await,
+    );
+    let sliced = pairs(
+        &run(
+            "lp-skip-cap",
+            &format!("MATCH (a:User)-[r:RATED]->(b:Movie) {PAIR_RETURN} SKIP 2 LIMIT 2"),
+        )
+        .await,
+    );
+    assert_eq!(sliced, &full[2..4]);
+}
+
+#[tokio::test]
+async fn skip_beyond_available_is_empty_and_does_not_overflow() {
+    let rows = run(
+        "lp-skip-huge",
+        &format!("MATCH (a:User)-[r:RATED]->(b:Movie) {PAIR_RETURN} SKIP 1000000 LIMIT 5"),
+    )
+    .await;
+    assert!(rows.is_empty());
+}
+
+#[tokio::test]
+async fn order_by_limit_is_globally_correct_not_capped() {
+    // ORDER BY makes TopN.keys non-empty → the cap is suppressed and the
+    // full input is sorted, so we get the GLOBAL top-2 by mid DESC, not a
+    // scan-order prefix. Highest mid is M2 (only U4 rated it), then M1.
+    let rows = run(
+        "lp-order",
+        &format!("MATCH (a:User)-[r:RATED]->(b:Movie) {PAIR_RETURN} ORDER BY b.mid DESC LIMIT 2"),
+    )
+    .await;
+    let got = pairs(&rows);
+    assert_eq!(got.len(), 2);
+    assert_eq!(got[0].1, 2, "top mid must be 2 (global), got {got:?}");
+    assert_eq!(got[1].1, 1, "second mid must be 1 (global), got {got:?}");
+}
+
+#[tokio::test]
+async fn pure_nodescan_limit_returns_exactly_limit() {
+    // NodeScan directly under TopN (no Expand shield): the cap is honoured
+    // at the scan. 6 users exist; LIMIT 4 returns exactly 4.
+    let rows = run("lp-scan", "MATCH (n:User) RETURN n.uid AS ua LIMIT 4").await;
+    assert_eq!(rows.len(), 4);
+}
+
+#[tokio::test]
+async fn multi_hop_expand_under_limit_is_correct() {
+    // Two stacked Expands: only the outermost is capped; the inner runs
+    // uncapped. Co-rated pairs (a)-[:RATED]->(b)<-[:RATED]-(c). Assert the
+    // capped result is a prefix of the full baseline.
+    let q = "MATCH (a:User)-[:RATED]->(b:Movie)<-[:RATED]-(c:User) RETURN a.uid AS ua, b.mid AS mb";
+    let full_pairs = pairs(&run("lp-multihop-full2", q).await);
+    let capped_pairs = pairs(&run("lp-multihop-cap", &format!("{q} LIMIT 3")).await);
+    assert!(
+        full_pairs.len() >= 3,
+        "fixture should yield ≥3 co-rated rows"
+    );
+    assert_eq!(capped_pairs, &full_pairs[..3]);
+}


### PR DESCRIPTION
## Why

A bare `LIMIT` (no `ORDER BY`) lowers to `TopN { keys: [] }`. The eager executor runs the child to completion before truncating, so a graph-explorer probe like:

```cypher
MATCH (a:User)-[r:RATED]->(b:Movie) RETURN a, r, b LIMIT 125
```

materialises **all ~226K RATED edges** (plus per-edge target-node hydration) just to return 125 rows — ~5-6s on a 2-vCPU worker. EXPLAIN confirms `TopN limit=125` sits above an `Expand` estimated at 226,880 rows over a `NodeScan`.

## What

A contained, order-insensitive **row budget** in the flat executor. When `TopN` has empty keys and a finite limit, the child runs via a new `execute_capped()` that honours `cap = saturating(skip + limit)` ONLY where a prefix of the output is a valid prefix of the full result:

| Operator | Behaviour |
|---|---|
| `Project { distinct: false }` | 1:1, order-preserving → pass cap through |
| `Expand` | 1:N order-preserving → run its **own input UNCAPPED** (zero-edge seeds must not starve the budget), stop at a **seed boundary** once `out.len() >= cap` |
| `NodeScan` | stop after `cap` rows (single global counter across labels) |
| **everything else** | falls through to the existing uncapped `execute_inner_with_routing` |

So **worst case == byte-identical to today** by construction — `Filter`, `Distinct`, `Aggregate`, `Union`, joins, `ORDER BY`-TopN, writes, etc. never receive the cap. `TopN` still applies its own `skip + take`, so the final row set is exact.

Flat executor only; the factored path (`NAMIDB_FACTORIZE`) is untouched and the cap is **not** added to the shared `execute_inner_with_routing` signature (a forgotten `None` at one of 21 call sites could leak a stale cap into an unsafe operator → wrong results; the contained helper avoids that risk entirely).

## Correctness tests — `exec_limit_pushdown.rs`

- capped result == uncapped baseline prefix
- **no under-fill** when leading source nodes are edge-less (the critical one — proves Expand uncaps its input)
- `SKIP n LIMIT m` slices `baseline[n..n+m]`
- `ORDER BY ... LIMIT` stays **globally correct** (cap suppressed)
- `LIMIT 0`, `SKIP` overflow (saturating), pure `NodeScan` + LIMIT, multi-hop Expand

Design verified by adversarial review before implementation. Full `namidb-query` suite green; `clippy -D warnings` + `fmt` clean.

## Downstream

Cuts the dashboard graph-explorer probes from ~5-6s each to ~1s, and speeds up every `LIMIT`-without-`ORDER BY` query (gateway API included). The cloud worker picks it up via the path-dep on `main` (release-images rebuild + worker redeploy), same as namidb#38.