### PR TITLE
refactor: remove the dormant BETWEEN range-pushdown machinery

### DIFF
--- a/crates/namidb-query/src/cost/selectivity.rs
+++ b/crates/namidb-query/src/cost/selectivity.rs
@@ -11,7 +11,6 @@
 //! |-------------------------------|---------|
 //! | `prop = literal` (no NDV) | 0.10 |
 //! | `prop < / > literal` | 0.33 |
-//! | `BETWEEN` | 0.25 |
 //! | `IS NULL` | 0.05 |
 //! | `STARTS WITH` / `CONTAINS` | 0.10 |
 //! | unknown | 0.50 |
@@ -51,7 +50,6 @@ impl<'a> BindingStats<'a> {
 
 const FALLBACK_EQ: f64 = 0.10;
 const FALLBACK_RANGE: f64 = 0.33;
-const FALLBACK_BETWEEN: f64 = 0.25;
 const FALLBACK_IS_NULL: f64 = 0.05;
 const FALLBACK_STRING_TEST: f64 = 0.10;
 const FALLBACK_UNKNOWN: f64 = 0.50;
@@ -119,8 +117,7 @@ fn sel_inner(expr: &Expression, bindings: &BindingStats<'_>) -> f64 {
             }
         }
 
-        // ─── BETWEEN / IN / string tests ───────────────────────────────
-        ExpressionKind::Between { target, low, high } => sel_between(target, low, high, bindings),
+        // ─── IN / string tests ─────────────────────────────────────────
         ExpressionKind::In { item, list } => sel_in(item, list, bindings),
         ExpressionKind::StringTest { .. } => FALLBACK_STRING_TEST,
 
@@ -251,25 +248,6 @@ fn range_selectivity(op: BinaryOp, lit: &StatScalar, ps: &PropStats) -> Option<f
         BinaryOp::Gt | BinaryOp::Ge => 1.0 - below,
         _ => FALLBACK_RANGE,
     })
