### PR TITLE
feat(storage): secondary equality index for non-unique properties (storage half)

### DIFF
--- a/crates/namidb-core/src/schema.rs
+++ b/crates/namidb-core/src/schema.rs
@@ -94,6 +94,16 @@ pub struct PropertyDef {
     /// Defaults to `false` so existing schemas / manifests load
     /// unchanged via the `#[serde(default)]` on the wire repr.
     pub unique: bool,
+    /// When `true`, the flush layer emits a secondary equality-index
+    /// sidecar for this property (value -> the node ids carrying it), so
+    /// `MATCH (a:Label {prop: literal})` can resolve through the index
+    /// instead of a full label scan + filter, even when the value is NOT
+    /// unique. Orthogonal to `unique`: a property may be `indexed` without
+    /// being unique. Like `unique`, it is a planner/storage hint.
+    ///
+    /// Defaults to `false`; the wire repr carries `#[serde(default)]` so
+    /// existing manifests load unchanged.
+    pub indexed: bool,
 }
 
 /// Wire-level representation used only by serde. The public type validates
@@ -106,6 +116,8 @@ struct PropertyDefRepr {
     nullable: bool,
     #[serde(default)]
     unique: bool,
+    #[serde(default)]
+    indexed: bool,
 }
 
 impl TryFrom<PropertyDefRepr> for PropertyDef {
@@ -113,6 +125,7 @@ impl TryFrom<PropertyDefRepr> for PropertyDef {
     fn try_from(r: PropertyDefRepr) -> Result<Self> {
         let mut p = PropertyDef::new(r.name, r.data_type, r.nullable)?;
         p.unique = r.unique;
+        p.indexed = r.indexed;
         Ok(p)
     }
 }
@@ -124,6 +137,7 @@ impl From<PropertyDef> for PropertyDefRepr {
             data_type: p.data_type,
             nullable: p.nullable,
             unique: p.unique,
+            indexed: p.indexed,
         }
     }
 }
@@ -155,6 +169,7 @@ impl PropertyDef {
             data_type,
             nullable,
             unique: false,
+            indexed: false,
         })
     }
 
@@ -166,6 +181,17 @@ impl PropertyDef {
     /// ```
     pub fn with_unique(mut self, unique: bool) -> Self {
         self.unique = unique;
+        self
+    }
+
+    /// Builder method: declare this property as indexed, so the flush layer
+    /// emits a secondary equality-index sidecar for it (non-unique).
+    ///
+    /// ```ignore
+    /// PropertyDef::new("city", DataType::Utf8, true)?.with_indexed(true)
+    /// ```
+    pub fn with_indexed(mut self, indexed: bool) -> Self {
+        self.indexed = indexed;
         self
     }
 

--- a/crates/namidb-query/src/cost/stats.rs
+++ b/crates/namidb-query/src/cost/stats.rs
@@ -578,6 +578,7 @@ mod tests {
             },
             bloom: None,
             unique_property_indices: Vec::new(),
+            equality_property_indices: Vec::new(),
         }
     }
 
@@ -612,6 +613,7 @@ mod tests {
             },
             bloom: None,
             unique_property_indices: Vec::new(),
+            equality_property_indices: Vec::new(),
         }
     }
 

--- a/crates/namidb-storage/src/compact.rs
+++ b/crates/namidb-storage/src/compact.rs
@@ -462,14 +462,28 @@ async fn put_node_sst_l1(
     // path after compaction. Without this, every compaction silently
     // demotes affected queries back to the legacy full label scan
     // (P4.19 only emitted sidecars on flush).
-    let (unique_property_indices, index_sidecars) = crate::flush::prepare_unique_property_sidecars(
-        paths,
-        level.as_u32(),
-        &id,
-        label,
-        label_def,
-        merged_rows,
-    )?;
+    let (unique_property_indices, mut index_sidecars) =
+        crate::flush::prepare_unique_property_sidecars(
+            paths,
+            level.as_u32(),
+            &id,
+            label,
+            label_def,
+            merged_rows,
+        )?;
+    // Re-emit equality-index posting-list sidecars too, rebuilt from the
+    // already-reconciled `merged_rows` (tombstones dropped, highest-lsn per
+    // id), so the L1 sidecar supersedes all the L0 partials.
+    let (equality_property_indices, equality_sidecars) =
+        crate::flush::prepare_equality_property_sidecars(
+            paths,
+            level.as_u32(),
+            &id,
+            label,
+            label_def,
+            merged_rows,
+        )?;
+    index_sidecars.extend(equality_sidecars);
     for (path, body) in &index_sidecars {
         put_create(store, path, body.clone()).await?;
     }
@@ -496,6 +510,7 @@ async fn put_node_sst_l1(
         },
         bloom: bloom_descriptor,
         unique_property_indices,
+        equality_property_indices,
     };
     Ok((descriptor, wrote_bloom))
 }
