### PR TITLE
feat(query): synthesise bindings for anonymous elements in a bound path

### DIFF
--- a/crates/namidb-query/src/plan/lower.rs
+++ b/crates/namidb-query/src/plan/lower.rs
@@ -160,13 +160,52 @@ fn require_input(p: Option<LogicalPlan>, span: SourceSpan) -> Result<LogicalPlan
 
 struct LowerCtx {
     bindings: BTreeSet<String>,
+    /// Monotonic source of internal binding names for anonymous path
+    /// elements (see [`LowerCtx::fill_anonymous_path_bindings`]). Never
+    /// reset, so names stay unique across clauses.
+    anon_counter: usize,
 }
 
 impl LowerCtx {
     fn new() -> Self {
         Self {
             bindings: BTreeSet::new(),
+            anon_counter: 0,
         }
+    }
+
+    /// A fresh internal binding name. The leading space can never appear
+    /// in a user-written identifier, so it cannot collide with a real
+    /// binding (and reads as internal if it ever surfaces).
+    fn fresh_anon(&mut self, span: SourceSpan) -> ast::Identifier {
+        let n = self.anon_counter;
+        self.anon_counter += 1;
+        ast::Identifier::new(format!(" anon{n}"), span)
+    }
+
+    /// Return a copy of `elem` with every anonymous head node,
+    /// relationship, and target node given a fresh internal binding.
+    ///
+    /// A *bound* path (`p = ...`) must address each element so
+    /// [`build_path_constructor`] can assemble it. Clients like gdotv
+    /// write path bindings with anonymous elements — `p = ()-[]->()` for
+    /// the default graph view, `p = ()-[r]-()` for edge expansion — which
+    /// would otherwise be rejected. Synthesising bindings makes those
+    /// behave exactly like the explicitly-aliased form.
+    fn fill_anonymous_path_bindings(&mut self, elem: &PatternElement) -> PatternElement {
+        let mut out = elem.clone();
+        if out.head.binding.is_none() {
+            out.head.binding = Some(self.fresh_anon(out.head.span));
+        }
+        for (rel, target) in out.chain.iter_mut() {
+            if rel.binding.is_none() {
+                rel.binding = Some(self.fresh_anon(rel.span));
+            }
+            if target.binding.is_none() {
+                target.binding = Some(self.fresh_anon(target.span));
+            }
+        }
+        out
     }
 
     fn introduce(&mut self, name: &str, span: SourceSpan) -> Result<(), LowerError> {
@@ -526,10 +565,14 @@ fn lower_pattern_part(
         return lower_pattern_element(&part.element, input, optional, shortest, ctx);
     }
     if let Some(path_bind) = &part.binding {
-        validate_path_pattern_v0(&part.element)?;
-        let plan = lower_pattern_element(&part.element, input, optional, shortest, ctx)?;
+        // Anonymous path elements (`p = ()-[]->()`, `p = ()-[r]-()`) get
+        // fresh internal bindings so the path can be assembled; without
+        // this the lower rejects them. See `fill_anonymous_path_bindings`.
+        let element = ctx.fill_anonymous_path_bindings(&part.element);
+        validate_path_pattern_v0(&element)?;
+        let plan = lower_pattern_element(&element, input, optional, shortest, ctx)?;
         ctx.introduce(&path_bind.name, path_bind.span)?;
-        let path_expr = build_path_constructor(&part.element, path_bind.span);
+        let path_expr = build_path_constructor(&element, path_bind.span);
         return Ok(LogicalPlan::Project {
             input: Box::new(plan),
             items: vec![ProjectionItem {
@@ -640,35 +683,15 @@ fn validate_shortest_path_pattern_v0(
 }
 
 fn validate_path_pattern_v0(elem: &PatternElement) -> Result<(), LowerError> {
-    if elem.head.binding.is_none() {
-        return Err(LowerError::new(
-            LowerErrorKind::UnsupportedFeature,
-            "path bindings require the head node to have an explicit alias \
- (e.g. `p = (a:Person)-[r]->(b:Person)`)",
-            elem.head.span,
-        ));
-    }
-    for (rel, target) in &elem.chain {
+    // Anonymous elements are filled with internal bindings before this
+    // runs (see `fill_anonymous_path_bindings`), so the only path-binding
+    // shape still unsupported in v0 is variable-length.
+    for (rel, _target) in &elem.chain {
         if rel.length.is_some() {
             return Err(LowerError::new(
                 LowerErrorKind::UnsupportedFeature,
                 "variable-length path bindings (e.g. `p = (a)-[*1..3]->(b)`) are not yet supported",
                 rel.span,
-            ));
-        }
-        if rel.binding.is_none() {
-            return Err(LowerError::new(
-                LowerErrorKind::UnsupportedFeature,
-                "path bindings require every relationship to have an explicit alias \
- (e.g. `-[r:KNOWS]-`)",
-                rel.span,
-            ));
-        }
-        if target.binding.is_none() {
-            return Err(LowerError::new(
-                LowerErrorKind::UnsupportedFeature,
-                "path bindings require every target node to have an explicit alias",
-                target.span,
             ));
         }
     }

--- a/crates/namidb-query/tests/exec_match_expand.rs
+++ b/crates/namidb-query/tests/exec_match_expand.rs
@@ -548,15 +548,50 @@ async fn path_binding_two_hop_chain() {
 }
 
 #[tokio::test]
-async fn path_binding_rejects_anonymous_rel() {
-    let q = parse("MATCH p = (a:Person)-[:KNOWS]->(b:Person) RETURN p").unwrap();
-    let err = lower(&q).expect_err("expected lowering error");
-    assert!(
-        err.message
-            .contains("relationship to have an explicit alias"),
-        "unexpected message: {}",
-        err.message
-    );
+async fn path_binding_supports_anonymous_elements() {
+    // Clients like gdotv bind paths with anonymous elements:
+    // `p = ()-[]->()` for the default graph view, or an anonymous
+    // relationship between named nodes. The lower fills the anonymous
+    // slots with internal bindings, so the path still materialises
+    // (rather than the old "explicit alias required" rejection).
+    let mut writer = WriterSession::open(store(), paths("exec-anon-path"))
+        .await
+        .unwrap();
+    build_friend_graph(&mut writer).await;
+    let snapshot = writer.snapshot();
+
+    // Anonymous relationship between named nodes.
+    let q = parse(
+        "MATCH p = (a:Person)-[:KNOWS]->(b:Person) \
+         WHERE a.name = 'Alice' AND b.name = 'Bob' \
+         RETURN p",
+    )
+    .unwrap();
+    let plan = lower(&q).unwrap();
+    let rows = execute(&plan, &snapshot, &Params::new()).await.unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_path_node_rel_node(rows[0].get("p"));
+
+    // Fully anonymous path — exactly what gdotv's default query emits.
+    let q = parse("MATCH p = ()-[]->() RETURN p").unwrap();
+    let plan = lower(&q).unwrap();
+    let rows = execute(&plan, &snapshot, &Params::new()).await.unwrap();
+    assert!(!rows.is_empty(), "anonymous path should match edges");
+    for row in &rows {
+        assert_path_node_rel_node(row.get("p"));
+    }
+}
+
+fn assert_path_node_rel_node(value: Option<&RuntimeValue>) {
+    match value {
+        Some(RuntimeValue::Path(items)) => {
+            assert_eq!(items.len(), 3, "path should be node-rel-node");
+            assert!(matches!(items[0], RuntimeValue::Node(_)), "head not a node");
+            assert!(matches!(items[1], RuntimeValue::Rel(_)), "middle not a rel");
+            assert!(matches!(items[2], RuntimeValue::Node(_)), "tail not a node");
+        }
+        other => panic!("expected Path, got {other:?}"),
+    }
 }
 
 #[tokio::test]


### PR DESCRIPTION
A bound path (`p = ...`) must address each element so the path constructor can assemble it, so the lower rejected a bound path whose head/rel/target were anonymous (`path bindings require ... explicit alias`). But that is exactly the shape a Bolt GUI writes:

- gdotv default graph view: `MATCH p=()-[]->() RETURN p LIMIT 100`
- gdotv click-to-expand: `MATCH p=()-[r]-() WHERE ID(r)=$id RETURN p`

Both were rejected at lowering before reaching the engine.

## Fix
`LowerCtx::fill_anonymous_path_bindings` gives every anonymous head node, relationship and target in a *bound* path a fresh internal binding (` anon{n}` — the leading space can never appear in a user identifier, so it cannot collide and reads as internal if it ever surfaces) before lowering the pattern, so anonymous-element bound paths behave exactly like the explicitly-aliased form. `validate_path_pattern_v0` now only rejects variable-length path bindings.

## Tests
New `path_binding_supports_anonymous_elements` (plus the existing path-binding tests) green; full `namidb-query` suite green (431 lib), `cargo fmt --check` clean. Verified live: gdotvs default query returns its paths.