-}
-
-fn sel_between(
-    target: &Expression,
-    low: &Expression,
-    high: &Expression,
-    bindings: &BindingStats<'_>,
-) -> f64 {
-    // Decompose to (target >= low) AND (target <= high) then estimate.
-    if let Some((alias, prop)) = property_access(target) {
-        if let (Some(ll), Some(hl)) = (literal_from_expr(low), literal_from_expr(high)) {
-            if let Some(ps) = bindings.prop_stats(&alias, &prop) {
-                let a = sel_comparison_on_stats(BinaryOp::Ge, ps, &ll);
-                let b = sel_comparison_on_stats(BinaryOp::Le, ps, &hl);
-                return a * b;
-            }
-        }
-    }
-    FALLBACK_BETWEEN
 }
 
 fn sel_in(item: &Expression, list: &Expression, bindings: &BindingStats<'_>) -> f64 {
@@ -425,14 +403,6 @@ pub fn scan_predicate_to_expression(
             lit(stat_to_literal(value)),
             span,
         ),
-        P::Between { column, low, high } => Expression {
-            kind: ExpressionKind::Between {
-                target: Box::new(prop(column)),
-                low: Box::new(lit(stat_to_literal(low))),
-                high: Box::new(lit(stat_to_literal(high))),
-            },
-            span,
-        },
         P::IsNull { column } => Expression {
             kind: ExpressionKind::IsNull {
                 expr: Box::new(prop(column)),
@@ -626,23 +596,6 @@ mod tests {
         let expr = binary(BinaryOp::Lt, lit_int(75), prop_access("a", "age"));
         let s = selectivity(&expr, &b);
         assert!((s - 0.25).abs() < 1e-12);
-    }
-
-    #[test]
-    fn between_decomposes_to_two_ranges() {
-        let stats = label_with_age_stats(0, 100, 0, 1000, None);
-        let b = BindingStats::empty().with("a", &stats);
-        let expr = Expression {
-            kind: ExpressionKind::Between {
-                target: Box::new(prop_access("a", "age")),
-                low: Box::new(lit_int(25)),
-                high: Box::new(lit_int(75)),
-            },
-            span: span(),
-        };
-        let s = selectivity(&expr, &b);
-        // (age >= 25) → 0.75; (age <= 75) → 0.75; AND → 0.5625.
-        assert!((s - 0.5625).abs() < 1e-12);
     }
 
     #[test]

--- a/crates/namidb-query/src/exec/expr.rs
+++ b/crates/namidb-query/src/exec/expr.rs
@@ -91,14 +91,6 @@ pub fn evaluate(expr: &Expression, row: &Row, params: &Params) -> Result<Runtime
             let list_v = evaluate(list, row, params)?;
             Ok(eval_in(&item_v, &list_v))
         }
-        ExpressionKind::Between { target, low, high } => {
-            let t = evaluate(target, row, params)?;
-            let lo = evaluate(low, row, params)?;
-            let hi = evaluate(high, row, params)?;
-            let cmp_lo = eval_binary(BinaryOp::Ge, &t, &lo, span)?;
-            let cmp_hi = eval_binary(BinaryOp::Le, &t, &hi, span)?;
-            eval_binary(BinaryOp::And, &cmp_lo, &cmp_hi, span)
-        }
         ExpressionKind::StringTest {
             op,
             target,

--- a/crates/namidb-query/src/exec/walker.rs
+++ b/crates/namidb-query/src/exec/walker.rs
@@ -3071,11 +3071,6 @@ fn collect_referenced_variables(expr: &Expression, out: &mut BTreeSet<String>) {
             collect_referenced_variables(item, out);
             collect_referenced_variables(list, out);
         }
-        ExpressionKind::Between { target, low, high } => {
-            collect_referenced_variables(target, out);
-            collect_referenced_variables(low, out);
-            collect_referenced_variables(high, out);
-        }
         ExpressionKind::StringTest {
             target, pattern, ..
         } => {

--- a/crates/namidb-query/src/optimize/mod.rs
+++ b/crates/namidb-query/src/optimize/mod.rs
@@ -144,11 +144,6 @@ fn visit_expression(expr: &Expression, out: &mut BTreeSet<String>) {
             visit_expression(item, out);
             visit_expression(list, out);
         }
-        ExpressionKind::Between { target, low, high } => {
-            visit_expression(target, out);
-            visit_expression(low, out);
-            visit_expression(high, out);
-        }
         ExpressionKind::StringTest {
             target, pattern, ..
         } => {

--- a/crates/namidb-query/src/optimize/parquet_pushdown.rs
+++ b/crates/namidb-query/src/optimize/parquet_pushdown.rs
@@ -52,16 +52,6 @@ pub fn try_into_scan_predicate(expr: &Expression, alias: &str) -> Option<ScanPre
         ExpressionKind::Binary { op, left, right } => {
             try_binary_to_predicate(*op, left, right, alias)
         }
-        ExpressionKind::Between { target, low, high } => {
-            let column = property_column_for_alias(target, alias)?;
-            let lo = literal_to_stat_scalar(literal_of(low)?)?;
-            let hi = literal_to_stat_scalar(literal_of(high)?)?;
-            Some(ScanPredicate::Between {
-                column,
-                low: lo,
-                high: hi,
-            })
-        }
         ExpressionKind::IsNull {
             expr: inner,
             negated,
@@ -359,26 +349,6 @@ mod tests {
             Some(ScanPredicate::Eq {
                 column: "name".into(),
                 value: StatScalar::Utf8("Alice".into()),
-            })
-        );
-    }
-
-    #[test]
-    fn between_translates() {
-        let e = Expression {
-            kind: ExpressionKind::Between {
-                target: Box::new(property("a", "age")),
-                low: Box::new(int_lit(20)),
-                high: Box::new(int_lit(40)),
-            },
-            span: span(),
-        };
-        assert_eq!(
-            try_into_scan_predicate(&e, "a"),
-            Some(ScanPredicate::Between {
-                column: "age".into(),
-                low: StatScalar::Int64(20),
-                high: StatScalar::Int64(40),
             })
         );
     }

--- a/crates/namidb-query/src/optimize/projection_pushdown.rs
+++ b/crates/namidb-query/src/optimize/projection_pushdown.rs
@@ -384,11 +384,6 @@ fn collect_from_expr(expr: &Expression, req: &mut RequiredSet) {
             collect_from_expr(item, req);
             collect_from_expr(list, req);
         }
-        ExpressionKind::Between { target, low, high } => {
-            collect_from_expr(target, req);
-            collect_from_expr(low, req);
-            collect_from_expr(high, req);
-        }
         ExpressionKind::StringTest {
             target, pattern, ..
         } => {

--- a/crates/namidb-query/src/parser/ast.rs
+++ b/crates/namidb-query/src/parser/ast.rs
@@ -383,11 +383,6 @@ pub enum ExpressionKind {
         item: Box<Expression>,
         list: Box<Expression>,
     },
-    Between {
-        target: Box<Expression>,
-        low: Box<Expression>,
-        high: Box<Expression>,
-    },
     StringTest {
         op: StringOp,
         target: Box<Expression>,

--- a/crates/namidb-query/src/parser/display.rs
+++ b/crates/namidb-query/src/parser/display.rs
@@ -327,9 +327,6 @@ impl fmt::Display for Expression {
                 write!(f, "({} {} {})", left, binary_op_symbol(*op), right)
             }
             ExpressionKind::In { item, list } => write!(f, "({} IN {})", item, list),
-            ExpressionKind::Between { target, low, high } => {
-                write!(f, "({} BETWEEN {} AND {})", target, low, high)
-            }
             ExpressionKind::StringTest {
                 op,
                 target,

--- a/crates/namidb-query/src/plan/explain.rs
+++ b/crates/namidb-query/src/plan/explain.rs
@@ -831,13 +831,6 @@ fn format_scan_predicate(p: &ScanPredicate, alias: &str) -> String {
         ScanPredicate::GtEq { column, value } => {
             format!("{alias}.{column} >= {}", format_stat_scalar(value))
         }
-        ScanPredicate::Between { column, low, high } => {
-            format!(
-                "{alias}.{column} BETWEEN {} AND {}",
-                format_stat_scalar(low),
-                format_stat_scalar(high)
-            )
-        }
         ScanPredicate::IsNull { column } => format!("{alias}.{column} IS NULL"),
         ScanPredicate::IsNotNull { column } => format!("{alias}.{column} IS NOT NULL"),
         ScanPredicate::In { column, values } => {

--- a/crates/namidb-query/src/plan/lower.rs
+++ b/crates/namidb-query/src/plan/lower.rs
@@ -428,11 +428,6 @@ fn reject_nested_pattern_comprehension(expr: &Expression) -> Result<(), LowerErr
             reject_nested_pattern_comprehension(item)?;
             reject_nested_pattern_comprehension(list)
         }
-        ExpressionKind::Between { target, low, high } => {
-            reject_nested_pattern_comprehension(target)?;
-            reject_nested_pattern_comprehension(low)?;
-            reject_nested_pattern_comprehension(high)
-        }
         ExpressionKind::StringTest {
             target, pattern, ..
         } => {
@@ -1359,11 +1354,6 @@ fn walk_extract_agg(expr: &Expression, aggs: &mut Aggregations) -> Result<Expres
             item: Box::new(walk_extract_agg(item, aggs)?),
             list: Box::new(walk_extract_agg(list, aggs)?),
         },
-        Between { target, low, high } => Between {
-            target: Box::new(walk_extract_agg(target, aggs)?),
-            low: Box::new(walk_extract_agg(low, aggs)?),
-            high: Box::new(walk_extract_agg(high, aggs)?),
-        },
         StringTest {
             op,
             target,
@@ -1448,11 +1438,6 @@ fn contains_agg_variable(expr: &Expression) -> bool {
         }
         ExpressionKind::In { item, list } => {
             contains_agg_variable(item) || contains_agg_variable(list)
-        }
-        ExpressionKind::Between { target, low, high } => {
-            contains_agg_variable(target)
-                || contains_agg_variable(low)
-                || contains_agg_variable(high)
         }
         ExpressionKind::StringTest {
             target, pattern, ..
@@ -1984,11 +1969,6 @@ fn check_expression_bindings(expr: &Expression, ctx: &LowerCtx) -> Result<(), Lo
         ExpressionKind::In { item, list } => {
             check_expression_bindings(item, ctx)?;
             check_expression_bindings(list, ctx)
-        }
-        ExpressionKind::Between { target, low, high } => {
-            check_expression_bindings(target, ctx)?;
-            check_expression_bindings(low, ctx)?;
-            check_expression_bindings(high, ctx)
         }
         ExpressionKind::StringTest {
             target, pattern, ..

--- a/crates/namidb-storage/src/sst/predicates.rs
+++ b/crates/namidb-storage/src/sst/predicates.rs
@@ -37,12 +37,6 @@ pub enum ScanPredicate {
     Gt { column: String, value: StatScalar },
     /// `column >= value`.
     GtEq { column: String, value: StatScalar },
-    /// `low <= column <= high` (inclusive both sides).
-    Between {
-        column: String,
-        low: StatScalar,
-        high: StatScalar,
-    },
     /// `column IS NULL`.
     IsNull { column: String },
     /// `column IS NOT NULL`.
@@ -63,7 +57,6 @@ impl ScanPredicate {
             | ScanPredicate::LtEq { column, .. }
             | ScanPredicate::Gt { column, .. }
             | ScanPredicate::GtEq { column, .. }
-            | ScanPredicate::Between { column, .. }
             | ScanPredicate::IsNull { column }
             | ScanPredicate::IsNotNull { column }
             | ScanPredicate::In { column, .. } => column,
@@ -155,34 +148,6 @@ pub fn eval_row_group(predicate: &ScanPredicate, stats: &PropertyColumnStats) ->
             None => MaybePresent,
         },
 
-        P::Between {
-            column: _,
-            low,
-            high,
-        } => {
-            let lower = eval_row_group(
-                &P::GtEq {
-                    column: predicate.column().to_string(),
-                    value: low.clone(),
-                },
-                stats,
-            );
-            if lower == Absent {
-                return Absent;
-            }
-            let upper = eval_row_group(
-                &P::LtEq {
-                    column: predicate.column().to_string(),
-                    value: high.clone(),
-                },
-                stats,
-            );
-            if upper == Absent {
-                return Absent;
-            }
-            MaybePresent
-        }
-
         P::IsNull { .. } => {
             if stats.null_count > 0 {
                 MaybePresent
@@ -200,8 +165,8 @@ pub fn eval_row_group(predicate: &ScanPredicate, stats: &PropertyColumnStats) ->
 
         P::In { values, .. } => {
             // Build the closed interval [min(values), max(values)] and
-            // reuse the Between path. False-positives (a value
-            // inside [low, high] but not in the list) are caught by
+            // prune with a GtEq(min) AND LtEq(max) pair. False-positives (a
+            // value inside [low, high] but not in the list) are caught by
             // the residual Filter the optimizer leaves intact when
             // `In` is partial.
             if values.is_empty() {
@@ -309,15 +274,6 @@ pub fn eval_against_value(predicate: &ScanPredicate, value: Option<&Value>) -> b
         P::GtEq { value: target, .. } => value_cmp(v, target)
             .map(|o| matches!(o, Ordering::Greater | Ordering::Equal))
             .unwrap_or(false),
-        P::Between { low, high, .. } => {
-            let lo_ok = value_cmp(v, low)
-                .map(|o| matches!(o, Ordering::Greater | Ordering::Equal))
-                .unwrap_or(false);
-            let hi_ok = value_cmp(v, high)
-                .map(|o| matches!(o, Ordering::Less | Ordering::Equal))
-                .unwrap_or(false);
-            lo_ok && hi_ok
-        }
         P::In { values, .. } => values.iter().any(|target| {
             value_cmp(v, target)
                 .map(|o| o == Ordering::Equal)
@@ -559,54 +515,6 @@ mod tests {
     }
 
     #[test]
-    fn between_overlap_is_maybe_present() {
-        let s = stats(
-            "age",
-            Some(StatScalar::Int64(10)),
-            Some(StatScalar::Int64(50)),
-            0,
-        );
-        let p = ScanPredicate::Between {
-            column: "age".into(),
-            low: StatScalar::Int64(20),
-            high: StatScalar::Int64(40),
-        };
-        assert_eq!(eval_row_group(&p, &s), RowGroupVerdict::MaybePresent);
-    }
-
-    #[test]
-    fn between_disjoint_above_is_absent() {
-        let s = stats(
-            "age",
-            Some(StatScalar::Int64(10)),
-            Some(StatScalar::Int64(50)),
-            0,
-        );
-        let p = ScanPredicate::Between {
-            column: "age".into(),
-            low: StatScalar::Int64(60),
-            high: StatScalar::Int64(80),
-        };
-        assert_eq!(eval_row_group(&p, &s), RowGroupVerdict::Absent);
-    }
-
-    #[test]
-    fn between_disjoint_below_is_absent() {
-        let s = stats(
-            "age",
-            Some(StatScalar::Int64(10)),
-            Some(StatScalar::Int64(50)),
-            0,
-        );
-        let p = ScanPredicate::Between {
-            column: "age".into(),
-            low: StatScalar::Int64(1),
-            high: StatScalar::Int64(5),
-        };
-        assert_eq!(eval_row_group(&p, &s), RowGroupVerdict::Absent);
-    }
-
-    #[test]
     fn is_null_with_nulls_is_maybe_present() {
         let s = stats(
             "age",
@@ -711,11 +619,6 @@ mod tests {
                 column: "age".into(),
                 value: StatScalar::Int64(5),
             },
-            ScanPredicate::Between {
-                column: "age".into(),
-                low: StatScalar::Int64(1),
-                high: StatScalar::Int64(2),
-            },
         ] {
             assert_eq!(
                 eval_row_group(&p, &s),
@@ -798,20 +701,6 @@ mod tests {
         assert!(eval_against_value(&p, Some(&Value::I64(20))));
         assert!(!eval_against_value(&p, Some(&Value::I64(30))));
         assert!(!eval_against_value(&p, Some(&Value::I64(40))));
-    }
-
-    #[test]
-    fn eval_against_value_between_works() {
-        let p = ScanPredicate::Between {
-            column: "age".into(),
-            low: StatScalar::Int64(20),
-            high: StatScalar::Int64(40),
-        };
-        assert!(eval_against_value(&p, Some(&Value::I64(20))));
-        assert!(eval_against_value(&p, Some(&Value::I64(30))));
-        assert!(eval_against_value(&p, Some(&Value::I64(40))));
-        assert!(!eval_against_value(&p, Some(&Value::I64(50))));
-        assert!(!eval_against_value(&p, Some(&Value::I64(10))));
     }
 
     #[test]


### PR DESCRIPTION
Roadmap item D9. `ExpressionKind::Between` (namidb-query) and `ScanPredicate::Between` (namidb-storage) carried full lowering, cost, exec, EXPLAIN and pushdown support with tests — but the path was unreachable and redundant, so this removes it.

## Why remove (not activate)
- **Unreachable:** the parser has no `BETWEEN` token and no optimizer pass fuses `x >= a AND x <= b`. The only two producer sites form a closed cycle (`parquet_pushdown` consumes an `ExpressionKind::Between` to make a `ScanPredicate::Between`; `selectivity` costing reverse-builds an `ExpressionKind::Between` from an existing predicate) with no external seed. No real query can ever construct one.
- **Redundant:** the storage row-group evaluator for `ScanPredicate::Between` literally decomposes into `GtEq(low) AND LtEq(high)` (`predicates.rs`), and the scan loop already AND-combines independent predicates with first-`Absent`-wins. The optimizer **already** splits `x >= a AND x <= b` into two `ScanPredicate`s that prune bit-for-bit identically. A fused `Between` adds zero skip capability — only a single selectivity estimate vs multiplying two, and a tidier EXPLAIN line. Not worth a correctness-sensitive fusion pass (5 constraints) for a machine that activates nothing the engine cannot already do.

## Change
Delete both enum variants and every match arm that referenced them across both crates (lowering, cost/selectivity incl. the `sel_between` fn + `FALLBACK_BETWEEN`, exec eval, variable collection, projection/visit, parquet pushdown producer, EXPLAIN render, Display), plus 7 unit tests that exercised the dead path. The two-range pruning tests (e.g. `age > 40 AND age < 60`) stay and cover the real path. Pure deletion: 11 files, +3/-249.

## Verify
`grep` confirms zero `Between` references remain in either crate. `namidb-query` (431 lib + integration) and `namidb-storage` (270 + suites) green, `cargo fmt --check` clean, no new clippy warnings, downstream cli/server/mcp build. No behaviour change for any query (the path was dead).

(Decision backed by a source-verified analysis: the row-group evaluator decomposition and the existing two-range split were confirmed at file:line before removing.)