### PR TITLE
feat(server): background L0->L1 compaction + orphan sweep scheduler

### DIFF
--- a/crates/namidb-server/src/lib.rs
+++ b/crates/namidb-server/src/lib.rs
@@ -27,7 +27,7 @@ use namidb_query::{
     execute, execute_write, parse as cypher_parse, plan as build_plan, Params, RuntimeValue,
     StatsCatalog, WriteOutcome,
 };
-use namidb_storage::{Manifest, SnapshotCell, WriterSession};
+use namidb_storage::{sweep_orphans, Manifest, ManifestStore, SnapshotCell, WriterSession};
 
 /// Process-wide configuration assembled from CLI flags or env vars.
 #[derive(Debug, Clone)]
@@ -39,6 +39,16 @@ pub struct Config {
     /// long random secret.
     pub auth_token: Option<String>,
     pub flush_interval: Duration,
+    /// Interval for the background maintenance task (L0->L1 compaction +
+    /// orphan sweep). `Duration::ZERO` disables it.
+    pub compaction_interval: Duration,
+    /// Minimum age before the orphan sweep may delete an unreferenced SST
+    /// body — the sole guard against deleting a file a slow reader's pinned
+    /// snapshot still references.
+    pub sweep_min_age: Duration,
+    /// When `false` the orphan sweep is a dry-run (logs what it would free
+    /// without deleting). Operators opt in after reviewing the volume.
+    pub sweep_delete: bool,
     /// Bolt listener address. `None` keeps the protocol off (HTTP only).
     pub bolt_listen: Option<std::net::SocketAddr>,
 }
@@ -131,6 +141,10 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
         store = %config.store_uri,
         "opening namespace"
     );
+    // A `ManifestStore` for the background orphan sweep, which loads the
+    // committed manifest itself without the writer lock. Built from the
+    // same `(store, paths)` before `open` consumes them.
+    let maint_manifest_store = ManifestStore::new(store.clone(), paths.clone());
     let writer = WriterSession::open(store, paths).await?;
 
     let state = AppState::new(writer, config.auth_token.clone(), namespace);
@@ -149,6 +163,62 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
                 match w.flush(schema).await {
                     Ok(_) => state_for_flush.snapshot.store(w.owned_snapshot()),
                     Err(e) => error!(error = %e, "periodic flush failed"),
+                }
+            }
+        });
+    }
+
+    // Periodic background maintenance: compact L0 SSTs to L1 (bounds read
+    // amplification), then sweep orphaned SST bodies left behind by
+    // compaction. Compaction is a writer mutation, so it goes through the
+    // ONE writer lock — never a second `WriterSession`, which would bump the
+    // epoch and fence the foreground writer. The sweep takes no lock (it
+    // reads the committed manifest itself) and is gated to a dry-run by
+    // default; `sweep_min_age` is the only thing keeping it from deleting a
+    // body a slow reader's pinned snapshot still references.
+    if config.compaction_interval > Duration::ZERO {
+        let state_for_maint = state.clone();
+        let interval = config.compaction_interval;
+        let sweep_min_age = config.sweep_min_age;
+        let sweep_delete = config.sweep_delete;
+        tokio::spawn(async move {
+            let mut tick = tokio::time::interval(interval);
+            tick.tick().await; // first tick fires immediately; skip.
+            loop {
+                tick.tick().await;
+                // Compaction under the writer lock. `compact_l0` self-no-ops
+                // below 2 L0 SSTs per bucket, so an idle tick is cheap and
+                // does not commit. Republish only when it actually merged,
+                // so reads pick up the new L1 SST and release the removed L0
+                // descriptors.
+                {
+                    let mut w = state_for_maint.writer.lock().await;
+                    let schema = w.snapshot().manifest().manifest.schema.clone();
+                    match w.compact_l0(&schema).await {
+                        Ok(outcome) if outcome.source_ssts_removed > 0 => {
+                            state_for_maint.snapshot.store(w.owned_snapshot());
+                            info!(
+                                removed = outcome.source_ssts_removed,
+                                written = outcome.new_ssts_written,
+                                "compacted L0 into L1"
+                            );
+                        }
+                        Ok(_) => {}
+                        Err(e) => error!(error = %e, "periodic compaction failed"),
+                    }
+                }
+                // Orphan sweep — no writer lock. `max_level = 1` because the
+                // engine only produces L0 + L1 today.
+                match sweep_orphans(&maint_manifest_store, sweep_min_age, 1, sweep_delete).await {
+                    Ok(report) if report.orphans_found > 0 => info!(
+                        found = report.orphans_found,
+                        deleted = report.orphans_deleted,
+                        bytes_freed = report.bytes_freed,
+                        dry_run = !sweep_delete,
+                        "orphan sweep"
+                    ),
+                    Ok(_) => {}
+                    Err(e) => error!(error = %e, "orphan sweep failed"),
                 }
             }
         });

--- a/crates/namidb-server/src/main.rs
+++ b/crates/namidb-server/src/main.rs
@@ -43,6 +43,36 @@ struct Cli {
     )]
     flush_interval: Duration,
 