@@ -561,6 +576,7 @@ async fn put_edge_sst_l1(
         },
         bloom: bloom_descriptor,
         unique_property_indices: Vec::new(),
+        equality_property_indices: Vec::new(),
     };
     Ok((descriptor, wrote_bloom))
 }

--- a/crates/namidb-storage/src/flush.rs
+++ b/crates/namidb-storage/src/flush.rs
@@ -573,8 +573,15 @@ fn prepare_node_pending(
     // `unique` property emit a `value_string → NodeId` map serialised to
     // bincode. The reader probes these instead of full-scanning the SST
     // to resolve `MATCH (a:Label {prop: 'X'})`.
-    let (unique_property_indices, index_sidecars) =
+    let (unique_property_indices, mut index_sidecars) =
         prepare_unique_property_sidecars(paths, level.as_u32(), &id, label, label_def, rows)?;
+    // Per-property equality sidecars (RFC-pending): for each declared
+    // `indexed` (non-unique) property emit a `value_string → [NodeId, ...]`
+    // posting map. The reader unions these across SSTs and confirms each
+    // candidate against the node's current value.
+    let (equality_property_indices, equality_sidecars) =
+        prepare_equality_property_sidecars(paths, level.as_u32(), &id, label, label_def, rows)?;
+    index_sidecars.extend(equality_sidecars);
 
     let stats = finish.stats;
     let descriptor = SstDescriptor {
@@ -598,6 +605,7 @@ fn prepare_node_pending(
         },
         bloom: bloom_descriptor,
         unique_property_indices,
+        equality_property_indices,
     };
 
     Ok(PendingSst {
@@ -691,6 +699,74 @@ pub(crate) fn prepare_unique_property_sidecars(
     Ok((descriptors, bodies))
 }
 
+/// Parallel outputs of [`prepare_equality_property_sidecars`].
+type EqualityPropertySidecars = (
+    Vec<crate::manifest::EqualityIndexDescriptor>,
+    Vec<(Path, Bytes)>,
+);
+
+/// For every `PropertyDef::indexed == true`, harvest `value_string ->
+/// [NodeId, ...]` posting lists from `rows` and emit one sidecar per
+/// property. Unlike [`prepare_unique_property_sidecars`] a value maps to
+/// MANY ids, so the reader unions postings across SSTs and confirms each
+/// candidate against the node's current value (which discards tombstoned
+/// or value-changed ids). Same string-only, upsert-only harvesting as the
+/// unique path; non-string values are skipped (typed keys are a follow-up).
+///
+/// `pub(crate)` so `compact.rs` can re-emit the sidecars on L0->L1 merge.
+pub(crate) fn prepare_equality_property_sidecars(
+    paths: &NamespacePaths,
+    level: u32,
+    sst_id: &Uuid,
+    label: &str,
+    label_def: &LabelDef,
+    rows: &[NodeRow],
+) -> Result<EqualityPropertySidecars> {
+    let mut descriptors = Vec::new();
+    let mut bodies = Vec::new();
+    for prop in &label_def.properties {
+        if !prop.indexed {
+            continue;
+        }
+        let mut index: BTreeMap<String, Vec<[u8; 16]>> = BTreeMap::new();
+        for row in rows {
+            if let MemOp::Upsert(payload) = &row.op {
+                let rec = NodeWriteRecord::decode(payload)?;
+                if let Some(Value::Str(s)) = rec.properties.get(&prop.name) {
+                    let ids = index.entry(s.clone()).or_default();
+                    if !ids.contains(&row.id) {
+                        ids.push(row.id);
+                    }
+                }
+            }
+        }
+        if index.is_empty() {
+            continue;
+        }
+        let distinct_values = index.len() as u64;
+        let body_bytes = bincode::serialize(&index)
+            .map_err(|e| Error::invariant(format!("equality-index bincode: {e}")))?;
+        let body = Bytes::from(body_bytes);
+        let file_name = format!(
+            "{}-{}-{}.eqidx_{}.bin",
+            uuid_path_id(sst_id),
+            SstKind::Nodes.path_tag(),
+            label,
+            prop.name,
+        );
+        let object_path = paths.sst_object(level, &file_name);
+        let relative = relative_sst_path(level, &file_name);
+        descriptors.push(crate::manifest::EqualityIndexDescriptor {
+            property: prop.name.clone(),
+            path: relative,
+            size_bytes: body.len() as u64,
+            distinct_values,
+        });
+        bodies.push((object_path, body));
+    }
+    Ok((descriptors, bodies))
+}
+
 fn prepare_edge_pending(
     paths: &NamespacePaths,
     edge_type: &str,
@@ -746,6 +822,7 @@ fn prepare_edge_pending(
         },
         bloom: bloom_descriptor,
         unique_property_indices: Vec::new(),
+        equality_property_indices: Vec::new(),
     };
 
     PendingSst {

--- a/crates/namidb-storage/src/manifest.rs
+++ b/crates/namidb-storage/src/manifest.rs
@@ -207,6 +207,13 @@ pub struct SstDescriptor {
     // sidecar emission (`serde(default)` covers backward compatibility).
     #[serde(default)]
     pub unique_property_indices: Vec<UniquePropertyIndexDescriptor>,
+    // Secondary equality-index sidecars for `indexed` (non-unique)
+    // properties. Same idea as `unique_property_indices`, but each value
+    // maps to MANY node ids (a posting list), so the reader unions the
+    // posting lists across SSTs and confirms each candidate. Empty for edge
+    // SSTs and older manifests (`serde(default)`).
+    #[serde(default)]
+    pub equality_property_indices: Vec<EqualityIndexDescriptor>,
 }
 
 /// Side-car pointer for a single `(SST, unique property)` pair. The
@@ -227,6 +234,24 @@ pub struct UniquePropertyIndexDescriptor {
     /// non-tombstone row count modulo nulls; surfaced for diagnostics
     /// and the cache prewarm decision.
     pub entry_count: u64,
+}
+
+/// Side-car pointer for a single `(SST, indexed non-unique property)` pair.
+/// The sidecar body is a bincode-serialised `BTreeMap<String, Vec<NodeId>>`
+/// (a posting list per value, sorted by value string). Unlike the unique
+/// sidecar a value may map to several ids, so the reader unions the lists
+/// across all in-scope SSTs and confirms each candidate against the node's
+/// current value (which also discards tombstoned or value-changed ids).
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct EqualityIndexDescriptor {
+    /// Name of the indexed property this sidecar covers.
+    pub property: String,
+    /// Object-store path relative to the namespace prefix.
+    pub path: String,
+    /// On-disk size of the sidecar body.
+    pub size_bytes: u64,
+    /// Number of distinct values in the sidecar (posting-list keys).
+    pub distinct_values: u64,
 }
 
 /// JSON serde helper: `[u8; 16]` ↔ base64-standard string.
@@ -927,6 +952,7 @@ mod tests {
                 xxhash3_64: 0xDEADBEEFCAFEBABE,
             }),
             unique_property_indices: Vec::new(),
+            equality_property_indices: Vec::new(),
         }
     }
 
@@ -958,6 +984,7 @@ mod tests {
             },
             bloom: None, // small SST → no side-car
             unique_property_indices: Vec::new(),
+            equality_property_indices: Vec::new(),
         }
     }
 

