### PR TITLE
feat(bolt): real BEGIN/COMMIT/ROLLBACK over the single-writer session

### DIFF
--- a/crates/namidb-bolt/src/session.rs
+++ b/crates/namidb-bolt/src/session.rs
@@ -134,6 +134,38 @@ pub trait Backend: Send + Sync {
         params: Params,
     ) -> std::result::Result<RunOutcome, BackendError>;
 
+    /// Begin an explicit transaction. Subsequent [`Backend::run_in_tx`]
+    /// calls stage into it; [`Backend::commit_tx`] makes them durable and
+    /// [`Backend::rollback_tx`] discards them. The default is a no-op so a
+    /// backend without transaction support keeps working (its in-tx writes
+    /// just behave like auto-commit).
+    async fn begin_tx(&self) -> std::result::Result<(), BackendError> {
+        Ok(())
+    }
+
+    /// Execute one statement inside the open explicit transaction. The
+    /// default delegates to [`Backend::run`] (auto-commit), which is the
+    /// pre-transaction behaviour for backends that do not override it.
+    async fn run_in_tx(
+        &self,
+        cypher: &str,
+        params: Params,
+    ) -> std::result::Result<RunOutcome, BackendError> {
+        self.run(cypher, params).await
+    }
+
+    /// Commit the open explicit transaction, making its staged statements
+    /// durable. Default is a no-op.
+    async fn commit_tx(&self) -> std::result::Result<(), BackendError> {
+        Ok(())
+    }
+
+    /// Roll back the open explicit transaction, discarding its staged
+    /// statements. Default is a no-op.
+    async fn rollback_tx(&self) -> std::result::Result<(), BackendError> {
+        Ok(())
+    }
+
     /// Optional override for the manifest version reported as the
     /// bookmark after COMMIT. Default returns `None` and the session
     /// emits no bookmark.
@@ -155,6 +187,12 @@ pub struct Session<S: AsyncReadExt + AsyncWriteExt + Unpin> {
     /// closing `SUCCESS` after PULL/DISCARD. `None` while no stream
     /// is active.
     pending_statement_type: Option<StatementType>,
+    /// While an explicit transaction is open the backend holds the writer
+    /// lock, so an idle client would pin it indefinitely. When set, a read
+    /// that blocks longer than this with a transaction open rolls the
+    /// transaction back (releasing the writer) and fails it. `None` (the
+    /// default) keeps the legacy unbounded behaviour for test backends.
+    tx_idle_timeout: Option<std::time::Duration>,
 }
 
 impl<S: AsyncReadExt + AsyncWriteExt + Unpin> Session<S> {
@@ -167,7 +205,15 @@ impl<S: AsyncReadExt + AsyncWriteExt + Unpin> Session<S> {
             state: State::Negotiation,
             version: None,
             pending_statement_type: None,
+            tx_idle_timeout: None,
         }
+    }
+
+    /// Set the idle timeout applied while an explicit transaction is open.
+    /// `None` disables it (a transaction may stay open indefinitely).
+    pub fn with_tx_idle_timeout(mut self, timeout: Option<std::time::Duration>) -> Self {
+        self.tx_idle_timeout = timeout;
+        self
     }
 
     /// Run the session to completion. Returns once the client sends
@@ -184,7 +230,31 @@ impl<S: AsyncReadExt + AsyncWriteExt + Unpin> Session<S> {
             } else {
                 POST_AUTH_MESSAGE_BYTES
             };
