### PR TITLE
feat(bolt): answer Memgraph schema-introspection procedures for GUI clients

### DIFF
--- a/crates/namidb-server/src/bolt.rs
+++ b/crates/namidb-server/src/bolt.rs
@@ -42,6 +42,18 @@ impl Backend for ServerBackend {
         cypher: &str,
         params: Params,
     ) -> std::result::Result<RunOutcome, BackendError> {
+        // Memgraph-style schema introspection (gdotv and other Bolt
+        // GUIs) hits procedures the Cypher parser has no `CALL` clause
+        // for. Answer them from the live snapshot before the parser
+        // would reject them as a syntax error. See `crate::introspect`.
+        {
+            let owned = self.state.snapshot.load();
+            let snap = owned.borrow();
+            if let Some(result) = crate::introspect::try_introspect(cypher, &snap).await {
+                return result;
+            }
+        }
+
         let parsed = match cypher_parse(cypher) {
             Ok(p) => p,
             Err(errs) => {
@@ -161,7 +173,17 @@ pub async fn serve(
 ) -> anyhow::Result<()> {
     let listener = TcpListener::bind(listen).await?;
     info!(addr = %listen, "namidb bolt listening");
-    let agent = format!("NamiDB/{}", env!("CARGO_PKG_VERSION"));
+    // The HELLO `server` agent must look like a Neo4j build or the
+    // official drivers (and GUIs built on them: gdotv, Neo4j Browser,
+    // Bloom) reject the connection with "Server does not identify as a
+    // genuine Neo4j instance". Memgraph and Amazon Neptune present a
+    // `Neo4j/<version>` agent for exactly this reason; the Bolt endpoint
+    // exists for driver compatibility, so we default to one too.
+    // Override via `NAMIDB_BOLT_SERVER_AGENT` (e.g. to the honest
+    // `NamiDB/<version>` when talking to a lenient client).
+    let agent =
+        std::env::var("NAMIDB_BOLT_SERVER_AGENT").unwrap_or_else(|_| "Neo4j/5.13.0".to_string());
+    info!(server_agent = %agent, "bolt server agent");
     loop {
         let (socket, peer) = match listener.accept().await {
             Ok(p) => p,

--- a/crates/namidb-server/src/introspect.rs
+++ b/crates/namidb-server/src/introspect.rs
@@ -1,0 +1,334 @@
+//! Memgraph-flavoured schema introspection for Bolt GUI clients.
+//!
+//! NamiDB's Cypher dialect has no `CALL`/`SHOW` clause, so the schema
+//! procedures a graph GUI fires on connect would be rejected at the
+//! parser with a `SyntaxError` before they ever reach the engine. A
+//! Neo4j/Memgraph-compatible client (e.g. G.V()/gdotv) needs those to
+//! answer, or its schema sidebar stays empty.
+//!
+//! Rather than grow a procedure subsystem in the query crate, we
+//! intercept the handful of introspection strings here, on the Bolt
+//! boundary, and synthesise the answer from the live [`Snapshot`]
+//! (memtable + SSTs, so freshly-written data shows up without a flush).
+//!
+//! The exact set is the queries G.V()/gdotv issues for a **Memgraph**
+//! connection, read verbatim from its bundled `neo4j-java-driver`
+//! backend:
+//!
+//! ```text
+//! CALL meta_util.schema() YIELD *;
+//! CALL schema.node_type_properties() YIELD *
+//! CALL schema.rel_type_properties() YIELD *
+//! CALL mg.procedures() YIELD name, signature
+//! CALL mg.functions() YIELD name, signature
+//! ```
+//!
+//! Anything else returns `None` and falls through to the real parser.
+//!
+//! Property type detail is best-effort: declared/persisted property
+//! types come from the manifest cheaply, and ad-hoc (schemaless) ones
+//! are picked up by sampling live nodes. Edge-property sampling and a
+//! bounded (non-materialising) node scan are deliberate follow-ups; see
+//! the notes at [`sample_label`].
+
+use std::collections::BTreeMap;
+
+use namidb_bolt::{BackendError, RunOutcome, StatementType};
+use namidb_core::{DataType, Value};
+use namidb_query::{Row, RuntimeValue};
+use namidb_storage::Snapshot;
+use tracing::warn;
+
+/// How many nodes per label we look at when sampling ad-hoc property
+/// names. The scan itself still walks the label (see follow-up note);
+/// this only caps how many rows we inspect for property keys.
+const SAMPLE_NODES: usize = 256;
+
+/// Intercept a Memgraph-style introspection query. Returns `None` for
+/// anything that isn't one of the known procedures, in which case the
+/// caller proceeds to the normal parse/plan/execute path.
+pub async fn try_introspect(
+    cypher: &str,
+    snap: &Snapshot<'_>,
+) -> Option<Result<RunOutcome, BackendError>> {
+    let norm = normalize(cypher);
+    let outcome = if norm.starts_with("call meta_util.schema(") {
+        meta_util_schema(snap).await
+    } else if norm.starts_with("call schema.node_type_properties(") {
+        node_type_properties(snap).await
+    } else if norm.starts_with("call schema.rel_type_properties(") {
+        rel_type_properties(snap)
+    } else if norm.starts_with("call mg.procedures(") {
+        mg_procedures()
+    } else if norm.starts_with("call mg.functions(") {
+        mg_functions()
+    } else {
+        return None;
+    };
+    Some(Ok(outcome))
+}
+
+/// Collapse whitespace, drop a trailing `;`, and lowercase so the
+/// match is robust to the small formatting differences between clients
+/// (`YIELD *` vs not, trailing semicolon, extra spaces).
+fn normalize(s: &str) -> String {
+    let trimmed = s.trim().trim_end_matches(';').trim();
+    trimmed
+        .split_whitespace()
+        .collect::<Vec<_>>()
+        .join(" ")
+        .to_lowercase()
+}
+
+/// `CALL meta_util.schema() YIELD *` — the primary schema source for a
+/// Memgraph client. Returns a single row, single column whose value is
+/// a map `{nodes: [...], relationships: [...]}`. Each node is a map
+/// `{id, labels, count, properties}` and each relationship a map
+/// `{id, start, end, label, count, properties}`, with `start`/`end`
+/// referencing node `id`s — the exact shape G.V() deserialises.
+async fn meta_util_schema(snap: &Snapshot<'_>) -> RunOutcome {
+    let labels = snap.observed_labels();
+
+    // Stable id per label so relationship endpoints can reference them.
+    let mut label_id: BTreeMap<String, i64> = BTreeMap::new();
+    let mut nodes: Vec<RuntimeValue> = Vec::with_capacity(labels.len());
+    for (i, label) in labels.iter().enumerate() {
+        let id = i as i64;
+        label_id.insert(label.clone(), id);
+        let (count, props) = sample_label(snap, label).await;
+        let mut node = BTreeMap::new();
+        node.insert("id".to_string(), RuntimeValue::Integer(id));
+        node.insert(
+            "labels".to_string(),
+            RuntimeValue::List(vec![RuntimeValue::String(label.clone())]),
+        );
+        node.insert("count".to_string(), RuntimeValue::Integer(count));
+        node.insert("properties".to_string(), props_to_map(props));
+        nodes.push(RuntimeValue::Map(node));
+    }
+
+    let mut rels: Vec<RuntimeValue> = Vec::new();
+    match snap.observed_edge_endpoints().await {
+        Ok(endpoints) => {
+            for (j, ep) in endpoints.iter().enumerate() {
+                let start = ep.src_label.as_ref().and_then(|l| label_id.get(l)).copied();
+                let end = ep.dst_label.as_ref().and_then(|l| label_id.get(l)).copied();
+                // Keep start/end pointing at a node that exists in the
+                // list above; an unresolved endpoint (edge type created
+                // without inferable labels) falls back to node id 0
+                // rather than dangling, which G.V() can't resolve.
+                let mut rel = BTreeMap::new();
+                rel.insert("id".to_string(), RuntimeValue::Integer(j as i64));
+                rel.insert(
+                    "start".to_string(),
+                    RuntimeValue::Integer(start.unwrap_or(0)),
+                );
+                rel.insert("end".to_string(), RuntimeValue::Integer(end.unwrap_or(0)));
+                rel.insert(
+                    "label".to_string(),
+                    RuntimeValue::String(ep.edge_type.clone()),
+                );
+                rel.insert("count".to_string(), RuntimeValue::Integer(0));
+                rel.insert("properties".to_string(), RuntimeValue::Map(BTreeMap::new()));
+                rels.push(RuntimeValue::Map(rel));
+            }
+        }
+        Err(e) => warn!(error = %e, "introspect: observed_edge_endpoints failed"),
+    }
+
+    let mut schema = BTreeMap::new();
+    schema.insert("nodes".to_string(), RuntimeValue::List(nodes));
+    schema.insert("relationships".to_string(), RuntimeValue::List(rels));
+
+    let row = Row::new().with("schema", RuntimeValue::Map(schema));
+    read_outcome(vec!["schema".to_string()], vec![row])
+}
+
+/// `CALL schema.node_type_properties()` — one row per (label, property)
+/// with Memgraph's column set. G.V() reads `nodeLabels`, `propertyName`
+/// and `propertyTypes`.
+async fn node_type_properties(snap: &Snapshot<'_>) -> RunOutcome {
+    let fields = vec![
+        "nodeType".to_string(),
+        "nodeLabels".to_string(),
+        "mandatory".to_string(),
+        "propertyName".to_string(),
+        "propertyTypes".to_string(),
+    ];
+    let mut rows = Vec::new();
+    for label in snap.observed_labels() {
+        let (_count, props) = sample_label(snap, &label).await;
+        let node_type = format!(":`{}`", label);
+        let node_labels = RuntimeValue::List(vec![RuntimeValue::String(label.clone())]);
+        if props.is_empty() {
+            rows.push(node_prop_row(&node_type, node_labels, "", ""));
+        } else {
+            for (name, ty) in props {
+                rows.push(node_prop_row(&node_type, node_labels.clone(), &name, &ty));
+            }
+        }
+    }
+    read_outcome(fields, rows)
+}
+
+/// `CALL schema.rel_type_properties()` — one row per edge type. Edge
+/// property sampling is a follow-up, so for now every type is reported
+/// with empty property columns; the type itself still shows up in the
+/// client's relationship list.
+fn rel_type_properties(snap: &Snapshot<'_>) -> RunOutcome {
+    let fields = vec![
+        "relType".to_string(),
+        "mandatory".to_string(),
+        "propertyName".to_string(),
+        "propertyTypes".to_string(),
+    ];
+    let mut rows = Vec::new();
+    for edge_type in snap.observed_edge_types() {
+        let rel_type = format!(":`{}`", edge_type);
+        let row = Row::new()
+            .with("relType", RuntimeValue::String(rel_type))
+            .with("mandatory", RuntimeValue::Bool(false))
+            .with("propertyName", RuntimeValue::String(String::new()))
+            .with("propertyTypes", RuntimeValue::String(String::new()));
+        rows.push(row);
+    }
+    read_outcome(fields, rows)
+}
+
+/// `CALL mg.procedures()` — advertise the procedures this shim answers
+/// so the client's autocomplete/catalog isn't empty.
+fn mg_procedures() -> RunOutcome {
+    let procs = [
+        ("meta_util.schema", "meta_util.schema() :: (schema :: MAP)"),
+        (
+            "schema.node_type_properties",
+            "schema.node_type_properties() :: (nodeType :: STRING, nodeLabels :: LIST, mandatory :: BOOLEAN, propertyName :: STRING, propertyTypes :: STRING)",
+        ),
+        (
+            "schema.rel_type_properties",
+            "schema.rel_type_properties() :: (relType :: STRING, mandatory :: BOOLEAN, propertyName :: STRING, propertyTypes :: STRING)",
+        ),
+        ("mg.procedures", "mg.procedures() :: (name :: STRING, signature :: STRING)"),
+        ("mg.functions", "mg.functions() :: (name :: STRING, signature :: STRING)"),
+    ];
+    let rows = procs
+        .iter()
+        .map(|(name, sig)| {
+            Row::new()
+                .with("name", RuntimeValue::String((*name).to_string()))
+                .with("signature", RuntimeValue::String((*sig).to_string()))
+        })
+        .collect();
+    read_outcome(vec!["name".to_string(), "signature".to_string()], rows)
+}
+
+/// `CALL mg.functions()` — no user-defined functions to advertise yet.
+fn mg_functions() -> RunOutcome {
+    read_outcome(
+        vec!["name".to_string(), "signature".to_string()],
+        Vec::new(),
+    )
+}
+
+// --- helpers ---------------------------------------------------------
+
+/// Label property names mapped to a Memgraph-style type label. Declared
+/// and persisted types come from the manifest for free; ad-hoc
+/// (schemaless) properties that only live in `__overflow_json` are not
+/// typed there, so we also sample live nodes to surface them.
+///
+/// Follow-up: `scan_label` materialises the whole label. Introspection
+/// runs rarely, but on a large undeclared label this is a full scan per
+/// schema refresh. A bounded streaming scan (stop after `SAMPLE_NODES`)
+/// would cap it; for declared/flushed schemas the manifest path alone is
+/// enough and the sample mostly adds nothing.
+async fn sample_label(snap: &Snapshot<'_>, label: &str) -> (i64, BTreeMap<String, String>) {
+    let mut props: BTreeMap<String, String> = snap
+        .observed_property_types_for_label(label)
+        .into_iter()
+        .map(|(name, dt)| (name, datatype_name(&dt).to_string()))
+        .collect();
+
+    let mut count: i64 = 0;
+    match snap.scan_label(label).await {
+        Ok(views) => {
+            count = views.len() as i64;
+            for view in views.iter().take(SAMPLE_NODES) {
+                for (name, value) in &view.properties {
+                    if matches!(value, Value::Null) {
+                        continue;
+                    }
+                    props
+                        .entry(name.clone())
+                        .or_insert_with(|| value_type_name(value).to_string());
+                }
+            }
+        }
+        Err(e) => warn!(error = %e, label, "introspect: scan_label failed"),
+    }
+    (count, props)
+}
+
+fn props_to_map(props: BTreeMap<String, String>) -> RuntimeValue {
+    RuntimeValue::Map(
+        props
+            .into_iter()
+            .map(|(name, ty)| (name, RuntimeValue::String(ty)))
+            .collect(),
+    )
+}
+
+fn node_prop_row(
+    node_type: &str,
+    node_labels: RuntimeValue,
+    prop_name: &str,
+    prop_type: &str,
+) -> Row {
+    Row::new()
+        .with("nodeType", RuntimeValue::String(node_type.to_string()))
+        .with("nodeLabels", node_labels)
+        .with("mandatory", RuntimeValue::Bool(false))
+        .with("propertyName", RuntimeValue::String(prop_name.to_string()))
+        .with("propertyTypes", RuntimeValue::String(prop_type.to_string()))
+}
+
+fn read_outcome(fields: Vec<String>, rows: Vec<Row>) -> RunOutcome {
+    RunOutcome {
+        fields,
+        rows,
+        statement_type: StatementType::Read,
+        counters: Default::default(),
+    }
+}
+
+/// Manifest-declared/persisted Arrow type → Memgraph-ish type label.
+fn datatype_name(dt: &DataType) -> &'static str {
+    match dt {
+        DataType::Bool => "Bool",
+        DataType::Int32 | DataType::Int64 => "Int",
+        DataType::Float32 | DataType::Float64 => "Float",
+        DataType::Utf8 | DataType::LargeUtf8 => "String",
+        DataType::Binary => "String",
+        DataType::Date32 => "Date",
+        DataType::TimestampMicrosUtc => "LocalDateTime",
+        DataType::FloatVector { .. } => "List",
+        DataType::Json => "Map",
+    }
+}
+
+/// Sampled runtime value → Memgraph-ish type label.
+fn value_type_name(v: &Value) -> &'static str {
+    match v {
+        Value::Null => "Null",
+        Value::Bool(_) => "Bool",
+        Value::I64(_) => "Int",
+        Value::F64(_) => "Float",
+        Value::Str(_) => "String",
+        Value::Bytes(_) => "String",
+        Value::Vec(_) => "List",
+        Value::Date(_) => "Date",
+        Value::DateTime(_) => "LocalDateTime",
+        Value::List(_) => "List",
+        _ => "Map",
+    }
+}

--- a/crates/namidb-server/src/lib.rs
+++ b/crates/namidb-server/src/lib.rs
@@ -7,6 +7,7 @@
 //! the end-to-end boot procedure.
 
 pub mod bolt;
+mod introspect;
 
 use std::sync::Arc;
 use std::time::Duration;

--- a/crates/namidb-server/tests/bolt_integration.rs
+++ b/crates/namidb-server/tests/bolt_integration.rs
@@ -366,3 +366,180 @@ async fn bolt_bad_token_yields_failure() {
 
     server_task.abort();
 }
+
+/// Like [`run_pull`], but issues a single `PULL` and drains every
+/// buffered `RECORD` up to the closing `SUCCESS`. Safe for result sets
+/// of any size (including zero rows), where the per-record `PULL` loop
+/// in `run_pull` would over-send.
+async fn pull_all(stream: &mut TcpStream, cypher: &str) -> (Vec<String>, Vec<RowMap>) {
+    let run = Value::Struct {
+        tag: struct_tag::RUN,
+        fields: vec![
+            Value::String(cypher.into()),
+            Value::Map(BTreeMap::new()),
+            Value::Map(BTreeMap::new()),
+        ],
+    };
+    send_msg(stream, &pack(&run)).await;
+
+    let fields = match recv_msg(stream).await {
+        Response::Success(meta) => match meta.get("fields") {
+            Some(Value::List(items)) => items
+                .iter()
+                .filter_map(|v| match v {
+                    Value::String(s) => Some(s.clone()),
+                    _ => None,
+                })
+                .collect::<Vec<_>>(),
+            _ => Vec::new(),
+        },
+        other => panic!("expected head SUCCESS, got {other:?}"),
+    };
+
+    let pull = Value::Struct {
+        tag: struct_tag::PULL,
+        fields: vec![Value::Map({
+            let mut m = BTreeMap::new();
+            m.insert("n".into(), Value::Int(-1));
+            m
+        })],
+    };
+    send_msg(stream, &pack(&pull)).await;
+
+    let mut rows: Vec<RowMap> = Vec::new();
+    loop {
+        match recv_msg(stream).await {
+            Response::Record(values) => {
+                let mut row = BTreeMap::new();
+                for (k, v) in fields.iter().cloned().zip(values) {
+                    row.insert(k, v);
+                }
+                rows.push(row);
+            }
+            Response::Success(_) => return (fields, rows),
+            other => panic!("unexpected message draining PULL: {other:?}"),
+        }
+    }
+}
+
+#[tokio::test]
+async fn bolt_memgraph_introspection_populates_schema() {
+    // A Memgraph-flavoured GUI (e.g. G.V()/gdotv) fires schema
+    // procedures on connect. The Cypher parser has no CALL clause, so
+    // the `introspect` shim must answer them from the live snapshot
+    // before the parser would reject them as a syntax error.
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let bolt_addr = listener.local_addr().unwrap();
+    drop(listener);
+
+    let http_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let http_addr = http_listener.local_addr().unwrap();
+    drop(http_listener);
+
+    let config = namidb_server::Config {
+        store_uri: "memory://bolt-introspect".into(),
+        listen: http_addr,
+        auth_token: Some("test-token".into()),
+        flush_interval: Duration::ZERO,
+        bolt_listen: Some(bolt_addr),
+    };
+    let server_task = tokio::spawn(async move {
+        let _ = namidb_server::run(config).await;
+    });
+    for _ in 0..50 {
+        if TcpStream::connect(bolt_addr).await.is_ok() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+
+    let mut stream = TcpStream::connect(bolt_addr).await.expect("connect bolt");
+    handshake(&mut stream).await;
+    hello_and_logon(&mut stream, "test-token").await;
+
+    // Seed a small graph with ad-hoc (schemaless) properties and one
+    // edge connecting two distinct labels.
+    pull_all(&mut stream, "CREATE (a:Person {name: 'Alice', age: 30})").await;
+    pull_all(&mut stream, "CREATE (c:Company {name: 'NamiDB'})").await;
+    pull_all(
+        &mut stream,
+        "MATCH (a:Person {name:'Alice'}),(c:Company {name:'NamiDB'}) CREATE (a)-[:WORKS_AT]->(c)",
+    )
+    .await;
+
+    // schema.node_type_properties(): one row per (label, property),
+    // surfacing the sampled schemaless types.
+    let (fields, rows) = pull_all(&mut stream, "CALL schema.node_type_properties() YIELD *").await;
+    assert!(fields.iter().any(|f| f == "nodeLabels"));
+    assert!(fields.iter().any(|f| f == "propertyName"));
+    assert!(fields.iter().any(|f| f == "propertyTypes"));
+    let person_name = rows
+        .iter()
+        .find(|r| {
+            r.get("propertyName") == Some(&Value::String("name".into()))
+                && matches!(
+                    r.get("nodeLabels"),
+                    Some(Value::List(l)) if l.contains(&Value::String("Person".into()))
+                )
+        })
+        .expect("Person.name row present");
+    assert_eq!(
+        person_name.get("propertyTypes"),
+        Some(&Value::String("String".into())),
+    );
+
+    // meta_util.schema(): a single row whose `schema` map carries the
+    // node and relationship lists G.V() renders.
+    let (_f, rows) = pull_all(&mut stream, "CALL meta_util.schema() YIELD *;").await;
+    assert_eq!(rows.len(), 1, "meta_util.schema must return one row");
+    let schema = match rows[0].get("schema") {
+        Some(Value::Map(m)) => m,
+        other => panic!("schema column not a map: {other:?}"),
+    };
+    let nodes = match schema.get("nodes") {
+        Some(Value::List(l)) => l,
+        other => panic!("nodes not a list: {other:?}"),
+    };
+    assert_eq!(nodes.len(), 2, "expected Person + Company node types");
+    let rels = match schema.get("relationships") {
+        Some(Value::List(l)) => l,
+        other => panic!("relationships not a list: {other:?}"),
+    };
+    assert_eq!(rels.len(), 1, "expected one WORKS_AT edge type");
+
+    // The edge's start/end must reference ids that exist in `nodes` so
+    // the client can resolve endpoint labels.
+    let node_ids: std::collections::BTreeSet<i64> = nodes
+        .iter()
+        .filter_map(|n| match n {
+            Value::Map(m) => match m.get("id") {
+                Some(Value::Int(i)) => Some(*i),
+                _ => None,
+            },
+            _ => None,
+        })
+        .collect();
+    let rel = match &rels[0] {
+        Value::Map(m) => m,
+        other => panic!("rel not a map: {other:?}"),
+    };
+    for key in ["start", "end"] {
+        match rel.get(key) {
+            Some(Value::Int(i)) => assert!(node_ids.contains(i), "{key} {i} dangling"),
+            other => panic!("{key} not an int: {other:?}"),
+        }
+    }
+    assert_eq!(rel.get("label"), Some(&Value::String("WORKS_AT".into())));
+
+    // rel_type_properties() lists the edge type.
+    let (_f, rows) = pull_all(&mut stream, "CALL schema.rel_type_properties() YIELD *").await;
+    assert!(
+        rows.iter()
+            .any(|r| r.get("relType") == Some(&Value::String(":`WORKS_AT`".into()))),
+        "WORKS_AT not listed by rel_type_properties: {rows:?}"
+    );
+
+    goodbye(&mut stream).await;
+    stream.shutdown().await.ok();
+    server_task.abort();
+}


### PR DESCRIPTION
A Neo4j/Memgraph-compatible graph GUI (G.V()/gdotv) fires schema-introspection procedures on connect. NamiDBs Cypher dialect has no `CALL`/`SHOW` clause, so those were rejected at the parser as a `SyntaxError` and the clients schema sidebar stayed empty (even though plain queries worked over Bolt).

## Change
Intercept the handful of Memgraph introspection strings at the Bolt boundary, before the parser, and synthesise the answer from the live `Snapshot` (memtable + SSTs, so freshly-written data shows up without a flush). Handled:
- `CALL meta_util.schema()` -> `{nodes, relationships}` with per-label counts, sampled property types, and edge endpoints resolved to node ids (the shape G.V() deserialises)
- `CALL schema.node_type_properties()` / `schema.rel_type_properties()`
- `CALL mg.procedures()` / `mg.functions()`

Anything else returns `None` and falls through to the normal parse/plan/execute path. Property types come from the manifest where declared/persisted and are otherwise sampled from live nodes (capped per label). The Bolt HELLO `server` agent now reports a Neo4j-shaped build string so the official drivers and the GUIs built on them complete the handshake.

Edge-property sampling and a bounded (non-materialising) label scan are noted as follow-ups in `introspect.rs`.

## Tests
New `bolt_memgraph_introspection_populates_schema` integration test drives a real Bolt connection through the introspection procedures and asserts the schema rows. Server suite green, `cargo fmt --check` clean, no new clippy warnings.