--- a/crates/namidb-storage/src/read.rs
+++ b/crates/namidb-storage/src/read.rs
@@ -486,6 +486,131 @@ impl<'mt> Snapshot<'mt> {
         Ok(found)
     }
 
+    /// Resolve `MATCH (a:label {property: value})` for a NON-unique
+    /// `indexed` property through the equality-index sidecars, returning
+    /// every live node carrying that value.
+    ///
+    /// Each in-scope Nodes SST emits a `value → [NodeId, ...]` posting list
+    /// for an `indexed` property. When every in-scope SST carries the
+    /// sidecar we union the posting lists (plus any memtable upserts) into a
+    /// candidate set, then *confirm* each candidate with `lookup_node`: that
+    /// resolves cross-store last-write-wins and tombstones, and we keep only
+    /// nodes whose CURRENT value still equals `value`. Confirmation makes
+    /// the lookup correct even when a node was deleted or had its value
+    /// changed after an older sidecar captured it (both yield a candidate
+    /// that fails the re-check). Falls back to a full label scan when any
+    /// in-scope SST predates the sidecar. String-valued properties only.
+    pub async fn lookup_nodes_by_property(
+        &self,
+        label: &str,
+        property: &str,
+        value: &str,
+    ) -> Result<Vec<NodeView>> {
+        namidb_core::profile_scope!("Snapshot::lookup_nodes_by_property");
+
+        let sst_idxs: Vec<usize> = self
+            .manifest
+            .index
+            .scope_descriptors(SstKind::Nodes, label)
+            .to_vec();
+        let all_have_sidecar = !sst_idxs.is_empty()
+            && sst_idxs.iter().all(|i| {
+                self.manifest.manifest.ssts[*i]
+                    .equality_property_indices
+                    .iter()
+                    .any(|d| d.property == property)
+            });
+
+        // Cold path: a pre-sidecar SST is in scope (or the property was not
+        // `indexed` at flush time). Scan + filter, returning every match.
+        if !all_have_sidecar {
+            let all_nodes = self.scan_label(label).await?;
+            return Ok(all_nodes
+                .into_iter()
+                .filter(|v| {
+                    matches!(v.properties.get(property),
+                        Some(namidb_core::Value::Str(s)) if s == value)
+                })
+                .collect());
+        }
+
+        namidb_core::profile_scope!("Snapshot::lookup_nodes_by_property.sidecar");
+        // Gather candidate ids: memtable upserts carrying `value`, plus the
+        // union of every SST posting list under `value`.
+        let mut candidates: std::collections::BTreeSet<namidb_core::id::NodeId> =
+            std::collections::BTreeSet::new();
+        for (mk, e) in self.memtable.iter() {
+            if let MemKey::Node { label: mlabel, id } = mk {
+                if mlabel != label {
+                    continue;
+                }
+                if let MemOp::Upsert(payload) = &e.op {
+                    let rec = NodeWriteRecord::decode(payload)?;
+                    if let Some(namidb_core::Value::Str(s)) = rec.properties.get(property) {
+                        if s == value {
+                            candidates.insert(*id);
+                        }
+                    }
+                }
+            }
+        }
+        for idx in &sst_idxs {
+            let desc = &self.manifest.manifest.ssts[*idx];
+            let sidecar_desc = desc
+                .equality_property_indices
+                .iter()
+                .find(|d| d.property == property)
+                .expect("all_have_sidecar guard");
+            let absolute = format!(
+                "{}/{}",
+                self.paths.namespace_prefix().as_ref(),
+                sidecar_desc.path
+            );
+            let body = if let Some(b) = self.cache_get(&absolute) {
+                b
+            } else {
+                let object_path = object_store::path::Path::from(absolute.clone());
+                let bytes = self
+                    .store
+                    .get(&object_path)
+                    .await
+                    .map_err(Error::ObjectStore)?
+                    .bytes()
+                    .await
+                    .map_err(Error::ObjectStore)?;
+                if let Some(cache) = &self.cache {
+                    cache.insert(absolute.clone(), bytes.clone());
+                }
+                bytes
+            };
+            let map: std::collections::BTreeMap<String, Vec<[u8; 16]>> =
+                bincode::deserialize(&body)
+                    .map_err(|e| Error::invariant(format!("equality-index bincode decode: {e}")))?;
+            if let Some(ids) = map.get(value) {
+                for id_bytes in ids {
+                    candidates.insert(namidb_core::id::NodeId::from_uuid(Uuid::from_bytes(
+                        *id_bytes,
+                    )));
+                }
+            }
+        }
+
+        // Confirm each candidate against its current value. `lookup_node`
+        // returns None for a tombstoned id and the live view otherwise; we
+        // drop any whose value no longer matches (the value-changed case).
+        let mut out = Vec::with_capacity(candidates.len());
+        for id in candidates {
+            if let Some(view) = self.lookup_node(label, id).await? {
+                if matches!(view.properties.get(property),
+                    Some(namidb_core::Value::Str(s)) if s == value)
+                {
+                    out.push(view);
+                }
+            }
+        }
+        Ok(out)
+    }
+
     pub fn manifest(&self) -> &LoadedManifest {
         &self.manifest
     }