-            let body = match read_message(&mut self.socket, max).await {
+            // Bound how long the writer lock is pinned by an open
+            // transaction: if the client idles past `tx_idle_timeout` while
+            // in a transaction, roll it back to release the writer and fail
+            // the transaction.
+            let in_tx = matches!(self.state, State::TxReady | State::TxStreaming);
+            let idle = self.tx_idle_timeout;
+            let read = read_message(&mut self.socket, max);
+            let read_result = match (idle, in_tx) {
+                (Some(t), true) => match tokio::time::timeout(t, read).await {
+                    Ok(r) => r,
+                    Err(_elapsed) => {
+                        let _ = self.backend.rollback_tx().await;
+                        self.state = State::Failed;
+                        self.write_failure(
+                            "Neo.TransientError.Transaction.LockClientStopped",
+                            "transaction idle timeout; rolled back to release the writer"
+                                .to_string(),
+                        )
+                        .await?;
+                        continue;
+                    }
+                },
+                _ => read.await,
+            };
+            let body = match read_result {
                 Ok(b) => b,
                 Err(BoltError::Io(e)) if e.kind() == std::io::ErrorKind::UnexpectedEof => {
                     debug!("bolt connection closed by client");
@@ -235,12 +305,20 @@ impl<S: AsyncReadExt + AsyncWriteExt + Unpin> Session<S> {
     }
 
     async fn handle(&mut self, req: Request, element_mode: ElementIdMode) -> Result<()> {
-        // RESET always recovers; GOODBYE always ends.
+        // RESET always recovers; GOODBYE always ends. Either one while a
+        // transaction is open must roll it back so its staged writes are
+        // discarded (and the writer it holds is released).
         if matches!(req, Request::Reset) {
+            if matches!(self.state, State::TxReady | State::TxStreaming) {
+                let _ = self.backend.rollback_tx().await;
+            }
             self.state = State::Ready;
             return self.write_response(Response::success_empty()).await;
         }
         if matches!(req, Request::Goodbye) {
+            if matches!(self.state, State::TxReady | State::TxStreaming) {
+                let _ = self.backend.rollback_tx().await;
+            }
             self.state = State::Defunct;
             return Ok(());
         }
@@ -320,10 +398,16 @@ impl<S: AsyncReadExt + AsyncWriteExt + Unpin> Session<S> {
                 params,
                 extra: _,
             } => self.execute_run(&cypher, params, element_mode, false).await,
-            Request::Begin(_) => {
-                self.state = State::TxReady;
-                self.write_response(Response::success_empty()).await
-            }
+            Request::Begin(_) => match self.backend.begin_tx().await {
+                Ok(()) => {
+                    self.state = State::TxReady;
+                    self.write_response(Response::success_empty()).await
+                }
+                Err(e) => {
+                    self.state = State::Failed;
+                    self.write_failure(e.code(), e.message().to_string()).await
+                }
+            },
             Request::Route { .. } => self.respond_route().await,
             Request::Logoff => {
                 self.state = State::Authentication;
@@ -353,10 +437,16 @@ impl<S: AsyncReadExt + AsyncWriteExt + Unpin> Session<S> {
                 extra: _,
             } => self.execute_run(&cypher, params, element_mode, true).await,
             Request::Commit => self.commit(element_mode).await,
-            Request::Rollback => {
-                self.state = State::Ready;
-                self.write_response(Response::success_empty()).await
-            }
+            Request::Rollback => match self.backend.rollback_tx().await {
+                Ok(()) => {
+                    self.state = State::Ready;
+                    self.write_response(Response::success_empty()).await
+                }
+                Err(e) => {
+                    self.state = State::Failed;
+                    self.write_failure(e.code(), e.message().to_string()).await
+                }
+            },
             _ => self.invalid_state("unexpected message in TX_READY").await,
         }
     }
@@ -401,8 +491,15 @@ impl<S: AsyncReadExt + AsyncWriteExt + Unpin> Session<S> {
         inside_tx: bool,
     ) -> Result<()> {
         let params = params_from_bolt_map(&bolt_params);
-        let _ = params.clone(); // explicit clone to avoid moves later
-        let outcome = match self.backend.run(cypher, params).await {
+        // Inside an explicit transaction the statement stages into the open
+        // tx (committed at COMMIT, discarded at ROLLBACK); a bare RUN
+        // auto-commits.
+        let run_result = if inside_tx {
+            self.backend.run_in_tx(cypher, params).await
+        } else {
+            self.backend.run(cypher, params).await
+        };
+        let outcome = match run_result {
             Ok(o) => o,
             Err(e) => {
                 self.state = State::Failed;
@@ -448,6 +545,13 @@ impl<S: AsyncReadExt + AsyncWriteExt + Unpin> Session<S> {
     }
 
     async fn commit(&mut self, _element_mode: ElementIdMode) -> Result<()> {
+        // Make the transaction's staged statements durable. A failure here
+        // (e.g. a lost manifest CAS) is the abort surface; surface it as a
+        // FAILURE and the client retries.
+        if let Err(e) = self.backend.commit_tx().await {
+            self.state = State::Failed;
+            return self.write_failure(e.code(), e.message().to_string()).await;
+        }
         let mut meta = BTreeMap::new();
         if let Some(bm) = self.backend.current_bookmark().await {
             meta.insert("bookmark".into(), Value::String(bm));

--- a/crates/namidb-query/src/exec/mod.rs
+++ b/crates/namidb-query/src/exec/mod.rs
@@ -22,4 +22,4 @@ pub use leapfrog::{LeapfrogIntersect, MergeSortedUnion, OrdIterator, SortedSlice
 pub use row::Row;
 pub use value::{NodeValue, RelValue, RuntimeValue};
 pub use walker::{execute, execute_factor_path, execute_flat_path, ExecError};
-pub use writer::{execute_write, WriteOutcome};
+pub use writer::{execute_write, execute_write_staged, WriteOutcome};

--- a/crates/namidb-query/src/exec/writer.rs
+++ b/crates/namidb-query/src/exec/writer.rs
@@ -44,18 +44,37 @@ pub struct WriteOutcome {
     pub properties_set: u64,
 }
 
-/// Execute `plan` against `writer`. Reads pin a snapshot per read
-/// sub-plan; writes go through `writer.upsert_*` / `tombstone_*`. At the
-/// end, `writer.commit_batch()` makes every mutation durable.
-pub async fn execute_write(
+/// Execute `plan` against `writer`, staging its mutations into the
+/// writer's pending batch but NOT committing. The caller must then either
+/// `writer.commit_batch()` to make the batch durable or
+/// `writer.discard_batch()` to roll it back. Used by explicit Bolt
+/// transactions, which stage several statements and commit once at COMMIT.
+/// The RETURN rows are computed during the apply, so they are available
+/// before the commit; like [`execute_write`] there is no
+/// read-your-own-writes (a later read sub-plan sees the pre-call snapshot).
+pub async fn execute_write_staged(
     plan: &LogicalPlan,
     writer: &mut WriterSession,
     params: &Params,
 ) -> Result<WriteOutcome, ExecError> {
     let mut outcome = WriteOutcome::default();
     let rows = execute_write_inner(plan, writer, params, &mut outcome).await?;
-    writer.commit_batch().await.map_err(ExecError::Storage)?;
     outcome.rows = rows;
+    Ok(outcome)
+}
+
+/// Execute `plan` against `writer` and commit. Auto-commit mode: each call
+/// is its own transaction. Reads pin a snapshot per read sub-plan; writes
+/// go through `writer.upsert_*` / `tombstone_*` and `writer.commit_batch()`
+/// makes them durable. For a multi-statement explicit transaction use
+/// [`execute_write_staged`] and commit once at the end.
+pub async fn execute_write(
+    plan: &LogicalPlan,
+    writer: &mut WriterSession,
+    params: &Params,
+) -> Result<WriteOutcome, ExecError> {
+    let outcome = execute_write_staged(plan, writer, params).await?;
+    writer.commit_batch().await.map_err(ExecError::Storage)?;
     Ok(outcome)
 }
 

--- a/crates/namidb-query/src/lib.rs
+++ b/crates/namidb-query/src/lib.rs
@@ -35,8 +35,8 @@ pub use cost::{
     estimate, BindingMeta, Cardinality, EdgeTypeStats, LabelStats, PropStats, StatsCatalog,
 };
 pub use exec::{
-    evaluate, execute, execute_factor_path, execute_flat_path, execute_write, factorize_enabled,
-    EvalError, ExecError, Params, Row, RuntimeValue, WriteOutcome,
+    evaluate, execute, execute_factor_path, execute_flat_path, execute_write, execute_write_staged,
+    factorize_enabled, EvalError, ExecError, Params, Row, RuntimeValue, WriteOutcome,
 };
 pub use optimize::{convert_cross_to_hash, normalize_filters, optimize, predicate_pushdown};
 pub use parser::{parse, ParseError, ParseResult, Query};

--- a/crates/namidb-server/src/bolt.rs
+++ b/crates/namidb-server/src/bolt.rs
@@ -14,24 +14,43 @@ use namidb_bolt::{
     AuthPolicy, Backend, BackendError, RunOutcome, ServerInfo, Session, StatementType,
 };
 use namidb_query::{
-    execute, execute_write, parse as cypher_parse, plan as build_plan, ExecError, LowerError,
-    Params, ParseError,
+    execute, execute_write, execute_write_staged, parse as cypher_parse, plan as build_plan,
+    ExecError, LowerError, Params, ParseError, Row, WriteOutcome,
 };
+use namidb_storage::WriterSession;
 use tokio::net::TcpListener;
+use tokio::sync::{Mutex, OwnedMutexGuard};
 use tracing::{error, info, warn};
 use uuid::Uuid;
 
 use crate::AppState;
 
+/// In-flight explicit transaction (BEGIN..COMMIT/ROLLBACK). Holds the
+/// global writer lock for the whole transaction so no other writer — nor
+/// the flush / compaction tasks — can commit a half-built batch in the
+/// middle of it. Staged statements live in the writer's pending batch and
+/// are made durable in one commit at COMMIT, or dropped at ROLLBACK.
+struct TxState {
+    writer: OwnedMutexGuard<WriterSession>,
+    /// Whether any statement staged a mutation, so ROLLBACK only discards
+    /// when there is something to discard.
+    staged: bool,
+}
+
 /// Adapter that drives Bolt `RUN` requests against the shared
-/// [`WriterSession`].
+/// [`WriterSession`]. One is created per connection.
 pub struct ServerBackend {
     state: AppState,
+    /// Per-connection explicit-transaction slot. `None` outside BEGIN..END.
+    tx: Mutex<Option<TxState>>,
 }
 
 impl ServerBackend {
     pub fn new(state: AppState) -> Self {
-        Self { state }
+        Self {
+            state,
+            tx: Mutex::new(None),
+        }
     }
 }
 
@@ -78,34 +97,101 @@ impl Backend for ServerBackend {
                 .await
                 .map_err(map_exec_err)?;
             self.state.snapshot.store(writer.owned_snapshot());
-            let stype = classify_write(&outcome);
-            let fields = field_list(&outcome.rows);
-            let mut counters = std::collections::BTreeMap::new();
-            counters.insert("nodes-created".into(), outcome.nodes_created as i64);
-            counters.insert("nodes-deleted".into(), outcome.nodes_deleted as i64);
-            counters.insert("relationships-created".into(), outcome.edges_created as i64);
-            counters.insert("relationships-deleted".into(), outcome.edges_deleted as i64);
-            counters.insert("properties-set".into(), outcome.properties_set as i64);
-            Ok(RunOutcome {
-                fields,
-                rows: outcome.rows,
-                statement_type: stype,
-                counters,
-            })
+            Ok(write_run_outcome(outcome))
         } else {
             // Read path: borrow a short-lived `Snapshot` from the owned
             // snapshot; the Arc keeps the underlying memtable alive for
             // the duration of the query, no writer lock needed.
             let snap = owned.borrow();
             let rows = execute(&plan, &snap, &params).await.map_err(map_exec_err)?;
-            let fields = field_list(&rows);
-            Ok(RunOutcome {
-                fields,
-                rows,
-                statement_type: StatementType::Read,
-                counters: Default::default(),
-            })
+            Ok(read_run_outcome(rows))
         }
+    }
+
+    async fn begin_tx(&self) -> std::result::Result<(), BackendError> {
+        let mut slot = self.tx.lock().await;
+        if slot.is_some() {
+            return Err(BackendError::Other("a transaction is already open".into()));
+        }
+        // Take the global writer lock for the whole transaction. Held across
+        // RUNs (and client think-time) until COMMIT/ROLLBACK — see TxState.
+        let writer = self.state.writer.clone().lock_owned().await;
+        *slot = Some(TxState {
+            writer,
+            staged: false,
+        });
+        Ok(())
+    }
+
+    async fn run_in_tx(
+        &self,
+        cypher: &str,
+        params: Params,
+    ) -> std::result::Result<RunOutcome, BackendError> {
+        // Introspection and reads run against the published snapshot, same
+        // as auto-commit — an in-tx read does NOT see the tx's own staged
+        // writes (no read-your-own-writes; documented limitation).
+        {
+            let owned = self.state.snapshot.load();
+            let snap = owned.borrow();
+            if let Some(result) = crate::introspect::try_introspect(cypher, &snap).await {
+                return result;
+            }
+        }
+        let parsed = match cypher_parse(cypher) {
+            Ok(p) => p,
+            Err(errs) => {
+                let first = &errs[0];
+                return Err(BackendError::Syntax(format!(
+                    "{} at {}",
+                    first.message, first.span
+                )));
+            }
+        };
+        let owned = self.state.snapshot.load();
+        let catalog = self.state.catalog_for(&owned.manifest().manifest);
+        let plan = build_plan(&parsed, &catalog).map_err(map_lower_err)?;
+
+        if plan.contains_write() {
+            // Stage into the transaction's held writer; do NOT commit. The
+            // RETURN rows are computed during the apply, so they stream now.
+            let mut slot = self.tx.lock().await;
+            let tx = slot
+                .as_mut()
+                .ok_or_else(|| BackendError::Other("no open transaction".into()))?;
+            let outcome = execute_write_staged(&plan, &mut tx.writer, &params)
+                .await
+                .map_err(map_exec_err)?;
+            tx.staged = true;
+            Ok(write_run_outcome(outcome))
+        } else {
+            let snap = owned.borrow();
+            let rows = execute(&plan, &snap, &params).await.map_err(map_exec_err)?;
+            Ok(read_run_outcome(rows))
+        }
+    }
+
+    async fn commit_tx(&self) -> std::result::Result<(), BackendError> {
+        let mut slot = self.tx.lock().await;
+        let mut tx = slot
+            .take()
+            .ok_or_else(|| BackendError::Other("no open transaction".into()))?;
+        // One manifest CAS makes the whole transaction durable; then
+        // republish so reads see it. Dropping `tx` releases the writer lock.
+        tx.writer.commit_batch().await.map_err(map_storage_err)?;
+        self.state.snapshot.store(tx.writer.owned_snapshot());
+        Ok(())
+    }
+
+    async fn rollback_tx(&self) -> std::result::Result<(), BackendError> {
+        let mut slot = self.tx.lock().await;
+        if let Some(mut tx) = slot.take() {
+            if tx.staged {
+                tx.writer.discard_batch();
+            }
+            // Dropping `tx` releases the writer lock.
+        }
+        Ok(())
     }
 
     async fn current_bookmark(&self) -> Option<String> {
@@ -135,6 +221,44 @@ fn field_list(rows: &[namidb_query::Row]) -> Vec<String> {
     rows.first()
         .map(|r| r.bindings.keys().cloned().collect())
         .unwrap_or_default()
+}
+
+/// Build the Bolt `RunOutcome` for a write statement (auto-commit or staged
+/// in a transaction): the result rows plus the update counters.
+fn write_run_outcome(outcome: WriteOutcome) -> RunOutcome {
+    let stype = classify_write(&outcome);
+    let fields = field_list(&outcome.rows);
+    let mut counters = std::collections::BTreeMap::new();
+    counters.insert("nodes-created".into(), outcome.nodes_created as i64);
+    counters.insert("nodes-deleted".into(), outcome.nodes_deleted as i64);
+    counters.insert("relationships-created".into(), outcome.edges_created as i64);
+    counters.insert("relationships-deleted".into(), outcome.edges_deleted as i64);
+    counters.insert("properties-set".into(), outcome.properties_set as i64);
+    RunOutcome {
+        fields,
+        rows: outcome.rows,
+        statement_type: stype,
+        counters,
+    }
+}
+
+/// Build the Bolt `RunOutcome` for a read statement.
+fn read_run_outcome(rows: Vec<Row>) -> RunOutcome {
+    let fields = field_list(&rows);
+    RunOutcome {
+        fields,
+        rows,
+        statement_type: StatementType::Read,
+        counters: Default::default(),
+    }
+}
+
+/// Map a storage commit failure to a Bolt error. A failed manifest CAS
+/// poisons the `WriterSession` (its contract is "drop and reopen"); the
+/// reopen orchestration is a documented follow-up, so for now the client
+/// sees a retryable storage error.
+fn map_storage_err(e: namidb_storage::Error) -> BackendError {
+    BackendError::Storage(format!("{e}"))
 }
 
 fn map_lower_err(e: LowerError) -> BackendError {
@@ -170,7 +294,10 @@ pub async fn serve(
     state: AppState,
     listen: std::net::SocketAddr,
     auth_token: Option<Arc<str>>,
+    tx_timeout: std::time::Duration,
 ) -> anyhow::Result<()> {
+    // `Duration::ZERO` disables the per-transaction idle timeout.
+    let tx_idle_timeout = (!tx_timeout.is_zero()).then_some(tx_timeout);
     let listener = TcpListener::bind(listen).await?;
     info!(addr = %listen, "namidb bolt listening");
     // The HELLO `server` agent must look like a Neo4j build or the
@@ -209,7 +336,8 @@ pub async fn serve(
                 },
                 policy,
                 backend,
-            );
+            )
+            .with_tx_idle_timeout(tx_idle_timeout);
             if let Err(e) = session.run().await {
                 warn!(error = %e, %peer, "bolt session ended with error");
             }

--- a/crates/namidb-server/src/lib.rs
+++ b/crates/namidb-server/src/lib.rs
@@ -51,6 +51,11 @@ pub struct Config {
     pub sweep_delete: bool,
     /// Bolt listener address. `None` keeps the protocol off (HTTP only).
     pub bolt_listen: Option<std::net::SocketAddr>,
+    /// Idle timeout for an open Bolt explicit transaction. While a
+    /// transaction is open the writer lock is held, so an idle client would
+    /// pin it; after this long without a message the transaction is rolled
+    /// back and failed. `Duration::ZERO` disables the timeout.
+    pub bolt_tx_timeout: Duration,
 }
 
 /// `(manifest_version, catalog)` memoised behind a mutex and shared across
@@ -230,8 +235,9 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
     if let Some(bolt_addr) = config.bolt_listen {
         let bolt_state = state.clone();
         let bolt_auth = state.auth_token.clone();
+        let tx_timeout = config.bolt_tx_timeout;
         tokio::spawn(async move {
-            if let Err(e) = bolt::serve(bolt_state, bolt_addr, bolt_auth).await {
+            if let Err(e) = bolt::serve(bolt_state, bolt_addr, bolt_auth, tx_timeout).await {
                 error!(error = %e, "bolt listener exited");
             }
         });

--- a/crates/namidb-server/src/main.rs
+++ b/crates/namidb-server/src/main.rs
@@ -78,6 +78,18 @@ struct Cli {
     /// server is HTTP-only. The canonical Bolt port is 7687.
     #[arg(long, env = "NAMIDB_BOLT_LISTEN")]
     bolt_listen: Option<std::net::SocketAddr>,
+
+    /// Idle timeout for an open Bolt explicit transaction. The writer lock
+    /// is held for the life of a transaction, so an idle client would pin
+    /// it; after this long without a message the transaction is rolled back
+    /// and failed. Set to `0s` to allow transactions to stay open forever.
+    #[arg(
+        long,
+        env = "NAMIDB_BOLT_TX_TIMEOUT",
+        default_value = "30s",
+        value_parser = humantime::parse_duration,
+    )]
+    bolt_tx_timeout: Duration,
 }
 
 fn main() -> anyhow::Result<()> {
@@ -98,6 +110,7 @@ fn main() -> anyhow::Result<()> {
         sweep_min_age: cli.sweep_min_age,
         sweep_delete: cli.sweep_delete,
         bolt_listen: cli.bolt_listen,
+        bolt_tx_timeout: cli.bolt_tx_timeout,
     };
 
     let rt = tokio::runtime::Builder::new_multi_thread()

--- a/crates/namidb-server/tests/bolt_integration.rs
+++ b/crates/namidb-server/tests/bolt_integration.rs
@@ -228,6 +228,80 @@ async fn goodbye(stream: &mut TcpStream) {
     send_msg(stream, &pack(&bye)).await;
 }
 
+async fn begin(stream: &mut TcpStream) {
+    let msg = Value::Struct {
+        tag: struct_tag::BEGIN,
+        fields: vec![Value::Map(BTreeMap::new())],
+    };
+    send_msg(stream, &pack(&msg)).await;
+    match recv_msg(stream).await {
+        Response::Success(_) => {}
+        other => panic!("BEGIN expected SUCCESS, got {other:?}"),
+    }
+}
+
+async fn commit(stream: &mut TcpStream) {
+    let msg = Value::Struct {
+        tag: struct_tag::COMMIT,
+        fields: vec![],
+    };
+    send_msg(stream, &pack(&msg)).await;
+    match recv_msg(stream).await {
+        Response::Success(_) => {}
+        other => panic!("COMMIT expected SUCCESS, got {other:?}"),
+    }
+}
+
+async fn rollback(stream: &mut TcpStream) {
+    let msg = Value::Struct {
+        tag: struct_tag::ROLLBACK,
+        fields: vec![],
+    };
+    send_msg(stream, &pack(&msg)).await;
+    match recv_msg(stream).await {
+        Response::Success(_) => {}
+        other => panic!("ROLLBACK expected SUCCESS, got {other:?}"),
+    }
+}
+
+/// Boot a server on ephemeral ports and return the bound Bolt address plus
+/// the server task handle. Mirrors the boilerplate in the older tests.
+async fn boot_bolt(
+    ns: &str,
+    tx_timeout: Duration,
+) -> (std::net::SocketAddr, tokio::task::JoinHandle<()>) {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let bolt_addr = listener.local_addr().unwrap();
+    drop(listener);
+    let http_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let http_addr = http_listener.local_addr().unwrap();
+    drop(http_listener);
+
+    let config = namidb_server::Config {
+        store_uri: format!("memory://{ns}"),
+        listen: http_addr,
+        auth_token: Some("test-token".into()),
+        flush_interval: Duration::ZERO,
+        compaction_interval: Duration::ZERO,
+        sweep_min_age: Duration::ZERO,
+        sweep_delete: false,
+        bolt_listen: Some(bolt_addr),
+        bolt_tx_timeout: tx_timeout,
+    };
+    let task = tokio::spawn(async move {
+        if let Err(e) = namidb_server::run(config).await {
+            eprintln!("server exited: {e}");
+        }
+    });
+    for _ in 0..50 {
+        if TcpStream::connect(bolt_addr).await.is_ok() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    (bolt_addr, task)
+}
+
 #[tokio::test]
 async fn bolt_create_then_match_roundtrip() {
     // Bind on an ephemeral port.
@@ -253,6 +327,7 @@ async fn bolt_create_then_match_roundtrip() {
         sweep_min_age: Duration::ZERO,
         sweep_delete: false,
         bolt_listen: Some(bolt_addr),
+        bolt_tx_timeout: Duration::ZERO,
     };
 
     let server_task = tokio::spawn(async move {
@@ -320,6 +395,7 @@ async fn bolt_bad_token_yields_failure() {
         sweep_min_age: Duration::ZERO,
         sweep_delete: false,
         bolt_listen: Some(bolt_addr),
+        bolt_tx_timeout: Duration::ZERO,
     };
 
     let server_task = tokio::spawn(async move {
@@ -451,6 +527,7 @@ async fn bolt_memgraph_introspection_populates_schema() {
         sweep_min_age: Duration::ZERO,
         sweep_delete: false,
         bolt_listen: Some(bolt_addr),
+        bolt_tx_timeout: Duration::ZERO,
     };
     let server_task = tokio::spawn(async move {
         let _ = namidb_server::run(config).await;
@@ -551,4 +628,138 @@ async fn bolt_memgraph_introspection_populates_schema() {
     goodbye(&mut stream).await;
     stream.shutdown().await.ok();
     server_task.abort();
+}
+
+#[tokio::test]
+async fn bolt_rollback_discards_write() {
+    let (bolt_addr, task) = boot_bolt("bolt-tx-rollback", Duration::ZERO).await;
+    let mut stream = TcpStream::connect(bolt_addr).await.expect("connect bolt");
+    handshake(&mut stream).await;
+    hello_and_logon(&mut stream, "test-token").await;
+
+    begin(&mut stream).await;
+    // The write executes and returns its row inside the transaction.
+    let (_f, rows) = pull_all(
+        &mut stream,
+        "CREATE (a:Person {name: 'Zoe'}) RETURN a.name AS name",
+    )
+    .await;
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].get("name"), Some(&Value::String("Zoe".into())));
+
+    rollback(&mut stream).await;
+
+    // After ROLLBACK the write must be gone (this is what was broken: the
+    // per-RUN commit made it durable before ROLLBACK was ever seen).
+    let (_f, rows) = pull_all(
+        &mut stream,
+        "MATCH (p:Person {name: 'Zoe'}) RETURN p.name AS name",
+    )
+    .await;
+    assert!(
+        rows.is_empty(),
+        "ROLLBACK must discard the write, got {rows:?}"
+    );
+
+    goodbye(&mut stream).await;
+    stream.shutdown().await.ok();
+    task.abort();
+}
+
+#[tokio::test]
+async fn bolt_commit_persists_write() {
+    let (bolt_addr, task) = boot_bolt("bolt-tx-commit", Duration::ZERO).await;
+    let mut stream = TcpStream::connect(bolt_addr).await.expect("connect bolt");
+    handshake(&mut stream).await;
+    hello_and_logon(&mut stream, "test-token").await;
+
+    begin(&mut stream).await;
+    let (_f, rows) = pull_all(
+        &mut stream,
+        "CREATE (a:Person {name: 'Yan'}) RETURN a.name AS name",
+    )
+    .await;
+    assert_eq!(rows.len(), 1);
+    commit(&mut stream).await;
+
+    let (_f, rows) = pull_all(
+        &mut stream,
+        "MATCH (p:Person {name: 'Yan'}) RETURN p.name AS name",
+    )
+    .await;
+    assert_eq!(rows.len(), 1, "COMMIT must persist the write");
+    assert_eq!(rows[0].get("name"), Some(&Value::String("Yan".into())));
+
+    goodbye(&mut stream).await;
+    stream.shutdown().await.ok();
+    task.abort();
+}
+
+#[tokio::test]
+async fn bolt_multi_statement_commit_is_atomic() {
+    let (bolt_addr, task) = boot_bolt("bolt-tx-multi", Duration::ZERO).await;
+    let mut stream = TcpStream::connect(bolt_addr).await.expect("connect bolt");
+    handshake(&mut stream).await;
+    hello_and_logon(&mut stream, "test-token").await;
+
+    // Two statements in one transaction, then commit: both must land.
+    begin(&mut stream).await;
+    pull_all(&mut stream, "CREATE (a:Person {name: 'Ann'})").await;
+    pull_all(&mut stream, "CREATE (a:Person {name: 'Ben'})").await;
+    commit(&mut stream).await;
+
+    let (_f, rows) = pull_all(&mut stream, "MATCH (p:Person) RETURN p.name AS name").await;
+    assert_eq!(rows.len(), 2, "both committed creates must be visible");
+
+    // A third create rolled back must NOT appear, and must not disturb the
+    // two committed rows.
+    begin(&mut stream).await;
+    pull_all(&mut stream, "CREATE (a:Person {name: 'Cara'})").await;
+    rollback(&mut stream).await;
+
+    let (_f, rows) = pull_all(&mut stream, "MATCH (p:Person) RETURN p.name AS name").await;
+    assert_eq!(rows.len(), 2, "rolled-back create must not appear");
+
+    goodbye(&mut stream).await;
+    stream.shutdown().await.ok();
+    task.abort();
+}
+
+#[tokio::test]
+async fn bolt_idle_transaction_times_out_and_releases_writer() {
+    // A short idle timeout keeps the test fast.
+    let (bolt_addr, task) = boot_bolt("bolt-tx-timeout", Duration::from_millis(300)).await;
+
+    // Connection A: open a transaction, stage a write, then go idle. The
+    // server must roll it back (releasing the writer) and fail it.
+    let mut a = TcpStream::connect(bolt_addr).await.expect("connect a");
+    handshake(&mut a).await;
+    hello_and_logon(&mut a, "test-token").await;
+    begin(&mut a).await;
+    pull_all(&mut a, "CREATE (p:Person {name: 'Idle'})").await;
+    let timed_out = recv_msg(&mut a).await;
+    assert!(
+        matches!(timed_out, Response::Failure(_)),
+        "an idle open transaction should be failed by the server, got {timed_out:?}"
+    );
+
+    // Connection B: a WRITE must succeed — if A still held the writer lock
+    // this would block forever — and only B's node exists (A's was rolled
+    // back).
+    let mut b = TcpStream::connect(bolt_addr).await.expect("connect b");
+    handshake(&mut b).await;
+    hello_and_logon(&mut b, "test-token").await;
+    pull_all(&mut b, "CREATE (p:Person {name: 'After'})").await;
+    let (_f, rows) = pull_all(&mut b, "MATCH (p:Person) RETURN p.name AS name").await;
+    assert_eq!(
+        rows.len(),
+        1,
+        "only the post-timeout write should exist, got {rows:?}"
+    );
+    assert_eq!(rows[0].get("name"), Some(&Value::String("After".into())));
+
+    goodbye(&mut b).await;
+    a.shutdown().await.ok();
+    b.shutdown().await.ok();
+    task.abort();
 }

--- a/crates/namidb-storage/src/ingest.rs
+++ b/crates/namidb-storage/src/ingest.rs
@@ -309,6 +309,21 @@ impl WriterSession {
         self.pending.records.len()
     }
 
+    /// Drop the uncommitted batch without making it durable, returning the
+    /// number of mutations discarded. Used to roll back an explicit
+    /// transaction. Safe because staged writes only touch `pending` /
+    /// `pending_payloads` (queued) and never the memtable until
+    /// `commit_batch` drains them after the manifest CAS, so there is
+    /// nothing durable or in-memory to unwind. The WAL sequence is reused
+    /// (the discarded segment was never persisted); a skipped `next_lsn` is
+    /// harmless (reads always pick the strictly-higher LSN).
+    pub fn discard_batch(&mut self) -> usize {
+        let discarded = self.pending.records.len();
+        self.pending = WalSegment::new(self.pending.seq);
+        self.pending_payloads.clear();
+        discarded
+    }
+
     /// Every edge type known to this writer — declared in the manifest
     /// schema, present in the current memtable, or persisted in at
     /// least one SST descriptor. Used by the query executor's
@@ -1117,6 +1132,47 @@ mod tests {
         let out_edges = snap.out_edges("KNOWS", alice).await.unwrap();
         assert_eq!(out_edges.edges.len(), 1);
         assert_eq!(out_edges.edges[0].dst, bob);
+    }
+
+    #[tokio::test]
+    async fn discard_batch_drops_uncommitted_writes() {
+        let store = make_store();
+        let paths = make_paths("ingest-discard");
+        let mut session = WriterSession::open(store, paths).await.unwrap();
+
+        session
+            .upsert_node("Person", sorted_node_id(1), &node_record("Alice", Some(30)))
+            .unwrap();
+        session
+            .upsert_node("Person", sorted_node_id(2), &node_record("Bob", None))
+            .unwrap();
+        assert_eq!(session.pending_len(), 2);
+
+        assert_eq!(session.discard_batch(), 2);
+        assert_eq!(session.pending_len(), 0);
+
+        // The discarded ops never reached the memtable, so a commit now is a
+        // no-op and nothing is visible.
+        assert_eq!(session.commit_batch().await.unwrap(), CommitOutcome::Empty);
+        let snap = session.snapshot();
+        assert!(snap
+            .lookup_node("Person", sorted_node_id(1))
+            .await
+            .unwrap()
+            .is_none());
+
+        // The session is still usable: a fresh write commits and persists.
+        session
+            .upsert_node("Person", sorted_node_id(3), &node_record("Cara", Some(20)))
+            .unwrap();
+        let out = session.commit_batch().await.unwrap();
+        assert!(matches!(out, CommitOutcome::Committed { records: 1, .. }));
+        let snap = session.snapshot();
+        assert!(snap
+            .lookup_node("Person", sorted_node_id(3))
+            .await
+            .unwrap()
+            .is_some());
     }
 
     #[tokio::test]


### PR DESCRIPTION
Roadmap B1. Bolt `BEGIN`/`COMMIT`/`ROLLBACK` were accepted on the wire but fake: every `RUN` committed durably and `ROLLBACK` was a no-op, so a driver that relies on `tx.rollback()` for correctness silently got a durable write. This makes explicit transactions real.

## Change
- **storage** `WriterSession::discard_batch()` drops the uncommitted pending batch. The writer already stages every mutation and only makes it durable in `commit_batch` (the memtable is untouched until the post-CAS drain), so rollback is a clean drop with nothing to unwind.
- **query** `execute_write_staged` applies a write plan **without** committing, leaving it in the pending batch; `execute_write` keeps auto-commit by calling it then `commit_batch`.
- **bolt** the `Backend` trait gains `begin_tx`/`run_in_tx`/`commit_tx`/`rollback_tx` (default no-ops, so test backends are unaffected). The session FSM routes an in-tx `RUN` to `run_in_tx`, `COMMIT` to `commit_tx`, and `ROLLBACK` + `RESET`/`GOODBYE`-while-open to `rollback_tx`.
- **server** `ServerBackend` holds the global writer lock for the life of an explicit transaction (never a second `WriterSession`, which would fence the foreground writer), stages each statement, and commits the whole tx in **one** manifest CAS at `COMMIT` or discards it at `ROLLBACK`.

## Concurrency
The lock is held for the transaction (single-writer model). To bound the hazard of an idle client pinning it, a per-transaction idle timeout (`--bolt-tx-timeout`, default `30s`, `0s` disables) rolls back and fails a transaction that goes quiet, releasing the writer. Reads never take the writer lock, so they are unaffected.

## Known limitation (documented)
No read-your-own-writes within a multi-statement transaction: a `RUN` reading a prior in-tx `RUN`s write sees the pre-BEGIN snapshot. Deferred: an uncommitted-overlay read path, writer reopen on a commit-poison, and honouring `BEGIN` extra (access mode, bookmarks, tx metadata).

## Tests
`bolt_integration` gains `bolt_rollback_discards_write`, `bolt_commit_persists_write`, `bolt_multi_statement_commit_is_atomic`, and `bolt_idle_transaction_times_out_and_releases_writer` (a second connection writes after the timeout, proving the lock was released); storage gains a `discard_batch` unit test. Affected suites green (bolt 43, query 431+integration, storage 271+, server incl. 7 bolt_integration), `cargo fmt --check` clean, no new clippy warnings.