### PR TITLE
test(storage): pin edge-needs-no-endpoint invariant (RFC-023 task 3)

### DIFF
--- a/crates/namidb-storage/src/ingest.rs
+++ b/crates/namidb-storage/src/ingest.rs
@@ -931,6 +931,39 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn flushed_edge_to_missing_endpoint_is_accepted_and_resolves_lazily() {
+        // Load-bearing invariant for multi-window / multi-shard bulk loads
+        // (RFC-023): an edge may reference an endpoint node not present in the
+        // same batch — or anywhere yet. It must be accepted, survive flush,
+        // and resolve lazily (None) at query time, never be rejected. A future
+        // referential-integrity feature must not silently break this.
+        let store = make_store();
+        let paths = make_paths("ingest-dangling-edge");
+        let mut session = WriterSession::open(store, paths).await.unwrap();
+
+        let alice = sorted_node_id(1);
+        let ghost = sorted_node_id(99); // never upserted as a node
+        session
+            .upsert_node("Person", alice, &node_record("Alice", Some(30)))
+            .unwrap();
+        // Edge to a non-existent endpoint — must be accepted, not rejected.
+        session
+            .upsert_edge("KNOWS", alice, ghost, &edge_record())
+            .unwrap();
+        let _ = session.commit_batch().await.unwrap();
+        let outcome = session.flush(schema()).await.unwrap();
+        assert!(outcome.committed.manifest.wal_segments.is_empty());
+
+        let snap = session.snapshot();
+        // The edge exists and points at the ghost endpoint…
+        let out = snap.out_edges("KNOWS", alice).await.unwrap();
+        assert_eq!(out.edges.len(), 1);
+        assert_eq!(out.edges[0].dst, ghost);
+        // …but the endpoint node itself does not resolve.
+        assert!(snap.lookup_node("Person", ghost).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
     async fn empty_commit_batch_is_noop() {
         let store = make_store();
         let paths = make_paths("ingest-empty");


### PR DESCRIPTION
Cheap insurance for the fast-loader work ([RFC-023](https://github.com/namidb/namidb-cloud/blob/main/docs/rfc/023-fast-ingest.md) task 3).

The offline SST builder and any multi-window/multi-shard load emit edges whose endpoint nodes may live in a different shard/batch (or be minted in a later window). That relies on an **implicit** engine invariant: `upsert_edge` never validates endpoint existence — it stores raw `NodeId`s and edge expansion resolves lazily (`None` on miss).

This test pins that contract so a future referential-integrity feature can't silently break multi-batch loading:
- A flushed edge to a never-upserted endpoint is **accepted** (not rejected).
- It survives flush and `out_edges` returns it pointing at the ghost.
- `lookup_node` on the missing endpoint returns `None`.

Test-only, additive. `cargo test -p namidb-storage` green; fmt clean.