@@ -2759,6 +2884,299 @@ mod tests {
         assert_eq!(view.properties.get("age"), Some(&Value::I64(30)));
     }
 
+    // ── secondary equality index (non-unique `indexed` property) ──
+
+    fn indexed_city_label() -> LabelDef {
+        LabelDef {
+            name: "Person".into(),
+            properties: vec![
+                PropertyDef::new("name", DataType::Utf8, false).unwrap(),
+                PropertyDef::new("city", DataType::Utf8, true)
+                    .unwrap()
+                    .with_indexed(true),
+            ],
+        }
+    }
+
+    fn city_payload(name: &str, city: &str) -> Bytes {
+        let mut props: BTreeMap<String, Value> = BTreeMap::new();
+        props.insert("name".into(), Value::Str(name.into()));
+        props.insert("city".into(), Value::Str(city.into()));
+        NodeWriteRecord {
+            properties: props,
+            schema_version: 1,
+        }
+        .encode()
+        .unwrap()
+    }
+
+    async fn flush_batch(
+        ms: &ManifestStore,
+        fence: &WriterFence,
+        base: &LoadedManifest,
+        schema: &namidb_core::Schema,
+        rows: Vec<(NodeId, u64, MemOp)>,
+    ) -> LoadedManifest {
+        let mut mt = Memtable::new();
+        for (id, lsn, op) in rows {
+            mt.apply(
+                MemKey::Node {
+                    label: "Person".into(),
+                    id,
+                },
+                lsn,
+                op,
+            );
+        }
+        let frozen = mt.freeze();
+        flush(ms, fence, base, &frozen, schema.clone())
+            .await
+            .unwrap()
+            .committed
+    }
+
+    /// Resolve `city == value` against `committed` (empty live memtable) and
+    /// return the matched names, sorted.
+    async fn lookup_cities(
+        committed: &LoadedManifest,
+        store: Arc<dyn ObjectStore>,
+        paths: NamespacePaths,
+        city: &str,
+    ) -> Vec<String> {
+        let empty = Memtable::new();
+        let view = empty.snapshot_view();
+        let snap = Snapshot::new(committed.clone(), &view, store, paths);
+        let mut names: Vec<String> = snap
+            .lookup_nodes_by_property("Person", "city", city)
+            .await
+            .unwrap()
+            .into_iter()
+            .filter_map(|v| match v.properties.get("name") {
+                Some(Value::Str(s)) => Some(s.clone()),
+                _ => None,
+            })
+            .collect();
+        names.sort();
+        names
+    }
+
+    #[tokio::test]
+    async fn equality_index_returns_all_matching_nodes() {
+        let store = make_store();
+        let paths = make_paths("eqidx-all");
+        let ms = ManifestStore::new(store.clone(), paths.clone());
+        let base = ms.bootstrap(Uuid::now_v7()).await.unwrap();
+        let fence = WriterFence::new(base.manifest.epoch);
+        let schema = SchemaBuilder::new()
+            .label(indexed_city_label())
+            .unwrap()
+            .build();
+
+        let committed = flush_batch(
+            &ms,
+            &fence,
+            &base,
+            &schema,
+            vec![
+                (
+                    sorted_node_id(1),
+                    10,
+                    MemOp::Upsert(city_payload("Ann", "LA")),
+                ),
+                (
+                    sorted_node_id(2),
+                    11,
+                    MemOp::Upsert(city_payload("Bob", "LA")),
+                ),
+                (
+                    sorted_node_id(3),
+                    12,
+                    MemOp::Upsert(city_payload("Cy", "NYC")),
+                ),
+            ],
+        )
+        .await;
+
+        assert_eq!(
+            lookup_cities(&committed, store.clone(), paths.clone(), "LA").await,
+            vec!["Ann".to_string(), "Bob".to_string()]
+        );
+        assert_eq!(
+            lookup_cities(&committed, store.clone(), paths.clone(), "NYC").await,
+            vec!["Cy".to_string()]
+        );
+        assert!(lookup_cities(&committed, store, paths, "SF")
+            .await
+            .is_empty());
+    }
+
+    #[tokio::test]
+    async fn equality_index_drops_tombstoned_candidate() {
+        let store = make_store();
+        let paths = make_paths("eqidx-tomb");
+        let ms = ManifestStore::new(store.clone(), paths.clone());
+        let base = ms.bootstrap(Uuid::now_v7()).await.unwrap();
+        let fence = WriterFence::new(base.manifest.epoch);
+        let schema = SchemaBuilder::new()
+            .label(indexed_city_label())
+            .unwrap()
+            .build();
+
+        // Two LA nodes flushed into one SST (which carries the sidecar).
+        let committed = flush_batch(
+            &ms,
+            &fence,
+            &base,
+            &schema,
+            vec![
+                (
+                    sorted_node_id(1),
+                    10,
+                    MemOp::Upsert(city_payload("Ann", "LA")),
+                ),
+                (
+                    sorted_node_id(2),
+                    11,
+                    MemOp::Upsert(city_payload("Bob", "LA")),
+                ),
+            ],
+        )
+        .await;
+
+        // A live-memtable tombstone on Ann: the sidecar still lists her id,
+        // but the confirmation via lookup_node sees the tombstone and drops
+        // her.
+        let mut mt = Memtable::new();
+        mt.apply(
+            MemKey::Node {
+                label: "Person".into(),
+                id: sorted_node_id(1),
+            },
+            20,
+            MemOp::Tombstone,
+        );
+        let view = mt.snapshot_view();
+        let snap = Snapshot::new(committed, &view, store, paths);
+        let rows = snap
+            .lookup_nodes_by_property("Person", "city", "LA")
+            .await
+            .unwrap();
+        assert_eq!(rows.len(), 1, "Ann was tombstoned");
+        assert_eq!(
+            rows[0].properties.get("name"),
+            Some(&Value::Str("Bob".into()))
+        );
+    }
+
+    #[tokio::test]
+    async fn equality_index_drops_value_changed_candidate() {
+        // The §4 correctness guard: a node whose indexed value changed must
+        // not be returned under its stale value.
+        let store = make_store();
+        let paths = make_paths("eqidx-changed");
+        let ms = ManifestStore::new(store.clone(), paths.clone());
+        let base = ms.bootstrap(Uuid::now_v7()).await.unwrap();
+        let fence = WriterFence::new(base.manifest.epoch);
+        let schema = SchemaBuilder::new()
+            .label(indexed_city_label())
+            .unwrap()
+            .build();
+
+        // Flush X under "LA" (the sidecar captures X at "LA").
+        let committed = flush_batch(
+            &ms,
+            &fence,
+            &base,
+            &schema,
+            vec![(
+                sorted_node_id(1),
+                10,
+                MemOp::Upsert(city_payload("X", "LA")),
+            )],
+        )
+        .await;
+
+        // X moves to "NYC" in the live memtable (newer lsn, not flushed).
+        let mut mt = Memtable::new();
+        mt.apply(
+            MemKey::Node {
+                label: "Person".into(),
+                id: sorted_node_id(1),
+            },
+            20,
+            MemOp::Upsert(city_payload("X", "NYC")),
+        );
+        let view = mt.snapshot_view();
+        let snap = Snapshot::new(committed, &view, store, paths);
+
+        // A query for the stale value must NOT return X.
+        let la = snap
+            .lookup_nodes_by_property("Person", "city", "LA")
+            .await
+            .unwrap();
+        assert!(la.is_empty(), "stale 'LA' must not return the moved node");
+        // The current value does.
+        let nyc = snap
+            .lookup_nodes_by_property("Person", "city", "NYC")
+            .await
+            .unwrap();
+        assert_eq!(nyc.len(), 1);
+        assert_eq!(nyc[0].properties.get("name"), Some(&Value::Str("X".into())));
+    }
+
+    #[tokio::test]
+    async fn equality_index_survives_compaction() {
+        let store = make_store();
+        let paths = make_paths("eqidx-compact");
+        let ms = ManifestStore::new(store.clone(), paths.clone());
+        let base = ms.bootstrap(Uuid::now_v7()).await.unwrap();
+        let fence = WriterFence::new(base.manifest.epoch);
+        let schema = SchemaBuilder::new()
+            .label(indexed_city_label())
+            .unwrap()
+            .build();
+
+        // Two separate flushes → two L0 Person SSTs, each with a partial
+        // sidecar.
+        let b1 = flush_batch(
+            &ms,
+            &fence,
+            &base,
+            &schema,
+            vec![(
+                sorted_node_id(1),
+                10,
+                MemOp::Upsert(city_payload("Ann", "LA")),
+            )],
+        )
+        .await;
+        let b2 = flush_batch(
+            &ms,
+            &fence,
+            &b1,
+            &schema,
+            vec![(
+                sorted_node_id(2),
+                11,
+                MemOp::Upsert(city_payload("Bob", "LA")),
+            )],
+        )
+        .await;
+
+        // Compact L0 → L1; the rebuilt L1 sidecar must serve the union.
+        let outcome = crate::compact::compact_l0_to_l1(&ms, &fence, &b2, &schema)
+            .await
+            .unwrap();
+        assert!(
+            outcome.source_ssts_removed >= 2,
+            "expected the two L0 Person SSTs to compact"
+        );
+        assert_eq!(
+            lookup_cities(&outcome.committed, store, paths, "LA").await,
+            vec!["Ann".to_string(), "Bob".to_string()]
+        );
+    }
+
     #[tokio::test]
     async fn lookup_node_falls_back_to_memtable_when_not_flushed() {
         let store = make_store();
@@ -3802,6 +4220,7 @@ mod tests {
             kind_specific: KindSpecificStats::Nodes { tombstone_count: 0 },
             bloom: Some(bloom_desc),
             unique_property_indices: Vec::new(),
+            equality_property_indices: Vec::new(),
         };
 
         let empty = Memtable::new();
@@ -3825,6 +4244,7 @@ mod tests {
         let no_bloom = SstDescriptor {
             bloom: None,
             unique_property_indices: Vec::new(),
+            equality_property_indices: Vec::new(),
             ..descriptor.clone()
         };
         assert!(snap
@@ -4152,6 +4572,7 @@ mod tests {
             kind_specific: KindSpecificStats::Nodes { tombstone_count: 0 },
             bloom: None::<BloomDescriptor>,
             unique_property_indices: Vec::new(),
+            equality_property_indices: Vec::new(),
         });
         let mt = Memtable::new();
         let view = mt.snapshot_view();


### PR DESCRIPTION
Roadmap C2, phase 1 (storage half). A selective `MATCH (a:Label {prop: literal})` on a **non-unique** property still degrades to a full label scan + filter — today only node id and *unique*-string lookups are indexed. This adds the storage machinery for a real secondary equality index, generalizing the existing unique-string sidecar from `value -> one id` to `value -> many ids`.

## Change
- **schema** an `indexed` flag on `PropertyDef`, orthogonal to `unique` (a prop can be indexed without being unique), serde-default `false` so existing manifests load unchanged.
- **flush + compact** emit a per-SST `.eqidx_<prop>.bin` posting-list sidecar (bincode `BTreeMap<String, Vec<NodeId>>`) for every `indexed` property, rebuilt on L0→L1 compaction so the index is not silently demoted to a full scan.
- **manifest** `EqualityIndexDescriptor` + a back-compatible `equality_property_indices` field on `SstDescriptor`.
- **read** `Snapshot::lookup_nodes_by_property` unions the posting lists across every in-scope SST (plus matching memtable upserts) into a candidate set, then **confirms** each candidate against its current value via `lookup_node`.

## Correctness
The confirm-via-`lookup_node` step is what keeps the union correct: a tombstoned candidate yields `None` and is dropped; a node whose indexed value **changed** after an older sidecar captured it fails the re-check, so it is never returned under its stale value. Falls back to a full scan when any in-scope SST predates the sidecar (acceptable for phase 1). String-valued properties only (typed keys are a follow-up, mirroring the unique path).

## Tests
The optimizer does not yet emit this path, so the reader is exercised directly by storage unit tests: multiple matches, tombstoned-candidate drop, **value-changed drop** (the correctness guard), and survival across compaction (rebuilt L1 sidecar serves the union). Storage suite green (275), `cargo fmt --check` clean, no new clippy warnings, dependent crates build.

## Follow-up (PR2)
Wire the optimizer (`optimize/unique_lookup.rs`) to emit a 1→N `NodeByPropertyEq` op when a property is `indexed` and the cost favours the index over a scan, the executor arm (flat + factor), and an e2e query test. Cut from phase 1: range/vector/composite indexes, typed non-string keys, the warm in-memory non-unique cache.