### PR TITLE
feat(query): resolve SKIP / LIMIT $parameters at execution time

### DIFF
--- a/crates/namidb-query/src/cost/cardinality.rs
+++ b/crates/namidb-query/src/cost/cardinality.rs
@@ -294,11 +294,15 @@ fn estimate_inner(plan: &LogicalPlan, catalog: &StatsCatalog) -> Cardinality {
             limit,
         } => {
             let child = estimate_inner(input, catalog);
-            let after_skip = (child.rows - *skip as f64).max(0.0);
-            let rows = if *limit == u64::MAX {
+            // A `$param` count is unknown at plan time: assume no skip and no
+            // limit so the estimate stays a conservative upper bound.
+            let skip = skip.as_const().unwrap_or(0);
+            let limit = limit.as_const().unwrap_or(u64::MAX);
+            let after_skip = (child.rows - skip as f64).max(0.0);
+            let rows = if limit == u64::MAX {
                 after_skip
             } else {
-                after_skip.min(*limit as f64)
+                after_skip.min(limit as f64)
             };
             let bindings = child.bindings.clone();
             Cardinality {
@@ -887,8 +891,8 @@ mod tests {
     use crate::cost::stats::{LabelStats, PropStats};
     use crate::parser::ast::Identifier;
     use crate::parser::SourceSpan;
-    use crate::plan::logical::AggregateExpr;
     use crate::plan::logical::ShortestMode;
+    use crate::plan::logical::{AggregateExpr, RowCount};
     use namidb_storage::sst::stats::StatScalar;
 
     fn span() -> SourceSpan {
@@ -1072,8 +1076,8 @@ mod tests {
         let plan = LogicalPlan::TopN {
             input: Box::new(person_scan()),
             keys: vec![],
-            skip: 0,
-            limit: 50,
+            skip: RowCount::Const(0),
+            limit: RowCount::Const(50),
         };
         let c = estimate(&plan, &cat);
         assert!((c.rows - 50.0).abs() < 1e-9);
@@ -1085,8 +1089,8 @@ mod tests {
         let plan = LogicalPlan::TopN {
             input: Box::new(person_scan()),
             keys: vec![],
-            skip: 100,
-            limit: 50,
+            skip: RowCount::Const(100),
+            limit: RowCount::Const(50),
         };
         let c = estimate(&plan, &cat);
         assert!((c.rows - 50.0).abs() < 1e-9);
@@ -1154,8 +1158,8 @@ mod tests {
             subplan: Box::new(LogicalPlan::TopN {
                 input: Box::new(person_scan()),
                 keys: vec![],
-                skip: 0,
-                limit: 500,
+                skip: RowCount::Const(0),
+                limit: RowCount::Const(500),
             }),
             negated: false,
         };
@@ -1171,8 +1175,8 @@ mod tests {
             subplan: Box::new(LogicalPlan::TopN {
                 input: Box::new(person_scan()),
                 keys: vec![],
-                skip: 0,
-                limit: 200,
+                skip: RowCount::Const(0),
+                limit: RowCount::Const(200),
             }),
             negated: true,
         };

--- a/crates/namidb-query/src/exec/walker.rs
+++ b/crates/namidb-query/src/exec/walker.rs
@@ -25,7 +25,7 @@ use super::row::Row;
 use super::value::{NodeValue, RelValue, RuntimeValue};
 use crate::parser::{Expression, RelationshipDirection, SourceSpan};
 use crate::plan::logical::{
-    AggregateExpr, EdgeConstraint, LogicalPlan, NodeBinding, OrderKey, ProjectionItem,
+    AggregateExpr, EdgeConstraint, LogicalPlan, NodeBinding, OrderKey, ProjectionItem, RowCount,
 };
 
 /// Top-level error produced by the executor. Wraps `EvalError`,
@@ -58,6 +58,32 @@ impl From<EvalError> for ExecError {
 impl From<namidb_storage::Error> for ExecError {
     fn from(e: namidb_storage::Error) -> Self {
         ExecError::Storage(e)
+    }
+}
+
+/// Resolve a `SKIP` / `LIMIT` [`RowCount`] to a concrete `u64` at execution
+/// time. A `$param` must bind to a non-negative integer; `what` names the
+/// clause (`"SKIP"` / `"LIMIT"`) for the error message.
+pub(crate) fn resolve_row_count(
+    rc: &RowCount,
+    params: &Params,
+    what: &str,
+) -> Result<u64, ExecError> {
+    match rc {
+        RowCount::Const(n) => Ok(*n),
+        RowCount::Param(name) => match params.get(name) {
+            Some(RuntimeValue::Integer(n)) if *n >= 0 => Ok(*n as u64),
+            Some(RuntimeValue::Integer(_)) => Err(ExecError::Runtime(format!(
+                "{what} parameter `${name}` must be non-negative"
+            ))),
+            Some(other) => Err(ExecError::Runtime(format!(
+                "{what} parameter `${name}` must be an integer, got {}",
+                other.type_name()
+            ))),
+            None => Err(ExecError::Runtime(format!(
+                "{what} parameter `${name}` not provided"
+            ))),
+        },
     }
 }
 
@@ -326,6 +352,10 @@ pub(crate) fn execute_inner_with_routing<'a>(
                 skip,
                 limit,
             } => {
+                // Resolve `$param` SKIP/LIMIT against the bound params before
+                // anything reads them numerically.
+                let skip = resolve_row_count(skip, params, "SKIP")?;
+                let limit = resolve_row_count(limit, params, "LIMIT")?;
                 // LIMIT-pushdown: with no ORDER BY (keys empty) and a finite
                 // limit, the child only needs its first `skip + limit` rows.
                 // Run it under a row budget (`execute_capped`) so an
@@ -335,8 +365,8 @@ pub(crate) fn execute_inner_with_routing<'a>(
                 // `execute_capped`, so the worst case equals today's
                 // behaviour. The sort/skip/take below are unchanged — they
                 // still truncate the (possibly over-shooting) result exactly.
-                let mut rows = if keys.is_empty() && *limit != u64::MAX {
-                    let cap = (*skip as usize).saturating_add(*limit as usize);
+                let mut rows = if keys.is_empty() && limit != u64::MAX {
+                    let cap = (skip as usize).saturating_add(limit as usize);
                     execute_capped(input, snapshot, params, outer, routing, cap).await?
                 } else {
                     execute_inner_with_routing(input, snapshot, params, outer, routing).await?
@@ -344,15 +374,15 @@ pub(crate) fn execute_inner_with_routing<'a>(
                 if !keys.is_empty() {
                     sort_rows(&mut rows, keys, params)?;
                 }
-                let skip = *skip as usize;
+                let skip = skip as usize;
                 if skip >= rows.len() {
                     return Ok(Vec::new());
                 }
                 let mut iter = rows.into_iter().skip(skip);
-                let take = if *limit == u64::MAX {
+                let take = if limit == u64::MAX {
                     usize::MAX
                 } else {
-                    *limit as usize
+                    limit as usize
                 };
                 let mut out = Vec::with_capacity(take.min(64));
                 for _ in 0..take {
@@ -1962,20 +1992,22 @@ pub(crate) fn execute_factor_inner_with_routing<'a>(
                 // 3. Materialise the full row only for the `skip..skip+limit`
                 // window — 20 materialisations for `LIMIT 20`
                 // regardless of input cardinality.
+                let skip = resolve_row_count(skip, params, "SKIP")?;
+                let limit = resolve_row_count(limit, params, "LIMIT")?;
                 let input_set =
                     execute_factor_inner_with_routing(input, snapshot, params, outer, routing)
                         .await?;
 
                 // Empty keys: stable order, just skip+take + materialise.
                 if keys.is_empty() {
-                    let skip = *skip as usize;
+                    let skip = skip as usize;
                     if skip >= input_set.cardinality() {
                         return Ok(FactorRowSet::from_flat(Vec::new()));
                     }
-                    let take = if *limit == u64::MAX {
+                    let take = if limit == u64::MAX {
                         usize::MAX
                     } else {
-                        *limit as usize
+                        limit as usize
                     };
                     let rows: Vec<Row> = input_set
                         .leaves
@@ -2012,14 +2044,14 @@ pub(crate) fn execute_factor_inner_with_routing<'a>(
 
                 keyed.sort_by(|(av, _), (bv, _)| compare_keys(av, bv, keys));
 
-                let skip = *skip as usize;
+                let skip = skip as usize;
                 if skip >= keyed.len() {
                     return Ok(FactorRowSet::from_flat(Vec::new()));
                 }
-                let take = if *limit == u64::MAX {
+                let take = if limit == u64::MAX {
                     usize::MAX
                 } else {
-                    *limit as usize
+                    limit as usize
                 };
                 let rows: Vec<Row> = keyed
                     .into_iter()

--- a/crates/namidb-query/src/exec/writer.rs
+++ b/crates/namidb-query/src/exec/writer.rs
@@ -173,19 +173,21 @@ fn execute_write_inner<'a>(
                 skip,
                 limit,
             } => {
+                let skip = crate::exec::walker::resolve_row_count(skip, params, "SKIP")?;
+                let limit = crate::exec::walker::resolve_row_count(limit, params, "LIMIT")?;
                 let mut rows = execute_write_inner(input, writer, params, outcome).await?;
                 if !keys.is_empty() {
                     crate::exec::walker::sort_rows(&mut rows, keys, params)?;
                 }
-                let skip = *skip as usize;
+                let skip = skip as usize;
                 if skip >= rows.len() {
                     return Ok(Vec::new());
                 }
                 let mut iter = rows.into_iter().skip(skip);
-                let take = if *limit == u64::MAX {
+                let take = if limit == u64::MAX {
                     usize::MAX
                 } else {
-                    *limit as usize
+                    limit as usize
                 };
                 let mut out = Vec::with_capacity(take.min(64));
                 for _ in 0..take {

--- a/crates/namidb-query/src/optimize/pushdown.rs
+++ b/crates/namidb-query/src/optimize/pushdown.rs
@@ -544,7 +544,7 @@ mod tests {
     use crate::parser::ast::{BinaryOp, Identifier, Literal, RelationshipDirection};
     use crate::parser::SourceSpan;
     use crate::plan::logical::ShortestMode;
-    use crate::plan::logical::{AggregateExpr, ProjectionItem};
+    use crate::plan::logical::{AggregateExpr, ProjectionItem, RowCount};
 
     fn span() -> SourceSpan {
         SourceSpan::point(0)
@@ -843,8 +843,8 @@ mod tests {
             input: Box::new(LogicalPlan::TopN {
                 input: Box::new(scan("Person", "a")),
                 keys: vec![],
-                skip: 0,
-                limit: 10,
+                skip: RowCount::Const(0),
+                limit: RowCount::Const(10),
             }),
             predicate: pred,
         };

--- a/crates/namidb-query/src/pagination.rs
+++ b/crates/namidb-query/src/pagination.rs
@@ -24,7 +24,7 @@ use crate::parser::{
     BinaryOp, Expression, ExpressionKind, Identifier, Literal, OrderDirection, PropertyAccess,
     SourceSpan,
 };
-use crate::plan::{LogicalPlan, OrderKey};
+use crate::plan::{LogicalPlan, OrderKey, RowCount};
 
 /// Wire-format version for the offset cursor.
 const CURSOR_PREFIX: &str = "v1:";
@@ -105,14 +105,14 @@ pub fn paginate_plan(plan: LogicalPlan, cursor: Option<&Cursor>, page_size: u64)
         LogicalPlan::TopN { input, keys, .. } => LogicalPlan::TopN {
             input,
             keys,
-            skip,
-            limit,
+            skip: RowCount::Const(skip),
+            limit: RowCount::Const(limit),
         },
         other => LogicalPlan::TopN {
             input: Box::new(other),
             keys: Vec::<OrderKey>::new(),
-            skip,
-            limit,
+            skip: RowCount::Const(skip),
+            limit: RowCount::Const(limit),
         },
     }
 }
@@ -243,8 +243,8 @@ pub fn paginate_plan_keyset(
     LogicalPlan::TopN {
         input: Box::new(plan),
         keys: vec![order_key],
-        skip: 0,
-        limit,
+        skip: RowCount::Const(0),
+        limit: RowCount::Const(limit),
     }
 }
 
@@ -322,8 +322,8 @@ mod tests {
             LogicalPlan::TopN {
                 skip, limit, keys, ..
             } => {
-                assert_eq!(skip, 7);
-                assert_eq!(limit, 50);
+                assert_eq!(skip, RowCount::Const(7));
+                assert_eq!(limit, RowCount::Const(50));
                 assert!(keys.is_empty());
             }
             other => panic!("expected TopN, got {:?}", other),
@@ -335,14 +335,14 @@ mod tests {
         let inner = LogicalPlan::TopN {
             input: Box::new(LogicalPlan::Empty),
             keys: vec![],
-            skip: 999,
-            limit: 999,
+            skip: RowCount::Const(999),
+            limit: RowCount::Const(999),
         };
         let plan = paginate_plan(inner, Some(&Cursor::from_skip(10)), 20);
         match plan {
             LogicalPlan::TopN { skip, limit, .. } => {
-                assert_eq!(skip, 10);
-                assert_eq!(limit, 20);
+                assert_eq!(skip, RowCount::Const(10));
+                assert_eq!(limit, RowCount::Const(20));
             }
             other => panic!("expected TopN, got {:?}", other),
         }
@@ -402,8 +402,8 @@ mod tests {
         else {
             panic!("expected TopN at the root");
         };
-        assert_eq!(skip, 0);
-        assert_eq!(limit, 25);
+        assert_eq!(skip, RowCount::Const(0));
+        assert_eq!(limit, RowCount::Const(25));
         assert_eq!(keys.len(), 1);
         assert!(matches!(keys[0].direction, OrderDirection::Asc));
         // Inside the TopN we expect Filter(<a._id > "01J5XY7K"> over input).
@@ -419,7 +419,7 @@ mod tests {
         let LogicalPlan::TopN { input, limit, .. } = plan else {
             panic!("expected TopN at the root");
         };
-        assert_eq!(limit, 50);
+        assert_eq!(limit, RowCount::Const(50));
         // No filter when there is no cursor — input should be the
         // original Empty.
         assert!(matches!(input.as_ref(), LogicalPlan::Empty));

--- a/crates/namidb-query/src/plan/explain.rs
+++ b/crates/namidb-query/src/plan/explain.rs
@@ -16,7 +16,7 @@ use serde::Serialize;
 use namidb_storage::sst::predicates::ScanPredicate;
 use namidb_storage::sst::stats::StatScalar;
 
-use super::logical::{AggregateExpr, CreateElement, LogicalPlan, RemoveOp, SetOp};
+use super::logical::{AggregateExpr, CreateElement, LogicalPlan, RemoveOp, RowCount, SetOp};
 use super::lower::{lower, LowerError};
 use crate::cost::{estimate, Cardinality, StatsCatalog};
 use crate::optimize::{is_join_candidate, optimize, produced_aliases};
@@ -495,11 +495,17 @@ fn write_header(plan: &LogicalPlan, out: &mut String) {
                 }
                 out.push(']');
             }
-            if *skip > 0 {
-                let _ = write!(out, " skip={}", skip);
+            if skip.as_const() != Some(0) {
+                let _ = match skip {
+                    RowCount::Const(n) => write!(out, " skip={n}"),
+                    RowCount::Param(p) => write!(out, " skip=${p}"),
+                };
             }
-            if *limit != u64::MAX {
-                let _ = write!(out, " limit={}", limit);
+            if limit.as_const() != Some(u64::MAX) {
+                let _ = match limit {
+                    RowCount::Const(n) => write!(out, " limit={n}"),
+                    RowCount::Param(p) => write!(out, " limit=${p}"),
+                };
             }
         }
         LogicalPlan::Distinct { .. } => {
@@ -987,8 +993,8 @@ mod tests {
                 expression: ident_expr("b"),
                 direction: OrderDirection::Desc,
             }],
-            skip: 0,
-            limit: 10,
+            skip: RowCount::Const(0),
+            limit: RowCount::Const(10),
         };
         let out = explain(&topn);
         let expected = "\

--- a/crates/namidb-query/src/plan/logical.rs
+++ b/crates/namidb-query/src/plan/logical.rs
@@ -147,13 +147,13 @@ pub enum LogicalPlan {
         aggregations: Vec<(String, AggregateExpr)>,
     },
 
-    /// Sort + skip + limit fused. Pure sort: `skip=0, limit=u64::MAX`.
-    /// Pure limit: `keys.is_empty()`.
+    /// Sort + skip + limit fused. Pure sort: `skip=Const(0),
+    /// limit=Const(u64::MAX)`. Pure limit: `keys.is_empty()`.
     TopN {
         input: Box<LogicalPlan>,
         keys: Vec<OrderKey>,
-        skip: u64,
-        limit: u64,
+        skip: RowCount,
+        limit: RowCount,
     },
 
     /// Distinct across every visible binding.
@@ -530,6 +530,30 @@ pub struct JoinKey {
 pub struct OrderKey {
     pub expression: Expression,
     pub direction: OrderDirection,
+}
+
+/// A `SKIP` / `LIMIT` row count: a plan-time constant, or a `$param`
+/// resolved at execution time. The param *name* is part of the plan (not
+/// its value), so a cached plan is reused across parameter sets and only
+/// the executor reads the bound value. Optimizations that need the concrete
+/// count (e.g. limit pushdown) must treat `Param` conservatively as
+/// "unknown" via [`RowCount::as_const`].
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub enum RowCount {
+    Const(u64),
+    Param(String),
+}
+
+impl RowCount {
+    /// The count when it is known at plan time. `Param` returns `None`, so a
+    /// caller that needs a numeric bound falls back to a conservative
+    /// default (`0` for a skip, "unbounded" for a limit).
+    pub fn as_const(&self) -> Option<u64> {
+        match self {
+            RowCount::Const(n) => Some(*n),
+            RowCount::Param(_) => None,
+        }
+    }
 }
 
 /// Aggregate function applied inside an `Aggregate` operator.

--- a/crates/namidb-query/src/plan/lower.rs
+++ b/crates/namidb-query/src/plan/lower.rs
@@ -11,7 +11,7 @@ use std::collections::{BTreeMap, BTreeSet};
 use std::fmt;
 
 use super::logical::{
-    AggregateExpr, CreateElement, LogicalPlan, OrderKey, ProjectionItem, RemoveOp, SetOp,
+    AggregateExpr, CreateElement, LogicalPlan, OrderKey, ProjectionItem, RemoveOp, RowCount, SetOp,
     ShortestMode,
 };
 use crate::parser::{
@@ -1150,8 +1150,8 @@ fn lower_projection(
             direction: k.direction,
         })
         .collect();
-    let skip_val = optional_literal_u64(skip)?;
-    let limit_val = optional_literal_u64(limit)?.unwrap_or(u64::MAX);
+    let skip_rc = optional_row_count(skip)?.unwrap_or(RowCount::Const(0));
+    let limit_rc = optional_row_count(limit)?.unwrap_or(RowCount::Const(u64::MAX));
 
     // Build the Project items. For group-key items under aggregation
     // the alias already lives on the row, so we project `Variable(alias)`.
@@ -1183,12 +1183,15 @@ fn lower_projection(
         })
         .collect();
 
-    if !order_keys.is_empty() || skip_val.is_some() || limit_val != u64::MAX {
+    if !order_keys.is_empty()
+        || skip_rc != RowCount::Const(0)
+        || limit_rc != RowCount::Const(u64::MAX)
+    {
         plan = LogicalPlan::TopN {
             input: Box::new(plan),
             keys: order_keys,
-            skip: skip_val.unwrap_or(0),
-            limit: limit_val,
+            skip: skip_rc,
+            limit: limit_rc,
         };
     }
 
@@ -1536,24 +1539,24 @@ fn expand_star_items(
     Ok(out)
 }
 
-fn optional_literal_u64(expr: &Option<Expression>) -> Result<Option<u64>, LowerError> {
+fn optional_row_count(expr: &Option<Expression>) -> Result<Option<RowCount>, LowerError> {
     match expr {
         None => Ok(None),
         Some(e) => match &e.kind {
-            ExpressionKind::Literal(Literal::Integer(n)) if *n >= 0 => Ok(Some(*n as u64)),
+            ExpressionKind::Literal(Literal::Integer(n)) if *n >= 0 => {
+                Ok(Some(RowCount::Const(*n as u64)))
+            }
             ExpressionKind::Literal(Literal::Integer(_)) => Err(LowerError::new(
                 LowerErrorKind::InvalidPattern,
-                "SKIP / LIMIT must be a non-negative integer literal in v0",
+                "SKIP / LIMIT must be a non-negative integer literal or a $parameter",
                 e.span,
             )),
-            ExpressionKind::Parameter(_) => Err(LowerError::new(
-                LowerErrorKind::UnsupportedFeature,
-                "parameterised SKIP / LIMIT are not yet supported",
-                e.span,
-            )),
+            // A `$param` is carried into the plan by name and resolved at
+            // execution time, so the cached plan is reused across params.
+            ExpressionKind::Parameter(name) => Ok(Some(RowCount::Param(name.clone()))),
             _ => Err(LowerError::new(
                 LowerErrorKind::InvalidPattern,
-                "SKIP / LIMIT must be a literal integer in v0",
+                "SKIP / LIMIT must be a non-negative integer literal or a $parameter",
                 e.span,
             )),
         },
@@ -2179,9 +2182,26 @@ mod tests {
                 LogicalPlan::TopN {
                     keys, skip, limit, ..
                 } => {
-                    assert_eq!(skip, 0);
-                    assert_eq!(limit, 10);
+                    assert_eq!(skip, RowCount::Const(0));
+                    assert_eq!(limit, RowCount::Const(10));
                     assert_eq!(keys.len(), 1);
+                }
+                other => panic!("expected TopN under Project, got {:?}", other),
+            },
+            other => panic!("expected Project, got {:?}", other),
+        }
+    }
+
+    #[test]
+    fn skip_limit_parameters_lower_to_row_count_param() {
+        // `SKIP $s LIMIT $l` carries the param names into the plan (resolved
+        // at execution time), instead of being rejected as it was in v0.
+        let p = lp("MATCH (a:Person) RETURN a SKIP $s LIMIT $l");
+        match p {
+            LogicalPlan::Project { input, .. } => match *input {
+                LogicalPlan::TopN { skip, limit, .. } => {
+                    assert_eq!(skip, RowCount::Param("s".into()));
+                    assert_eq!(limit, RowCount::Param("l".into()));
                 }
                 other => panic!("expected TopN under Project, got {:?}", other),
             },

--- a/crates/namidb-query/src/plan/mod.rs
+++ b/crates/namidb-query/src/plan/mod.rs
@@ -18,5 +18,5 @@ pub use explain::{
     explain_query_tree_verbose, explain_query_verbose, explain_tree, explain_tree_verbose,
     explain_verbose, ExplainNode, RuntimeStats,
 };
-pub use logical::{AggregateExpr, LogicalPlan, OrderKey, ProjectionItem, ShortestMode};
+pub use logical::{AggregateExpr, LogicalPlan, OrderKey, ProjectionItem, RowCount, ShortestMode};
 pub use lower::{lower, LowerError, LowerErrorKind};

--- a/crates/namidb-query/tests/exec_limit_pushdown.rs
+++ b/crates/namidb-query/tests/exec_limit_pushdown.rs
@@ -220,3 +220,67 @@ async fn multi_hop_expand_under_limit_is_correct() {
     );
     assert_eq!(capped_pairs, &full_pairs[..3]);
 }
+
+#[tokio::test]
+async fn param_skip_limit_resolves_per_execution_on_one_plan() {
+    // Lower ONCE, then execute the same plan with different params: the
+    // window must follow the params. This proves the plan carries the
+    // `$param` by name (so a cached plan is reused across parameter sets)
+    // rather than baking a value at plan time.
+    let mut writer = WriterSession::open(store(), paths("lp-param-reuse"))
+        .await
+        .unwrap();
+    build_graph(&mut writer).await;
+    let snapshot = writer.snapshot();
+
+    let full = pairs(
+        &run(
+            "lp-param-full",
+            &format!("MATCH (a:User)-[r:RATED]->(b:Movie) {PAIR_RETURN}"),
+        )
+        .await,
+    );
+
+    let q = parse(&format!(
+        "MATCH (a:User)-[r:RATED]->(b:Movie) {PAIR_RETURN} SKIP $s LIMIT $l"
+    ))
+    .unwrap();
+    let plan = lower(&q).unwrap();
+
+    let mut p1 = Params::new();
+    p1.insert("s".into(), RuntimeValue::Integer(1));
+    p1.insert("l".into(), RuntimeValue::Integer(2));
+    let win1 = pairs(&execute_flat_path(&plan, &snapshot, &p1).await.unwrap());
+    assert_eq!(win1, &full[1..3], "first params -> rows [1,3)");
+
+    let mut p2 = Params::new();
+    p2.insert("s".into(), RuntimeValue::Integer(3));
+    p2.insert("l".into(), RuntimeValue::Integer(2));
+    let win2 = pairs(&execute_flat_path(&plan, &snapshot, &p2).await.unwrap());
+    assert_eq!(
+        win2,
+        &full[3..5],
+        "second params -> rows [3,5) on the SAME plan"
+    );
+}
+
+#[tokio::test]
+async fn param_limit_not_provided_errors() {
+    let mut writer = WriterSession::open(store(), paths("lp-param-missing"))
+        .await
+        .unwrap();
+    build_graph(&mut writer).await;
+    let snapshot = writer.snapshot();
+    let q = parse(&format!(
+        "MATCH (a:User)-[r:RATED]->(b:Movie) {PAIR_RETURN} LIMIT $l"
+    ))
+    .unwrap();
+    let plan = lower(&q).unwrap();
+    let err = execute_flat_path(&plan, &snapshot, &Params::new())
+        .await
+        .unwrap_err();
+    assert!(
+        format!("{err}").contains("not provided"),
+        "expected a missing-parameter error, got: {err}"
+    );
+}


### PR DESCRIPTION
Previously `SKIP $n` / `LIMIT $n` were rejected at lowering with `parameterised SKIP / LIMIT are not yet supported` — only an integer literal worked. Paginating with a driver (`SKIP $skip LIMIT $pageSize`) was impossible. Roadmap item D5.

## Change
`TopN.skip` / `TopN.limit` change from `u64` to a new `RowCount` enum:

```rust
pub enum RowCount { Const(u64), Param(String) }
```

- A literal lowers to `Const`, a `$param` to `Param(name)`.
- The executor resolves `Param` against the bound params at run time (`resolve_row_count`), so **the value is never baked into the plan** — the query-text-cached plan is reused across parameter sets. A dedicated test lowers once and runs the same plan with two different param sets, asserting two different windows.
- Optimisations that need the concrete count (LIMIT pushdown budget, cardinality estimate, EXPLAIN) read it through `RowCount::as_const()` and treat a `Param` conservatively as "unknown" (no skip / no limit), so they degrade safely instead of under-fetching.
- A `$param` must bind to a non-negative integer, else execution errors (`LIMIT parameter ` + "`$l`" + ` not provided` / `must be non-negative` / `must be an integer`).

The enum threads through every site that reads or builds a `TopN` (executor flat + factor paths, writer path, pagination, cardinality, explain); the ~40 passthrough optimizer sites are type-agnostic. Compiler exhaustiveness guarantees no read site silently mishandles a `Param`.

## Tests
- `skip_limit_parameters_lower_to_row_count_param` (lowering).
- `param_skip_limit_resolves_per_execution_on_one_plan` (one plan, two param sets, two windows).
- `param_limit_not_provided_errors` (missing-param error path).

Full `namidb-query` suite green (433 lib + integration), `cargo fmt --check` clean, downstream `namidb-cli`/`server`/`mcp` build, no new clippy warnings. Plan cache stays correct because the param **name** (not value) is part of the plan.