+    /// Interval at which the background maintenance task compacts L0 SSTs
+    /// (collapsing each bucket to a single L1 SST to keep read
+    /// amplification bounded) and then sweeps orphaned SST bodies. Set to
+    /// `0s` to disable maintenance entirely.
+    #[arg(
+        long,
+        env = "NAMIDB_COMPACTION_INTERVAL",
+        default_value = "300s",
+        value_parser = humantime::parse_duration,
+    )]
+    compaction_interval: Duration,
+
+    /// Minimum age an orphaned SST body must reach before the sweep may
+    /// delete it. This is the only guard against removing a file a slow
+    /// reader's pinned snapshot still references, so keep it comfortably
+    /// above the longest expected query/snapshot lifetime.
+    #[arg(
+        long,
+        env = "NAMIDB_SWEEP_MIN_AGE",
+        default_value = "24h",
+        value_parser = humantime::parse_duration,
+    )]
+    sweep_min_age: Duration,
+
+    /// Actually delete orphaned SST bodies during the sweep. Off by
+    /// default: the sweep runs as a dry-run and only logs what it would
+    /// free, so an operator can review the volume before opting in.
+    #[arg(long, env = "NAMIDB_SWEEP_DELETE", default_value_t = false)]
+    sweep_delete: bool,
+
     /// Address for the Bolt protocol listener (Neo4j driver
     /// compatibility). When omitted the protocol is off and the
     /// server is HTTP-only. The canonical Bolt port is 7687.
@@ -64,6 +94,9 @@ fn main() -> anyhow::Result<()> {
         listen: cli.listen,
         auth_token: cli.auth_token,
         flush_interval: cli.flush_interval,
+        compaction_interval: cli.compaction_interval,
+        sweep_min_age: cli.sweep_min_age,
+        sweep_delete: cli.sweep_delete,
         bolt_listen: cli.bolt_listen,
     };
 

