### PR TITLE
feat(storage): offline SST builder + attach_ssts (RFC-023 tasks 4/5)

### DIFF
--- a/crates/namidb-storage/src/flush.rs
+++ b/crates/namidb-storage/src/flush.rs
@@ -275,6 +275,7 @@ pub async fn flush(
 /// a Node SST and the label declares one or more `unique` properties — each
 /// entry is a `(value_string → NodeId)` map serialised to bincode that the
 /// reader can probe in O(log N) without rescanning the SST body.
+#[derive(Debug)]
 struct PendingSst {
     descriptor: SstDescriptor,
     body_path: Path,
@@ -816,7 +817,7 @@ const MULTIPART_MAX_CONCURRENCY: usize = 8;
 /// (see [`crate::flush`] §"PUT helpers") so collisions are impossible in
 /// practice; the small-PUT branch is kept for bloom side-cars and any
 /// future small body, where the CAS protection is cheap to keep.
-async fn put_object(
+pub(crate) async fn put_object(
     store: std::sync::Arc<dyn ObjectStore>,
     path: &Path,
     body: Bytes,
@@ -1070,6 +1071,279 @@ impl PropertyBuilder {
             PropertyBuilder::FloatVector { builder, .. } => Arc::new(builder.finish()),
             PropertyBuilder::Json(b) => Arc::new(b.finish()),
         }
+    }
+}
+
+// ───────────────────────── Offline SST builder facade (RFC-023) ─────────
+
+/// Public, attach-ready SST builder for offline / out-of-band ingestion
+/// (RFC-023). An import-box binary links `namidb-storage`, builds finished
+/// SSTs from already-minted node ids, and hands them to
+/// [`WriterSession::attach_ssts`](crate::WriterSession::attach_ssts).
+///
+/// This is a CHILD module of `flush`, so it reaches `flush`'s private
+/// builders (`prepare_node_pending`, `build_edge_stream_rows`, …) and the
+/// private `PendingSst` via `super::` with no visibility changes. The public
+/// surface is deliberately narrow — `NodeInput` / `EdgeInput` / `BuiltSst`
+/// plus two build fns — over the engine's already-public `Schema` / `Value`
+/// vocabulary; no internal type (`MemOp`, `NodeRow`, `NodeSstFinish`, …)
+/// crosses the boundary.
+pub mod builder {
+    use std::collections::BTreeMap;
+
+    use bytes::Bytes;
+    use object_store::path::Path;
+
+    use namidb_core::{Schema, Value};
+
+    use crate::error::Result;
+    use crate::manifest::SstDescriptor;
+    use crate::memtable::MemOp;
+    use crate::paths::NamespacePaths;
+    use crate::sst::edges::inverse::transpose_forward_to_inverse;
+    use crate::sst::edges::EdgeDirection;
+
+    use super::{
+        build_edge_stream_rows, prepare_edge_pending, prepare_node_pending,
+        schema_label_or_synthetic, EdgeRow, EdgeWriteRecord, NodeRow, NodeWriteRecord, PendingSst,
+    };
+
+    /// One node to ingest. `id` is the ALREADY-MINTED 16-byte NodeId — the
+    /// deterministic UUIDv5 mint is the cloud seam's job
+    /// (`namidb_cloud_shared::mint`); the builder never sees the natural key.
+    /// `properties` is the decoded property map; the natural-key value lives
+    /// as an ordinary entry (e.g. `{"id": Value::Str("…")}`) and is what the
+    /// unique-property sidecar harvests when the label declares it `unique`.
+    /// Set `tombstone` for a delete marker (`properties` then ignored).
+    #[derive(Debug, Clone)]
+    pub struct NodeInput {
+        /// Already-minted 16-byte NodeId.
+        pub id: [u8; 16],
+        /// Decoded property map (the natural key is a normal entry).
+        pub properties: BTreeMap<String, Value>,
+        /// When true, emit a delete marker instead of an upsert.
+        pub tombstone: bool,
+    }
+
+    /// One edge to ingest. `src` / `dst` are already-minted 16-byte NodeIds.
+    /// `properties` is decoded; the facade routes declared edge-type
+    /// properties into their positional streams and the rest into the
+    /// overflow stream internally.
+    #[derive(Debug, Clone)]
+    pub struct EdgeInput {
+        /// Already-minted source NodeId.
+        pub src: [u8; 16],
+        /// Already-minted destination NodeId.
+        pub dst: [u8; 16],
+        /// Decoded edge property map.
+        pub properties: BTreeMap<String, Value>,
+        /// When true, emit a delete marker instead of an upsert.
+        pub tombstone: bool,
+    }
+
+    /// A finished, attach-ready SST: body + optional bloom + unique-property
+    /// sidecars plus a fully-assembled manifest [`SstDescriptor`]. Opaque —
+    /// the caller gets read-only views;
+    /// [`WriterSession::attach_ssts`](crate::WriterSession::attach_ssts)
+    /// consumes it via the in-crate `into_parts`.
+    #[derive(Debug)]
+    pub struct BuiltSst {
+        inner: PendingSst,
+    }
+
+    impl BuiltSst {
+        /// Highest LSN carried by this SST (the `next_lsn` floor after attach).
+        #[must_use]
+        pub fn max_lsn(&self) -> u64 {
+            self.inner.descriptor.max_lsn
+        }
+        /// Body size in bytes.
+        #[must_use]
+        pub fn size_bytes(&self) -> u64 {
+            self.inner.descriptor.size_bytes
+        }
+        /// Manifest-relative path this SST will occupy.
+        #[must_use]
+        pub fn relative_path(&self) -> &str {
+            &self.inner.descriptor.path
+        }
+        /// Row count (nodes: rows; edges: edge count).
+        #[must_use]
+        pub fn row_count(&self) -> u64 {
+            self.inner.descriptor.row_count
+        }
+
+        /// Hand the PUT bodies + descriptor to `attach_ssts`. Lives here
+        /// because only a descendant of `flush` may read `PendingSst`'s
+        /// private fields.
+        #[allow(clippy::type_complexity)]
+        pub(crate) fn into_parts(
+            self,
+        ) -> (
+            Path,
+            Bytes,
+            Option<(Path, Bytes)>,
+            Vec<(Path, Bytes)>,
+            SstDescriptor,
+        ) {
+            let PendingSst {
+                descriptor,
+                body_path,
+                body,
+                bloom_path,
+                bloom_body,
+                index_sidecars,
+            } = self.inner;
+            let bloom = match (bloom_path, bloom_body) {
+                (Some(p), Some(b)) => Some((p, b)),
+                _ => None,
+            };
+            (body_path, body, bloom, index_sidecars, descriptor)
+        }
+    }
+
+    /// Build ONE node SST (+ a unique-property sidecar per `unique` string
+    /// key) for `label`. The facade OWNS sort + dedup: it sorts `rows` by id
+    /// ascending and, on a duplicate id, keeps the LAST occurrence
+    /// (silent-upsert), then assigns `lsn = sorted position` so the unique
+    /// sidecar's last-write-wins (row order == lsn order) holds. This is the
+    /// contract `NodeSstWriter` (which rejects `nid <= prev`) and the sidecar
+    /// depend on — done here so the import binary cannot get it wrong.
+    ///
+    /// `paths` MUST be the SAME [`NamespacePaths`] the attaching session
+    /// targets. Returns `None` when `rows` is empty.
+    pub fn build_node_sst(
+        paths: &NamespacePaths,
+        schema: &Schema,
+        label: &str,
+        rows: Vec<NodeInput>,
+    ) -> Result<Option<BuiltSst>> {
+        if rows.is_empty() {
+            return Ok(None);
+        }
+        let rows = dedup_keep_last_node(rows);
+        let label_def = schema_label_or_synthetic(schema, label);
+        let node_rows: Vec<NodeRow> = rows
+            .into_iter()
+            .enumerate()
+            .map(|(i, n)| {
+                let op = if n.tombstone {
+                    MemOp::Tombstone
+                } else {
+                    MemOp::Upsert(
+                        NodeWriteRecord {
+                            properties: n.properties,
+                            schema_version: 0,
+                        }
+                        .encode()?,
+                    )
+                };
+                Ok(NodeRow {
+                    id: n.id,
+                    lsn: (i as u64) + 1,
+                    op,
+                })
+            })
+            .collect::<Result<_>>()?;
+
+        let finish = super::build_node_sst(&label_def, &node_rows)?;
+        let pending = prepare_node_pending(paths, label, &label_def, &node_rows, finish)?;
+        Ok(Some(BuiltSst { inner: pending }))
+    }
+
+    /// Build BOTH the forward and inverse CSR SSTs for `edge_type`, owning the
+    /// sort, keep-last dedup (by `(src, dst)`), and monotonic lsn assignment,
+    /// mirroring `flush()`'s edge path. Returns `[]` when `rows` is empty,
+    /// else `[forward, inverse]`.
+    pub fn build_edge_ssts(
+        paths: &NamespacePaths,
+        schema: &Schema,
+        edge_type: &str,
+        rows: Vec<EdgeInput>,
+    ) -> Result<Vec<BuiltSst>> {
+        if rows.is_empty() {
+            return Ok(Vec::new());
+        }
+        let rows = dedup_keep_last_edge(rows);
+        let edge_def = schema.edge_type(edge_type).cloned();
+        let declared_property_names: Vec<String> = edge_def
+            .as_ref()
+            .map(|d| d.properties.iter().map(|p| p.name.clone()).collect())
+            .unwrap_or_default();
+
+        let edge_rows: Vec<EdgeRow> = rows
+            .into_iter()
+            .enumerate()
+            .map(|(i, e)| {
+                let op = if e.tombstone {
+                    MemOp::Tombstone
+                } else {
+                    MemOp::Upsert(
+                        EdgeWriteRecord {
+                            properties: e.properties,
+                            schema_version: 0,
+                        }
+                        .encode()?,
+                    )
+                };
+                Ok(EdgeRow {
+                    src: e.src,
+                    dst: e.dst,
+                    lsn: (i as u64) + 1,
+                    op,
+                })
+            })
+            .collect::<Result<_>>()?;
+
+        let forward_rows = build_edge_stream_rows(&edge_rows, &declared_property_names)?;
+        let inverse_rows = transpose_forward_to_inverse(&forward_rows);
+        let fwd = super::build_edge_sst(
+            edge_type,
+            edge_def.as_ref(),
+            &forward_rows,
+            EdgeDirection::Forward,
+        )?;
+        let inv = super::build_edge_sst(
+            edge_type,
+            edge_def.as_ref(),
+            &inverse_rows,
+            EdgeDirection::Inverse,
+        )?;
+        Ok(vec![
+            BuiltSst {
+                inner: prepare_edge_pending(paths, edge_type, EdgeDirection::Forward, fwd),
+            },
+            BuiltSst {
+                inner: prepare_edge_pending(paths, edge_type, EdgeDirection::Inverse, inv),
+            },
+        ])
+    }
+
+    /// Sort by id ascending and keep the LAST input per id (silent-upsert).
+    /// `Vec::dedup_by` keeps the first, so fold explicitly.
+    fn dedup_keep_last_node(mut rows: Vec<NodeInput>) -> Vec<NodeInput> {
+        rows.sort_by_key(|n| n.id);
+        let mut out: Vec<NodeInput> = Vec::with_capacity(rows.len());
+        for n in rows {
+            match out.last_mut() {
+                Some(prev) if prev.id == n.id => *prev = n,
+                _ => out.push(n),
+            }
+        }
+        out
+    }
+
+    /// Sort by `(src, dst)` ascending and keep the LAST input per pair.
+    fn dedup_keep_last_edge(mut rows: Vec<EdgeInput>) -> Vec<EdgeInput> {
+        rows.sort_by_key(|e| (e.src, e.dst));
+        let mut out: Vec<EdgeInput> = Vec::with_capacity(rows.len());
+        for e in rows {
+            match out.last_mut() {
+                Some(prev) if prev.src == e.src && prev.dst == e.dst => *prev = e,
+                _ => out.push(e),
+            }
+        }
+        out
     }
 }
 

--- a/crates/namidb-storage/src/ingest.rs
+++ b/crates/namidb-storage/src/ingest.rs
@@ -781,6 +781,104 @@ impl WriterSession {
         Ok(outcome)
     }
 
+    /// Attach offline-built SSTs into a FRESH namespace as ONE new manifest
+    /// version (RFC-023). PUTs every body + bloom + unique-property sidecar
+    /// via the size-adaptive uploader, then commits `next_version` with
+    /// `schema` REPLACING the base schema and `.ssts` extended with the built
+    /// descriptors — exactly the "PUT N immutable SSTs, then one CAS" shape
+    /// `flush` already uses, minus the in-process memtable build.
+    ///
+    /// **Fresh-namespace-only.** The schema is a *replace* and the SST set an
+    /// *extend-from-empty*, both safe only on a bootstrap namespace with no
+    /// SSTs and no WAL segments; importing into a populated namespace would
+    /// clobber other labels' schema and orphan their indexes.
+    ///
+    /// Error contract mirrors `flush`/`commit`: [`Error::Fenced`] ⇒ abort and
+    /// drop the session; a lost manifest CAS ⇒ retryable (already-PUT bodies
+    /// are harmless orphans the janitor sweeps).
+    pub async fn attach_ssts(
+        &mut self,
+        built: Vec<crate::flush::builder::BuiltSst>,
+        schema: Schema,
+    ) -> Result<FlushOutcome> {
+        self.fence.assert_alive(self.current.manifest.epoch)?;
+        if !self.current.manifest.ssts.is_empty() || !self.current.manifest.wal_segments.is_empty()
+        {
+            return Err(Error::invariant(
+                "attach_ssts requires a fresh namespace (no SSTs, no WAL segments)",
+            ));
+        }
+        if built.is_empty() {
+            return Ok(FlushOutcome {
+                committed: self.current.clone(),
+                ssts_written: 0,
+                bloom_sidecars_written: 0,
+            });
+        }
+
+        // 1. Decompose every BuiltSst into its PUT bodies + manifest
+        //    descriptor. `into_parts` is the in-crate accessor that reads
+        //    PendingSst's private fields (defined inside flush::builder).
+        let store = self.manifest_store.store().clone();
+        let mut descriptors = Vec::with_capacity(built.len());
+        let mut put_futures: Vec<_> = Vec::with_capacity(built.len() * 2);
+        let mut bloom_count = 0usize;
+        let mut attached_max_lsn = 0u64;
+        for b in built {
+            let (body_path, body, bloom, sidecars, descriptor) = b.into_parts();
+            attached_max_lsn = attached_max_lsn.max(descriptor.max_lsn);
+            let store_ref = store.clone();
+            put_futures.push(Box::pin(async move {
+                crate::flush::put_object(store_ref, &body_path, body).await
+            })
+                as std::pin::Pin<
+                    Box<dyn std::future::Future<Output = Result<()>> + Send>,
+                >);
+            if let Some((bloom_path, bloom_body)) = bloom {
+                bloom_count += 1;
+                let store_ref = store.clone();
+                put_futures.push(Box::pin(async move {
+                    crate::flush::put_object(store_ref, &bloom_path, bloom_body).await
+                }));
+            }
+            for (sidecar_path, sidecar_body) in sidecars {
+                let store_ref = store.clone();
+                put_futures.push(Box::pin(async move {
+                    crate::flush::put_object(store_ref, &sidecar_path, sidecar_body).await
+                }));
+            }
+            descriptors.push(descriptor);
+        }
+        let ssts_written = descriptors.len();
+
+        // 2. I/O phase — concurrent PUTs; first error short-circuits.
+        futures::future::try_join_all(put_futures).await?;
+
+        // 3. Commit phase — one new manifest version (mirrors flush()).
+        let mut next = self.current.manifest.next_version(self.fence.writer_id);
+        next.schema = schema; // REPLACE (fresh-namespace-only)
+        next.ssts.extend(descriptors); // extend == set on a fresh base
+        next.wal_segments.clear();
+        let committed = self
+            .manifest_store
+            .commit(&self.fence, &self.current, next)
+            .await?;
+
+        // 4. Post-commit fixup (mirror flush()) + the PR#40 next_lsn rebase:
+        //    seed past the attached SST high-water so a later online write
+        //    cannot be silently shadowed by an attached row.
+        self.current = committed.clone();
+        self.next_lsn = self.next_lsn.max(attached_max_lsn.saturating_add(1)).max(1);
+        self.refresh_published();
+        self.property_index_cache.reset();
+
+        Ok(FlushOutcome {
+            committed,
+            ssts_written,
+            bloom_sidecars_written: bloom_count,
+        })
+    }
+
     fn alloc_lsn(&mut self) -> u64 {
         let lsn = self.next_lsn;
         self.next_lsn = self.next_lsn.saturating_add(1);
@@ -1595,5 +1693,183 @@ mod tests {
         // next_lsn must continue from the snapshot's last_lsn, not
         // restart from 1.
         assert!(session2.next_lsn() > 1);
+    }
+
+    // ── Offline SST builder + attach (RFC-023) ──────────────────────────
+
+    #[tokio::test]
+    async fn attach_built_node_sst_is_queryable_on_fresh_namespace() {
+        use crate::flush::builder::{build_node_sst, NodeInput};
+        let store = make_store();
+        let paths = make_paths("attach-nodes");
+
+        let id_bytes = {
+            let mut b = [0u8; 16];
+            b[15] = 1;
+            b
+        };
+        let mut props = BTreeMap::new();
+        props.insert("name".to_string(), Value::Str("Alice".into()));
+        // Build the SST OUT-OF-BAND — no live writer involved.
+        let built = build_node_sst(
+            &paths,
+            &schema(),
+            "Person",
+            vec![NodeInput {
+                id: id_bytes,
+                properties: props,
+                tombstone: false,
+            }],
+        )
+        .unwrap()
+        .expect("non-empty rows yield a BuiltSst");
+
+        // Attach into a FRESH session on the same paths + store.
+        let mut session = WriterSession::open(store, paths).await.unwrap();
+        let outcome = session.attach_ssts(vec![built], schema()).await.unwrap();
+        assert_eq!(outcome.ssts_written, 1);
+        assert_eq!(outcome.committed.manifest.ssts.len(), 1);
+        assert!(outcome.committed.manifest.wal_segments.is_empty());
+
+        // The attached node is queryable.
+        let alice = NodeId::from_uuid(Uuid::from_bytes(id_bytes));
+        let snap = session.snapshot();
+        let view = snap.lookup_node("Person", alice).await.unwrap().unwrap();
+        assert_eq!(
+            view.properties.get("name"),
+            Some(&Value::Str("Alice".into()))
+        );
+    }
+
+    #[tokio::test]
+    async fn attach_into_nonfresh_namespace_is_rejected() {
+        use crate::flush::builder::{build_node_sst, NodeInput};
+        let store = make_store();
+        let paths = make_paths("attach-nonfresh");
+        let mut session = WriterSession::open(store, paths.clone()).await.unwrap();
+        // Make the namespace non-fresh (a committed WAL segment).
+        session
+            .upsert_node("Person", sorted_node_id(1), &node_record("Alice", Some(30)))
+            .unwrap();
+        let _ = session.commit_batch().await.unwrap();
+
+        let built = build_node_sst(
+            &paths,
+            &schema(),
+            "Person",
+            vec![NodeInput {
+                id: [0u8; 16],
+                properties: BTreeMap::new(),
+                tombstone: false,
+            }],
+        )
+        .unwrap()
+        .unwrap();
+        let err = session
+            .attach_ssts(vec![built], schema())
+            .await
+            .unwrap_err();
+        assert!(
+            format!("{err:?}").contains("fresh"),
+            "expected fresh-namespace guard, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn builder_dedups_duplicate_node_ids_keeping_last() {
+        use crate::flush::builder::{build_node_sst, NodeInput};
+        let store = make_store();
+        let paths = make_paths("attach-dedup");
+        let id = {
+            let mut b = [0u8; 16];
+            b[15] = 7;
+            b
+        };
+        let mk = |name: &str| {
+            let mut p = BTreeMap::new();
+            p.insert("name".to_string(), Value::Str(name.into()));
+            NodeInput {
+                id,
+                properties: p,
+                tombstone: false,
+            }
+        };
+        // Same id twice — "Old" then "New". Keep-LAST ⇒ "New".
+        let built = build_node_sst(&paths, &schema(), "Person", vec![mk("Old"), mk("New")])
+            .unwrap()
+            .unwrap();
+        assert_eq!(built.row_count(), 1, "duplicate ids collapse to one row");
+
+        let mut session = WriterSession::open(store, paths).await.unwrap();
+        session.attach_ssts(vec![built], schema()).await.unwrap();
+        let node = NodeId::from_uuid(Uuid::from_bytes(id));
+        let snap = session.snapshot();
+        let view = snap.lookup_node("Person", node).await.unwrap().unwrap();
+        assert_eq!(
+            view.properties.get("name"),
+            Some(&Value::Str("New".into())),
+            "keep-last upsert semantics"
+        );
+    }
+
+    #[tokio::test]
+    async fn attach_built_nodes_and_edges_is_traversable() {
+        use crate::flush::builder::{build_edge_ssts, build_node_sst, EdgeInput, NodeInput};
+        let store = make_store();
+        let paths = make_paths("attach-graph");
+        let a = {
+            let mut b = [0u8; 16];
+            b[15] = 1;
+            b
+        };
+        let z = {
+            let mut b = [0u8; 16];
+            b[15] = 2;
+            b
+        };
+        let node = |id: [u8; 16], name: &str| {
+            let mut p = BTreeMap::new();
+            p.insert("name".to_string(), Value::Str(name.into()));
+            NodeInput {
+                id,
+                properties: p,
+                tombstone: false,
+            }
+        };
+        let nodes = build_node_sst(
+            &paths,
+            &schema(),
+            "Person",
+            vec![node(a, "A"), node(z, "Z")],
+        )
+        .unwrap()
+        .unwrap();
+        let edges = build_edge_ssts(
+            &paths,
+            &schema(),
+            "KNOWS",
+            vec![EdgeInput {
+                src: a,
+                dst: z,
+                properties: BTreeMap::new(),
+                tombstone: false,
+            }],
+        )
+        .unwrap();
+        assert_eq!(edges.len(), 2, "forward + inverse CSR");
+
+        let mut all = vec![nodes];
+        all.extend(edges);
+        let mut session = WriterSession::open(store, paths).await.unwrap();
+        let outcome = session.attach_ssts(all, schema()).await.unwrap();
+        assert_eq!(outcome.ssts_written, 3, "1 node + 2 edge SSTs");
+
+        // The graph is traversable: A -KNOWS-> Z.
+        let aid = NodeId::from_uuid(Uuid::from_bytes(a));
+        let zid = NodeId::from_uuid(Uuid::from_bytes(z));
+        let snap = session.snapshot();
+        let out = snap.out_edges("KNOWS", aid).await.unwrap();
+        assert_eq!(out.edges.len(), 1);
+        assert_eq!(out.edges[0].dst, zid);
     }
 }


### PR DESCRIPTION
The **launch path** for neo4j-admin-class ingestion ([RFC-023](https://github.com/namidb/namidb-cloud/blob/main/docs/rfc/023-fast-ingest.md)): build finished SSTs out-of-band (on the import box) and attach them as **one manifest CAS** — delivering throughput AND the unique-property (natural-key) index from the same mechanism (the sidecar is emitted in the build pass).

## `flush::builder` — a CHILD module of `flush`
Reaches `flush`'s private builders + `PendingSst` via `super::` with **zero visibility bumps**. The only existing-item change in the whole feature: `flush::put_object` private → `pub(crate)`.

- **`NodeInput` / `EdgeInput`** — clean public rows over `Schema`/`Value`. Input is the already-minted 16-byte NodeId (the UUIDv5 mint is the cloud seam, `namidb-cloud-shared::mint`). **No internal type leaks** (`MemOp`/`NodeRow`/`NodeSstFinish` stay private).
- **`BuiltSst`** — opaque, attach-ready (body + bloom + unique sidecars + descriptor); `pub(crate) into_parts()` for attach.
- **`build_node_sst` / `build_edge_ssts`** — own sort + **keep-LAST dedup** (silent-upsert) + `lsn = row order`, the contract `NodeSstWriter` (rejects `nid<=prev`) and the unique sidecar depend on. Done in the facade so the import binary can't get it wrong.

## `WriterSession::attach_ssts` (ingest.rs)
PUT bodies (concurrent, size-adaptive) + one `next_version` CAS (schema **replace**, ssts **extend**) reusing `flush`'s commit path, then the **PR#40 `next_lsn` rebase** so a later online write can't be shadowed. **Fresh-namespace-only** (schema replace is unsafe on populated namespaces — RFC-023 §4).

## Tests (4 new, end-to-end)
- offline-built node SST attaches and is **queryable** ✓
- nodes + fwd/inv edge SSTs attach and the graph is **traversable** ✓
- fresh-namespace guard **rejects** a populated namespace ✓
- duplicate ids **dedup keeping last** (silent-upsert) ✓

`cargo test -p namidb-storage`: **274 passed, 0 failed**. fmt clean; clippy adds no new lints.

Next (RFC-023): task 6 `offline_builder.rs` (the import-box binary consuming this facade) + the coexistence spike.