--- a/crates/namidb-server/tests/background_maintenance.rs
+++ b/crates/namidb-server/tests/background_maintenance.rs
@@ -1,0 +1,179 @@
+//! A1: background compaction + orphan sweep.
+//!
+//! The server's maintenance task collapses L0 SSTs into L1 (bounding read
+//! amplification) and sweeps the orphaned L0 bodies compaction leaves
+//! behind. This test drives ONE maintenance tick inline (no wall-clock
+//! dependency) against the same `AppState` the server uses, and pins the
+//! contract:
+//!
+//! 1. Seeding three flushed batches creates >= 2 L0 SSTs in one bucket.
+//! 2. `compact_l0` collapses them to a single L1 SST and removes the L0s.
+//! 3. Reads return the same data before and after — including a snapshot
+//!    pinned *before* compaction (the source bodies survive for it).
+//! 4. The orphan sweep finds the now-unreferenced L0 bodies, deletes them
+//!    when asked, and a re-run finds nothing — and reads still hold.
+
+use std::sync::Arc;
+
+use namidb_query::{
+    execute, execute_write, parse as cypher_parse, plan as build_plan, Params, RuntimeValue,
+    StatsCatalog,
+};
+use namidb_storage::{
+    sweep_orphans, ManifestStore, OwnedSnapshot, SstKind, SstLevel, WriterSession,
+};
+
+const NS: &str = "maint-test";
+
+async fn create_person(state: &namidb_server::AppState, i: usize) {
+    let q = format!(
+        "CREATE (a:Person {{name: 'p{i}', age: {}}})",
+        (i % 80) as i64
+    );
+    let parsed = cypher_parse(&q).expect("parse");
+    let mut w = state.writer.lock().await;
+    let catalog = StatsCatalog::from_manifest(&w.snapshot().manifest().manifest);
+    let plan = build_plan(&parsed, &catalog).expect("plan");
+    execute_write(&plan, &mut w, &Params::new())
+        .await
+        .expect("write");
+    state.snapshot.store(w.owned_snapshot());
+}
+
+/// Flush the live memtable into one L0 SST per touched bucket and
+/// republish.
+async fn flush(state: &namidb_server::AppState) {
+    let mut w = state.writer.lock().await;
+    let schema = w.snapshot().manifest().manifest.schema.clone();
+    w.flush(schema).await.expect("flush");
+    state.snapshot.store(w.owned_snapshot());
+}
+
+fn person_ssts(snap: &OwnedSnapshot, level: SstLevel) -> usize {
+    snap.manifest()
+        .manifest
+        .ssts
+        .iter()
+        .filter(|d| d.kind == SstKind::Nodes && d.scope == "Person" && d.level == level)
+        .count()
+}
+
+/// `MATCH (p:Person) RETURN count(p)` against a pinned snapshot.
+async fn count_persons(snap: &Arc<OwnedSnapshot>) -> i64 {
+    let parsed = cypher_parse("MATCH (p:Person) RETURN count(p) AS c").expect("parse");
+    let catalog = StatsCatalog::from_manifest(&snap.manifest().manifest);
+    let plan = build_plan(&parsed, &catalog).expect("plan");
+    let borrowed = snap.borrow();
+    let rows = execute(&plan, &borrowed, &Params::new())
+        .await
+        .expect("read");
+    match rows.first().and_then(|r| r.get("c")) {
+        Some(RuntimeValue::Integer(n)) => *n,
+        other => panic!("unexpected count row: {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn compaction_collapses_l0_and_sweep_reclaims_orphans() {
+    let (store, paths) = namidb_storage::parse_uri(&format!("memory://{NS}")).unwrap();
+    // The sweep loads the committed manifest itself, so it needs its own
+    // ManifestStore built from the same (store, paths) — exactly what the
+    // server does in `run()`.
+    let manifest_store = ManifestStore::new(store.clone(), paths.clone());
+    let writer = WriterSession::open(store, paths).await.unwrap();
+    let state = namidb_server::AppState::new(writer, None, NS.into());
+
+    // Three flushed batches → three L0 SSTs in the (Nodes, Person) bucket.
+    const BATCHES: usize = 3;
+    const PER_BATCH: usize = 4;
+    for b in 0..BATCHES {
+        for j in 0..PER_BATCH {
+            create_person(&state, b * PER_BATCH + j).await;
+        }
+        flush(&state).await;
+    }
+    let total = (BATCHES * PER_BATCH) as i64;
+
+    let before = state.snapshot.load();
+    assert!(
+        person_ssts(&before, SstLevel::L0) >= 2,
+        "expected >= 2 L0 Person SSTs before compaction, got {}",
+        person_ssts(&before, SstLevel::L0)
+    );
+    assert_eq!(count_persons(&before).await, total, "baseline count");
+
+    // Pin a snapshot from before compaction: its source L0 bodies must
+    // remain readable even after compaction drops them from the manifest.
+    let pinned_pre_compaction = state.snapshot.load();
+
+    // ── One maintenance tick: compaction under the writer lock ──
+    {
+        let mut w = state.writer.lock().await;
+        let schema = w.snapshot().manifest().manifest.schema.clone();
+        let outcome = w.compact_l0(&schema).await.expect("compact");
+        assert!(
+            outcome.source_ssts_removed >= 2,
+            "compaction should consume >= 2 L0 SSTs, removed {}",
+            outcome.source_ssts_removed
+        );
+        assert!(
+            outcome.new_ssts_written >= 1,
+            "compaction should write >= 1 L1 SST, wrote {}",
+            outcome.new_ssts_written
+        );
+        state.snapshot.store(w.owned_snapshot());
+    }
+
+    let after = state.snapshot.load();
+    assert_eq!(
+        person_ssts(&after, SstLevel::L0),
+        0,
+        "no L0 Person SSTs should remain after compaction"
+    );
+    assert_eq!(
+        person_ssts(&after, SstLevel(1)),
+        1,
+        "the bucket should collapse to a single L1 SST"
+    );
+
+    // Reads stay correct on the new snapshot AND on the pre-compaction one.
+    assert_eq!(count_persons(&after).await, total, "count after compaction");
+    assert_eq!(
+        count_persons(&pinned_pre_compaction).await,
+        total,
+        "a snapshot pinned before compaction still reads its source bodies"
+    );
+
+    // ── Orphan sweep: the dropped L0 bodies are now unreferenced. ──
+    // min_age = 0 in-test (production default is 24h); max_level = 1.
+    let dry = sweep_orphans(&manifest_store, std::time::Duration::ZERO, 1, false)
+        .await
+        .expect("dry-run sweep");
+    assert!(
+        dry.orphans_found >= 2,
+        "dry-run should find >= 2 orphaned L0 bodies, found {}",
+        dry.orphans_found
+    );
+    assert_eq!(dry.orphans_deleted, 0, "dry-run deletes nothing");
+
+    let del = sweep_orphans(&manifest_store, std::time::Duration::ZERO, 1, true)
+        .await
+        .expect("delete sweep");
+    assert_eq!(
+        del.orphans_deleted, dry.orphans_found,
+        "delete sweep removes exactly the orphans the dry-run found"
+    );
+
+    let dry2 = sweep_orphans(&manifest_store, std::time::Duration::ZERO, 1, false)
+        .await
+        .expect("second dry-run");
+    assert_eq!(dry2.orphans_found, 0, "no orphans remain after the sweep");
+
+    // The live L1 SST was untouched: a fresh read still returns everything.
+    let final_snap = state.snapshot.load();
+    assert_eq!(
+        count_persons(&final_snap).await,
+        total,
+        "count still correct after the sweep deleted the orphaned bodies"
+    );
+}

--- a/crates/namidb-server/tests/bolt_integration.rs
+++ b/crates/namidb-server/tests/bolt_integration.rs
@@ -249,6 +249,9 @@ async fn bolt_create_then_match_roundtrip() {
         listen: http_addr,
         auth_token: Some("test-token".into()),
         flush_interval: Duration::ZERO,
+        compaction_interval: Duration::ZERO,
+        sweep_min_age: Duration::ZERO,
+        sweep_delete: false,
         bolt_listen: Some(bolt_addr),
     };
 
@@ -313,6 +316,9 @@ async fn bolt_bad_token_yields_failure() {
         listen: http_addr,
         auth_token: Some("correct-token".into()),
         flush_interval: Duration::ZERO,
+        compaction_interval: Duration::ZERO,
+        sweep_min_age: Duration::ZERO,
+        sweep_delete: false,
         bolt_listen: Some(bolt_addr),
     };
 
@@ -441,6 +447,9 @@ async fn bolt_memgraph_introspection_populates_schema() {
         listen: http_addr,
         auth_token: Some("test-token".into()),
         flush_interval: Duration::ZERO,
+        compaction_interval: Duration::ZERO,
+        sweep_min_age: Duration::ZERO,
+        sweep_delete: false,
         bolt_listen: Some(bolt_addr),
     };
     let server_task = tokio::spawn(async move {


### PR DESCRIPTION
Roadmap A1 — the #1 strategic gap. A long-running `namidb-server` only spawned the periodic flush task, so L0 SSTs accumulated and the orphan bodies compaction leaves behind were never reclaimed. Read and storage amplification grew without bound on exactly the long-lived "cloud-native on S3" deployment the project targets. The machinery (`compact_l0`, `sweep_orphans`) already existed but was only caller-driven.

## Change
A background maintenance task — a sibling of the flush task, gated by `--compaction-interval` (default `300s`, `0s` disables). Each tick:

1. **Compacts L0 into L1 under the ONE writer lock** (same discipline as flush). It never opens a second `WriterSession` — that would bump the epoch and fence the foreground writer — and republishes the snapshot only when a merge actually happened so reads pick up the new L1 SST and release the removed L0 descriptors. `compact_l0` self-no-ops below 2 L0 SSTs per bucket, so an idle tick is cheap and commits nothing.
2. **Sweeps orphaned SST bodies** with no writer lock (it reads the committed manifest itself).

## Safety
The sweep is the only structurally-unsafe half: a body a slow readers pinned snapshot still references could be deleted (there is no snapshot-anchor refcount yet). So it ships **gated to a dry-run** (`--sweep-delete`, default off) and only removes bodies older than `--sweep-min-age` (default `24h`) — the sole guard. The compaction half (structurally safe under the writer lock) delivers the read-amp win immediately; orphan reclamation is opt-in. Reads never touch the writer lock and run on a pinned snapshot, so compaction + republish is transparent to in-flight reads.

## Tests
New `background_maintenance.rs` drives one tick inline: three flushed batches create >= 2 L0 SSTs, compaction collapses them to a single L1 and removes the L0s, reads return the same data before and after (including a snapshot pinned *before* compaction, proving source bodies survive for in-flight readers), and the sweep finds, deletes, and then no longer finds the orphans while reads stay correct. Server suite green, `cargo fmt --check` clean, no new clippy warnings.

Deferred (noted in code): multi-level compaction (L1->L2+, A2), WAL-segment janitor (A5), a snapshot-anchor side-table, and driving shutdown on a persistent fence.