### PR TITLE
feat: full G.V()/gdotv support — Neo4j connection type, write counters, elementId point lookup

### DIFF
--- a/crates/namidb-bolt/src/session.rs
+++ b/crates/namidb-bolt/src/session.rs
@@ -155,6 +155,9 @@ pub struct Session<S: AsyncReadExt + AsyncWriteExt + Unpin> {
     /// closing `SUCCESS` after PULL/DISCARD. `None` while no stream
     /// is active.
     pending_statement_type: Option<StatementType>,
+    /// Write counters of the in-flight stream, emitted as `stats` in the
+    /// closing `SUCCESS` after PULL/DISCARD. Empty for reads.
+    pending_counters: BTreeMap<String, i64>,
 }
 
 impl<S: AsyncReadExt + AsyncWriteExt + Unpin> Session<S> {
@@ -167,6 +170,7 @@ impl<S: AsyncReadExt + AsyncWriteExt + Unpin> Session<S> {
             state: State::Negotiation,
             version: None,
             pending_statement_type: None,
+            pending_counters: BTreeMap::new(),
         }
     }
 
@@ -379,6 +383,16 @@ impl<S: AsyncReadExt + AsyncWriteExt + Unpin> Session<S> {
                     .take()
                     .unwrap_or(StatementType::Read);
                 meta.insert("type".into(), Value::String(stype.as_str().into()));
+                // Emit write counters (Neo4j `stats`) so a client shows
+                // "N created / deleted" after a write. Empty for reads.
+                let counters = std::mem::take(&mut self.pending_counters);
+                if !counters.is_empty() {
+                    let stats: BTreeMap<String, Value> = counters
+                        .into_iter()
+                        .map(|(k, v)| (k, Value::Int(v)))
+                        .collect();
+                    meta.insert("stats".into(), Value::Map(stats));
+                }
                 if self.state == State::TxStreaming {
                     self.state = State::TxReady;
                 } else {
@@ -441,6 +455,7 @@ impl<S: AsyncReadExt + AsyncWriteExt + Unpin> Session<S> {
             State::Streaming
         };
         self.pending_statement_type = Some(outcome.statement_type);
+        self.pending_counters = outcome.counters;
         // Buffered model: rows already emitted. PULL/DISCARD will
         // observe the streaming state and answer with a closing
         // SUCCESS in handle_in_streaming.

--- a/crates/namidb-query/src/cost/cardinality.rs
+++ b/crates/namidb-query/src/cost/cardinality.rs
@@ -124,8 +124,26 @@ fn estimate_inner(plan: &LogicalPlan, catalog: &StatsCatalog) -> Cardinality {
             label,
             alias,
             ..
+        } => {
+            let child = estimate_inner(input, catalog);
+            // Point lookup: each input row triggers at most one hit.
+            let rows = child.rows.min(child.rows.max(1.0));
+            let mut bindings = child.bindings.clone();
+            bindings.insert(
+                alias.clone(),
+                BindingMeta {
+                    label: label.clone(),
+                    ..Default::default()
+                },
+            );
+            Cardinality {
+                rows,
+                bindings,
+                children: vec![child],
+                operator: plan.operator_name(),
+            }
         }
-        | LogicalPlan::NodeByPropertyValue {
+        LogicalPlan::NodeByPropertyValue {
             input,
             label,
             alias,

--- a/crates/namidb-query/src/exec/expr.rs
+++ b/crates/namidb-query/src/exec/expr.rs
@@ -578,6 +578,18 @@ fn call_scalar_function(
             RuntimeValue::Rel(r) => RuntimeValue::String(format!("{}:{}", r.src, r.dst)),
             _ => RuntimeValue::Null,
         }),
+        // `elementId()` returns the exact id string the Bolt layer emits
+        // as `element_id`, so a GUI's `WHERE elementId(x) = $id` (G.V()'s
+        // node/edge fetch and expand) round-trips. Nodes: the UUID;
+        // relationships: the synthetic `<type>-<src>-><dst>` form. These
+        // mirror `uuid_to_bolt_ids` / `synthetic_edge_id` in namidb-bolt.
+        "elementid" => single_arg(name, args, span).map(|v| match v {
+            RuntimeValue::Node(n) => RuntimeValue::String(n.id.to_string()),
+            RuntimeValue::Rel(r) => {
+                RuntimeValue::String(format!("{}-{}->{}", r.edge_type, r.src.0, r.dst.0))
+            }
+            _ => RuntimeValue::Null,
+        }),
         "labels" => single_arg(name, args, span).map(|v| match v {
             RuntimeValue::Node(n) => {
                 RuntimeValue::List(vec![RuntimeValue::String(n.label.clone())])

--- a/crates/namidb-query/src/exec/walker.rs
+++ b/crates/namidb-query/src/exec/walker.rs
@@ -278,7 +278,11 @@ pub(crate) fn execute_inner_with_routing<'a>(
                 for row in input_rows {
                     let id_value = evaluate(id, &row, params)?;
                     let node_id = node_id_from_value(&id_value, id.span)?;
-                    if let Some(view) = snapshot.lookup_node(label, node_id).await? {
+                    let found = match label {
+                        Some(l) => snapshot.lookup_node(l, node_id).await?,
+                        None => scan_node_for_id(snapshot, node_id).await?,
+                    };
+                    if let Some(view) = found {
                         let mut new_row = row;
                         new_row.set(
                             alias.clone(),
@@ -1286,7 +1290,7 @@ fn should_skip_target_materialize(
 /// Cypher's `Expand` doesn't carry the target label in v1 (only the
 /// edge type), so we trial-search until storage provides a
 /// label-index for ids.
-async fn scan_node_for_id(
+pub(crate) async fn scan_node_for_id(
     snapshot: &Snapshot<'_>,
     id: NodeId,
 ) -> Result<Option<namidb_storage::NodeView>, ExecError> {
@@ -1784,7 +1788,11 @@ pub(crate) fn execute_factor_inner_with_routing<'a>(
                     let row = arena_view.materialize(leaf, None);
                     let id_value = evaluate(id, &row, params)?;
                     let node_id = node_id_from_value(&id_value, id.span)?;
-                    if let Some(view) = snapshot.lookup_node(label, node_id).await? {
+                    let found = match label {
+                        Some(l) => snapshot.lookup_node(l, node_id).await?,
+                        None => scan_node_for_id(snapshot, node_id).await?,
+                    };
+                    if let Some(view) = found {
                         let slot = Slot {
                             name: alias_arc.clone(),
                             value: RuntimeValue::Node(Box::new(NodeValue::from(view))),

--- a/crates/namidb-query/src/exec/writer.rs
+++ b/crates/namidb-query/src/exec/writer.rs
@@ -281,11 +281,14 @@ fn execute_write_inner<'a>(
                 for row in input_rows {
                     let id_value = evaluate(id, &row, params)?;
                     let node_id = crate::exec::walker::node_id_from_value(&id_value, id.span)?;
-                    if let Some(view) = snap
-                        .lookup_node(label, node_id)
-                        .await
-                        .map_err(ExecError::Storage)?
-                    {
+                    let found = match label {
+                        Some(l) => snap
+                            .lookup_node(l, node_id)
+                            .await
+                            .map_err(ExecError::Storage)?,
+                        None => crate::exec::walker::scan_node_for_id(&snap, node_id).await?,
+                    };
+                    if let Some(view) = found {
                         let mut new_row = row;
                         new_row.set(
                             alias.clone(),

--- a/crates/namidb-query/src/optimize/decorrelation.rs
+++ b/crates/namidb-query/src/optimize/decorrelation.rs
@@ -143,8 +143,11 @@ fn collect_outer_labels(plan: &LogicalPlan, out: &mut BTreeMap<String, Option<St
             label,
             input,
             ..
+        } => {
+            collect_outer_labels(input, out);
+            out.insert(alias.clone(), label.clone());
         }
-        | LogicalPlan::NodeByPropertyValue {
+        LogicalPlan::NodeByPropertyValue {
             alias,
             label,
             input,

--- a/crates/namidb-query/src/optimize/pushdown.rs
+++ b/crates/namidb-query/src/optimize/pushdown.rs
@@ -1145,7 +1145,7 @@ mod tests {
         let plan = LogicalPlan::Filter {
             input: Box::new(LogicalPlan::NodeById {
                 input: Box::new(LogicalPlan::Empty),
-                label: "Person".into(),
+                label: Some("Person".into()),
                 alias: "a".into(),
                 id: int(1),
             }),
@@ -1165,7 +1165,7 @@ mod tests {
                 input: Box::new(LogicalPlan::Argument {
                     bindings: vec!["b".into()],
                 }),
-                label: "Person".into(),
+                label: Some("Person".into()),
                 alias: "a".into(),
                 id: int(1),
             }),

--- a/crates/namidb-query/src/optimize/unique_lookup.rs
+++ b/crates/namidb-query/src/optimize/unique_lookup.rs
@@ -1,6 +1,11 @@
-//! Rewrite `Filter(predicate = a.<prop> == <literal>)` over
-//! `NodeScan(label = L)` into `NodeByPropertyValue` whenever `<prop>`
-//! is declared `unique` in the schema (see `PropertyDef::unique`).
+//! Point-lookup rewrites over `Filter(... , NodeScan(...))`:
+//!
+//! - `a.<prop> == <literal>` → `NodeByPropertyValue` when `<prop>` is
+//!   declared `unique` in the schema (see `PropertyDef::unique`).
+//! - `elementId(a) == <expr>` / `id(a) == <expr>` → `NodeById` (a UUID
+//!   point lookup), with or without a label on the scan. This is what
+//!   turns a GUI's `MATCH (n) WHERE elementId(n) = $id` node fetch and
+//!   expand from a full scan into a direct lookup.
 //!
 //! Triggers a point lookup in place of a full label scan + filter for
 //! the LDBC SNB anchor pattern `MATCH (p:Person {id: 'literal'})`,
@@ -58,6 +63,29 @@ fn rewrite(plan: LogicalPlan, catalog: &StatsCatalog) -> LogicalPlan {
                                 value: value_expr,
                             };
                         }
+                    }
+                }
+            }
+            // `WHERE elementId(n) = <v>` / `WHERE id(n) = <v>` over a bare
+            // scan becomes a NodeById point lookup by UUID — scoped to the
+            // scan's label when it has one, or fanned across observed labels
+            // when it doesn't (the unlabelled `MATCH (n) WHERE elementId(n)
+            // = $id` shape a GUI fetch/expand uses). Avoids a full scan.
+            if let LogicalPlan::NodeScan {
+                label,
+                alias,
+                predicates,
+                projection,
+            } = input.as_ref()
+            {
+                if predicates.is_empty() && projection.is_none() {
+                    if let Some(value_expr) = extract_eq_on_node_id(&predicate, alias) {
+                        return LogicalPlan::NodeById {
+                            input: Box::new(LogicalPlan::Empty),
+                            label: label.clone(),
+                            alias: alias.clone(),
+                            id: value_expr,
+                        };
                     }
                 }
             }
@@ -286,4 +314,41 @@ fn property_on_alias(expr: &Expression, alias: &str) -> Option<String> {
     } else {
         None
     }
+}
+
+/// Match `elementId(<alias>) == <value>` or `id(<alias>) == <value>`
+/// (either argument order) and return the value expression. Both
+/// functions yield a node's UUID string, which `node_id_from_value`
+/// parses back into a `NodeId` at execution time.
+fn extract_eq_on_node_id(expr: &Expression, scan_alias: &str) -> Option<Expression> {
+    use crate::parser::ast::BinaryOp;
+    let ExpressionKind::Binary { op, left, right } = &expr.kind else {
+        return None;
+    };
+    if !matches!(op, BinaryOp::Eq) {
+        return None;
+    }
+    if is_node_id_call(left, scan_alias) {
+        return Some((**right).clone());
+    }
+    if is_node_id_call(right, scan_alias) {
+        return Some((**left).clone());
+    }
+    None
+}
+
+/// `elementId(<alias>)` or `id(<alias>)` — a single-argument call of
+/// either function on the scan's own variable.
+fn is_node_id_call(expr: &Expression, alias: &str) -> bool {
+    let ExpressionKind::FunctionCall { name, args, .. } = &expr.kind else {
+        return false;
+    };
+    if args.len() != 1 {
+        return false;
+    }
+    let fname = name.joined().to_ascii_lowercase();
+    if fname != "elementid" && fname != "id" {
+        return false;
+    }
+    matches!(&args[0].kind, ExpressionKind::Variable(id) if id.name == alias)
 }

--- a/crates/namidb-query/src/plan/explain.rs
+++ b/crates/namidb-query/src/plan/explain.rs
@@ -332,12 +332,13 @@ fn plan_has_stats(plan: &LogicalPlan, catalog: &StatsCatalog) -> bool {
             .and_then(|l| catalog.label(l))
             .map(|l| l.node_count > 0)
             .unwrap_or(false),
-        LogicalPlan::NodeById { label, .. } | LogicalPlan::NodeByPropertyValue { label, .. } => {
-            catalog
-                .label(label)
-                .map(|l| l.node_count > 0)
-                .unwrap_or(false)
-        }
+        LogicalPlan::NodeById { label, .. } => label.as_deref().map_or(true, |l| {
+            catalog.label(l).map(|x| x.node_count > 0).unwrap_or(false)
+        }),
+        LogicalPlan::NodeByPropertyValue { label, .. } => catalog
+            .label(label)
+            .map(|l| l.node_count > 0)
+            .unwrap_or(false),
         LogicalPlan::Expand {
             edge_type: Some(ets),
             ..
@@ -375,7 +376,12 @@ fn write_header(plan: &LogicalPlan, out: &mut String) {
         LogicalPlan::NodeById {
             label, alias, id, ..
         } => {
-            let _ = write!(out, "NodeById label={} alias={} id={}", label, alias, id);
+            let label_str = label.as_deref().unwrap_or("*");
+            let _ = write!(
+                out,
+                "NodeById label={} alias={} id={}",
+                label_str, alias, id
+            );
         }
         LogicalPlan::NodeByPropertyValue {
             label,

--- a/crates/namidb-query/src/plan/logical.rs
+++ b/crates/namidb-query/src/plan/logical.rs
@@ -47,14 +47,16 @@ pub enum LogicalPlan {
         projection: Option<Vec<String>>,
     },
 
-    /// Point-lookup by id. Lowering emits this when the AST contains an
-    /// inline filter `{id: <expr>}` on a node pattern. The id expression
-    /// is evaluated against each row produced by `input` (typically
-    /// `Empty` for queries that start with the lookup, or a populated
-    /// plan when the lookup follows UNWIND / WITH).
+    /// Point-lookup by id. Lowering emits this for an inline `{_id: <expr>}`
+    /// filter on a node pattern, and `optimize::unique_lookup` emits it for
+    /// `WHERE elementId(n) = <expr>` / `WHERE id(n) = <expr>`. The id
+    /// expression is evaluated against each row from `input` (typically
+    /// `Empty`). `label = Some(L)` scopes the lookup to one column family;
+    /// `label = None` (the unlabelled `MATCH (n) WHERE elementId(n) = ...`
+    /// shape a GUI fetch uses) fans out across every observed label.
     NodeById {
         input: Box<LogicalPlan>,
-        label: String,
+        label: Option<String>,
         alias: String,
         id: Expression,
     },

--- a/crates/namidb-query/src/plan/lower.rs
+++ b/crates/namidb-query/src/plan/lower.rs
@@ -840,7 +840,7 @@ fn lower_node_pattern_head(
             let inner_input = input.unwrap_or(LogicalPlan::Empty);
             let mut plan = LogicalPlan::NodeById {
                 input: Box::new(inner_input),
-                label: label.to_string(),
+                label: Some(label.to_string()),
                 alias: alias.clone(),
                 id: id_expr,
             };
@@ -2146,7 +2146,7 @@ mod tests {
         match p {
             LogicalPlan::Project { input, .. } => match *input {
                 LogicalPlan::NodeById { label, alias, .. } => {
-                    assert_eq!(label, "Person");
+                    assert_eq!(label.as_deref(), Some("Person"));
                     assert_eq!(alias, "a");
                 }
                 other => panic!("expected NodeById, got {:?}", other),

--- a/crates/namidb-query/tests/exec_match_expand.rs
+++ b/crates/namidb-query/tests/exec_match_expand.rs
@@ -930,3 +930,53 @@ async fn global_edge_type_count_pushdown_matches_nodescan_path() {
         "EdgeTypeCount must match the NodeScan+Expand count exactly"
     );
 }
+
+fn has_node_by_id(plan: &namidb_query::LogicalPlan) -> bool {
+    matches!(plan, namidb_query::LogicalPlan::NodeById { .. })
+        || plan.children().iter().any(|c| has_node_by_id(c))
+}
+
+#[tokio::test]
+async fn element_id_filter_lowers_to_point_lookup() {
+    use namidb_query::{parse_lower_optimize, StatsCatalog};
+
+    let mut writer = WriterSession::open(store(), paths("exec-element-id"))
+        .await
+        .unwrap();
+    build_friend_graph(&mut writer).await;
+    let snapshot = writer.snapshot();
+
+    // Grab a real node and its element id (the UUID).
+    let any = execute(
+        &lower(&parse("MATCH (p:Person) RETURN p LIMIT 1").unwrap()).unwrap(),
+        &snapshot,
+        &Params::new(),
+    )
+    .await
+    .unwrap();
+    let (eid, name) = match any[0].get("p") {
+        Some(RuntimeValue::Node(n)) => (n.id.to_string(), n.properties.get("name").cloned()),
+        other => panic!("expected a node, got {other:?}"),
+    };
+
+    // Unlabelled `WHERE elementId(v) = '<uuid>'` (the GUI node-fetch shape)
+    // must optimise to a NodeById point lookup rather than a full scan, and
+    // return exactly that node.
+    let query = format!("MATCH (v) WHERE elementId(v) = '{eid}' RETURN v");
+    let optimized = parse_lower_optimize(&query, &StatsCatalog::empty()).unwrap();
+    assert!(
+        has_node_by_id(&optimized),
+        "elementId equality must lower to a NodeById point lookup, got {optimized:?}"
+    );
+    let rows = execute(&optimized, &snapshot, &Params::new())
+        .await
+        .unwrap();
+    assert_eq!(rows.len(), 1, "point lookup must return exactly the node");
+    match rows[0].get("v") {
+        Some(RuntimeValue::Node(n)) => {
+            assert_eq!(n.id.to_string(), eid);
+            assert_eq!(n.properties.get("name").cloned(), name);
+        }
+        other => panic!("expected the looked-up node, got {other:?}"),
+    }
+}

--- a/crates/namidb-server/src/introspect.rs
+++ b/crates/namidb-server/src/introspect.rs
@@ -44,6 +44,9 @@ use tracing::warn;
 /// this only caps how many rows we inspect for property keys.
 const SAMPLE_NODES: usize = 256;
 
+/// How many edges per type we inspect for relationship property names.
+const SAMPLE_EDGES: usize = 256;
+
 /// Intercept a Memgraph-style introspection query. Returns `None` for
 /// anything that isn't one of the known procedures, in which case the
 /// caller proceeds to the normal parse/plan/execute path.
@@ -53,15 +56,35 @@ pub async fn try_introspect(
 ) -> Option<Result<RunOutcome, BackendError>> {
     let norm = normalize(cypher);
     let outcome = if norm.starts_with("call meta_util.schema(") {
+        // Memgraph connection type.
         meta_util_schema(snap).await
     } else if norm.starts_with("call schema.node_type_properties(") {
         node_type_properties(snap).await
     } else if norm.starts_with("call schema.rel_type_properties(") {
-        rel_type_properties(snap)
+        rel_type_properties(snap).await
     } else if norm.starts_with("call mg.procedures(") {
         mg_procedures()
     } else if norm.starts_with("call mg.functions(") {
         mg_functions()
+    } else if norm.starts_with("call db.labels(") {
+        // Neo4j connection type (db.*, apoc.meta.*, SHOW, dbms.*).
+        db_labels(snap)
+    } else if norm.starts_with("call db.relationshiptypes(") {
+        db_relationship_types(snap)
+    } else if norm.starts_with("call db.propertykeys(") {
+        db_property_keys(snap).await
+    } else if norm.starts_with("call apoc.meta.nodetypeproperties(") {
+        apoc_node_type_properties(snap).await
+    } else if norm.starts_with("call apoc.meta.reltypeproperties(") {
+        apoc_rel_type_properties(snap).await
+    } else if norm.starts_with("call dbms.components(") {
+        dbms_components()
+    } else if norm.starts_with("show procedures") || norm.starts_with("call dbms.procedures(") {
+        show_procedures()
+    } else if norm.starts_with("show functions") || norm.starts_with("call dbms.functions(") {
+        show_functions()
+    } else if norm.starts_with("show databases") {
+        show_databases()
     } else {
         return None;
     };
@@ -171,11 +194,11 @@ async fn node_type_properties(snap: &Snapshot<'_>) -> RunOutcome {
     read_outcome(fields, rows)
 }
 
-/// `CALL schema.rel_type_properties()` — one row per edge type. Edge
-/// property sampling is a follow-up, so for now every type is reported
-/// with empty property columns; the type itself still shows up in the
-/// client's relationship list.
-fn rel_type_properties(snap: &Snapshot<'_>) -> RunOutcome {
+/// `CALL schema.rel_type_properties()` — one row per (edge type,
+/// property), with property names and types sampled from live edges.
+/// Edge types with no sampled properties still get one row so the type
+/// shows up in the client's relationship list.
+async fn rel_type_properties(snap: &Snapshot<'_>) -> RunOutcome {
     let fields = vec![
         "relType".to_string(),
         "mandatory".to_string(),
@@ -185,14 +208,273 @@ fn rel_type_properties(snap: &Snapshot<'_>) -> RunOutcome {
     let mut rows = Vec::new();
     for edge_type in snap.observed_edge_types() {
         let rel_type = format!(":`{}`", edge_type);
-        let row = Row::new()
-            .with("relType", RuntimeValue::String(rel_type))
-            .with("mandatory", RuntimeValue::Bool(false))
-            .with("propertyName", RuntimeValue::String(String::new()))
-            .with("propertyTypes", RuntimeValue::String(String::new()));
-        rows.push(row);
+        let props = sample_edge_type(snap, &edge_type).await;
+        if props.is_empty() {
+            rows.push(rel_prop_row(&rel_type, "", ""));
+        } else {
+            for (name, ty) in props {
+                rows.push(rel_prop_row(&rel_type, &name, &ty));
+            }
+        }
     }
     read_outcome(fields, rows)
+}
+
+fn rel_prop_row(rel_type: &str, prop_name: &str, prop_type: &str) -> Row {
+    Row::new()
+        .with("relType", RuntimeValue::String(rel_type.to_string()))
+        .with("mandatory", RuntimeValue::Bool(false))
+        .with("propertyName", RuntimeValue::String(prop_name.to_string()))
+        .with("propertyTypes", RuntimeValue::String(prop_type.to_string()))
+}
+
+// ── Neo4j connection type ────────────────────────────────────────────
+
+/// `CALL db.labels()` — one `label` column per node label.
+fn db_labels(snap: &Snapshot<'_>) -> RunOutcome {
+    let rows = snap
+        .observed_labels()
+        .into_iter()
+        .map(|l| Row::new().with("label", RuntimeValue::String(l)))
+        .collect();
+    read_outcome(vec!["label".to_string()], rows)
+}
+
+/// `CALL db.relationshipTypes()` — one `relationshipType` column per type.
+fn db_relationship_types(snap: &Snapshot<'_>) -> RunOutcome {
+    let rows = snap
+        .observed_edge_types()
+        .into_iter()
+        .map(|t| Row::new().with("relationshipType", RuntimeValue::String(t)))
+        .collect();
+    read_outcome(vec!["relationshipType".to_string()], rows)
+}
+
+/// `CALL db.propertyKeys()` — distinct property keys across all labels.
+async fn db_property_keys(snap: &Snapshot<'_>) -> RunOutcome {
+    let mut keys: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+    for label in snap.observed_labels() {
+        let (_count, props) = sample_label(snap, &label).await;
+        keys.extend(props.into_keys());
+    }
+    let rows = keys
+        .into_iter()
+        .map(|k| Row::new().with("propertyKey", RuntimeValue::String(k)))
+        .collect();
+    read_outcome(vec!["propertyKey".to_string()], rows)
+}
+
+/// `CALL dbms.components()` — product name, version, edition. Drivers
+/// read the version from the Bolt `HELLO` already; this is for display.
+fn dbms_components() -> RunOutcome {
+    let row = Row::new()
+        .with("name", RuntimeValue::String("Neo4j Kernel".to_string()))
+        .with(
+            "versions",
+            RuntimeValue::List(vec![RuntimeValue::String("5.13.0".to_string())]),
+        )
+        .with("edition", RuntimeValue::String("community".to_string()));
+    read_outcome(
+        vec![
+            "name".to_string(),
+            "versions".to_string(),
+            "edition".to_string(),
+        ],
+        vec![row],
+    )
+}
+
+/// `SHOW PROCEDURES` / `CALL dbms.procedures()` — the procedures this
+/// shim answers, in Neo4j's column shape.
+fn show_procedures() -> RunOutcome {
+    let procs = [
+        ("db.labels", "db.labels() :: (label :: STRING)"),
+        (
+            "db.relationshipTypes",
+            "db.relationshipTypes() :: (relationshipType :: STRING)",
+        ),
+        ("db.propertyKeys", "db.propertyKeys() :: (propertyKey :: STRING)"),
+        (
+            "apoc.meta.nodeTypeProperties",
+            "apoc.meta.nodeTypeProperties() :: (nodeType :: STRING, nodeLabels :: LIST, propertyName :: STRING, propertyTypes :: LIST, mandatory :: BOOLEAN)",
+        ),
+        (
+            "apoc.meta.relTypeProperties",
+            "apoc.meta.relTypeProperties() :: (relType :: STRING, sourceNodeLabels :: LIST, targetNodeLabels :: LIST, propertyName :: STRING, propertyTypes :: LIST, mandatory :: BOOLEAN)",
+        ),
+    ];
+    let rows = procs
+        .iter()
+        .map(|(name, sig)| {
+            Row::new()
+                .with("name", RuntimeValue::String((*name).to_string()))
+                .with("description", RuntimeValue::String(String::new()))
+                .with("signature", RuntimeValue::String((*sig).to_string()))
+        })
+        .collect();
+    read_outcome(
+        vec![
+            "name".to_string(),
+            "description".to_string(),
+            "signature".to_string(),
+        ],
+        rows,
+    )
+}
+
+/// `SHOW FUNCTIONS` / `CALL dbms.functions()` — no user functions to
+/// advertise; the column shape matters more than the rows.
+fn show_functions() -> RunOutcome {
+    read_outcome(
+        vec![
+            "name".to_string(),
+            "description".to_string(),
+            "signature".to_string(),
+        ],
+        Vec::new(),
+    )
+}
+
+/// `SHOW DATABASES` — NamiDB serves a single namespace, presented as the
+/// default `neo4j` database so the client's database picker resolves.
+fn show_databases() -> RunOutcome {
+    let row = Row::new()
+        .with("name", RuntimeValue::String("neo4j".to_string()))
+        .with("type", RuntimeValue::String("standard".to_string()))
+        .with("access", RuntimeValue::String("read-write".to_string()))
+        .with(
+            "address",
+            RuntimeValue::String("localhost:7687".to_string()),
+        )
+        .with("role", RuntimeValue::String("primary".to_string()))
+        .with(
+            "requestedStatus",
+            RuntimeValue::String("online".to_string()),
+        )
+        .with("currentStatus", RuntimeValue::String("online".to_string()))
+        .with("default", RuntimeValue::Bool(true))
+        .with("home", RuntimeValue::Bool(true));
+    read_outcome(
+        vec![
+            "name".to_string(),
+            "type".to_string(),
+            "access".to_string(),
+            "address".to_string(),
+            "role".to_string(),
+            "requestedStatus".to_string(),
+            "currentStatus".to_string(),
+            "default".to_string(),
+            "home".to_string(),
+        ],
+        vec![row],
+    )
+}
+
+/// `CALL apoc.meta.nodeTypeProperties()` — Neo4j/APOC node schema. Same
+/// data as `schema.node_type_properties` but APOC's column shape, where
+/// `propertyTypes` is a list. The `{includeLabels: [$label]}` variant is
+/// answered with the full set; the client keys on `nodeLabels`.
+async fn apoc_node_type_properties(snap: &Snapshot<'_>) -> RunOutcome {
+    let fields = vec![
+        "nodeType".to_string(),
+        "nodeLabels".to_string(),
+        "propertyName".to_string(),
+        "propertyTypes".to_string(),
+        "mandatory".to_string(),
+    ];
+    let mut rows = Vec::new();
+    for label in snap.observed_labels() {
+        let (_count, props) = sample_label(snap, &label).await;
+        let node_type = format!(":`{}`", label);
+        let node_labels = vec![RuntimeValue::String(label.clone())];
+        if props.is_empty() {
+            rows.push(apoc_node_row(&node_type, &node_labels, "", None));
+        } else {
+            for (name, ty) in props {
+                rows.push(apoc_node_row(&node_type, &node_labels, &name, Some(&ty)));
+            }
+        }
+    }
+    read_outcome(fields, rows)
+}
+
+fn apoc_node_row(
+    node_type: &str,
+    node_labels: &[RuntimeValue],
+    prop_name: &str,
+    prop_type: Option<&str>,
+) -> Row {
+    Row::new()
+        .with("nodeType", RuntimeValue::String(node_type.to_string()))
+        .with("nodeLabels", RuntimeValue::List(node_labels.to_vec()))
+        .with("propertyName", RuntimeValue::String(prop_name.to_string()))
+        .with("propertyTypes", type_list(prop_type))
+        .with("mandatory", RuntimeValue::Bool(false))
+}
+
+/// `CALL apoc.meta.relTypeProperties()` — Neo4j/APOC relationship schema
+/// with endpoint labels and sampled property types.
+async fn apoc_rel_type_properties(snap: &Snapshot<'_>) -> RunOutcome {
+    let fields = vec![
+        "relType".to_string(),
+        "sourceNodeLabels".to_string(),
+        "targetNodeLabels".to_string(),
+        "propertyName".to_string(),
+        "propertyTypes".to_string(),
+        "mandatory".to_string(),
+    ];
+    let endpoints = edge_endpoints(snap).await;
+    let mut rows = Vec::new();
+    for edge_type in snap.observed_edge_types() {
+        let rel_type = format!(":`{}`", edge_type);
+        let (src, dst) = endpoints.get(&edge_type).cloned().unwrap_or((None, None));
+        let src_labels = label_list(src);
+        let dst_labels = label_list(dst);
+        let props = sample_edge_type(snap, &edge_type).await;
+        if props.is_empty() {
+            rows.push(apoc_rel_row(&rel_type, &src_labels, &dst_labels, "", None));
+        } else {
+            for (name, ty) in props {
+                rows.push(apoc_rel_row(
+                    &rel_type,
+                    &src_labels,
+                    &dst_labels,
+                    &name,
+                    Some(&ty),
+                ));
+            }
+        }
+    }
+    read_outcome(fields, rows)
+}
+
+fn apoc_rel_row(
+    rel_type: &str,
+    src_labels: &[RuntimeValue],
+    dst_labels: &[RuntimeValue],
+    prop_name: &str,
+    prop_type: Option<&str>,
+) -> Row {
+    Row::new()
+        .with("relType", RuntimeValue::String(rel_type.to_string()))
+        .with("sourceNodeLabels", RuntimeValue::List(src_labels.to_vec()))
+        .with("targetNodeLabels", RuntimeValue::List(dst_labels.to_vec()))
+        .with("propertyName", RuntimeValue::String(prop_name.to_string()))
+        .with("propertyTypes", type_list(prop_type))
+        .with("mandatory", RuntimeValue::Bool(false))
+}
+
+fn type_list(prop_type: Option<&str>) -> RuntimeValue {
+    match prop_type {
+        Some(t) => RuntimeValue::List(vec![RuntimeValue::String(t.to_string())]),
+        None => RuntimeValue::List(Vec::new()),
+    }
+}
+
+fn label_list(label: Option<String>) -> Vec<RuntimeValue> {
+    label
+        .map(|l| vec![RuntimeValue::String(l)])
+        .unwrap_or_default()
 }
 
 /// `CALL mg.procedures()` — advertise the procedures this shim answers
@@ -267,6 +549,41 @@ async fn sample_label(snap: &Snapshot<'_>, label: &str) -> (i64, BTreeMap<String
         Err(e) => warn!(error = %e, label, "introspect: scan_label failed"),
     }
     (count, props)
+}
+
+/// Sampled property names of an edge type, mapped to a type label.
+async fn sample_edge_type(snap: &Snapshot<'_>, edge_type: &str) -> BTreeMap<String, String> {
+    let mut props: BTreeMap<String, String> = BTreeMap::new();
+    match snap.scan_edge_type(edge_type).await {
+        Ok(edges) => {
+            for edge in edges.iter().take(SAMPLE_EDGES) {
+                for (name, value) in &edge.properties {
+                    if matches!(value, Value::Null) {
+                        continue;
+                    }
+                    props
+                        .entry(name.clone())
+                        .or_insert_with(|| value_type_name(value).to_string());
+                }
+            }
+        }
+        Err(e) => warn!(error = %e, edge_type, "introspect: scan_edge_type failed"),
+    }
+    props
+}
+
+/// Inferred endpoint labels per edge type (`edge_type -> (src, dst)`).
+async fn edge_endpoints(snap: &Snapshot<'_>) -> BTreeMap<String, (Option<String>, Option<String>)> {
+    let mut map = BTreeMap::new();
+    match snap.observed_edge_endpoints().await {
+        Ok(endpoints) => {
+            for ep in endpoints {
+                map.insert(ep.edge_type, (ep.src_label, ep.dst_label));
+            }
+        }
+        Err(e) => warn!(error = %e, "introspect: observed_edge_endpoints failed"),
+    }
+    map
 }
 
 fn props_to_map(props: BTreeMap<String, String>) -> RuntimeValue {

--- a/crates/namidb-server/tests/bolt_integration.rs
+++ b/crates/namidb-server/tests/bolt_integration.rs
@@ -552,3 +552,157 @@ async fn bolt_memgraph_introspection_populates_schema() {
     stream.shutdown().await.ok();
     server_task.abort();
 }
+
+/// Run a statement and return the metadata of its closing `SUCCESS`
+/// (after a single PULL) — e.g. to inspect the write `stats` map.
+async fn run_capture_close(stream: &mut TcpStream, cypher: &str) -> BTreeMap<String, Value> {
+    let run = Value::Struct {
+        tag: struct_tag::RUN,
+        fields: vec![
+            Value::String(cypher.into()),
+            Value::Map(BTreeMap::new()),
+            Value::Map(BTreeMap::new()),
+        ],
+    };
+    send_msg(stream, &pack(&run)).await;
+    match recv_msg(stream).await {
+        Response::Success(_) => {}
+        other => panic!("expected head SUCCESS, got {other:?}"),
+    }
+    let pull = Value::Struct {
+        tag: struct_tag::PULL,
+        fields: vec![Value::Map({
+            let mut m = BTreeMap::new();
+            m.insert("n".into(), Value::Int(-1));
+            m
+        })],
+    };
+    send_msg(stream, &pack(&pull)).await;
+    loop {
+        match recv_msg(stream).await {
+            Response::Record(_) => {}
+            Response::Success(meta) => return meta,
+            other => panic!("unexpected message capturing close: {other:?}"),
+        }
+    }
+}
+
+#[tokio::test]
+async fn bolt_neo4j_type_introspection_and_counters() {
+    // The Neo4j connection type fires db.*, apoc.meta.* and SHOW, uses
+    // elementId(), and expects write counters in the closing SUCCESS.
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let bolt_addr = listener.local_addr().unwrap();
+    drop(listener);
+
+    let http_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let http_addr = http_listener.local_addr().unwrap();
+    drop(http_listener);
+
+    let config = namidb_server::Config {
+        store_uri: "memory://bolt-neo4j".into(),
+        listen: http_addr,
+        auth_token: Some("test-token".into()),
+        flush_interval: Duration::ZERO,
+        compaction_interval: Duration::ZERO,
+        sweep_min_age: Duration::ZERO,
+        sweep_delete: false,
+        bolt_listen: Some(bolt_addr),
+    };
+    let server_task = tokio::spawn(async move {
+        let _ = namidb_server::run(config).await;
+    });
+    for _ in 0..50 {
+        if TcpStream::connect(bolt_addr).await.is_ok() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+
+    let mut stream = TcpStream::connect(bolt_addr).await.expect("connect bolt");
+    handshake(&mut stream).await;
+    hello_and_logon(&mut stream, "test-token").await;
+
+    // A write reports counters in the closing SUCCESS `stats` map.
+    let close = run_capture_close(
+        &mut stream,
+        "CREATE (a:Person {name: 'Alice', age: 30})-[:KNOWS]->(b:Person {name: 'Bob'})",
+    )
+    .await;
+    let stats = match close.get("stats") {
+        Some(Value::Map(m)) => m,
+        other => panic!("write summary has no stats map: {other:?}"),
+    };
+    assert_eq!(stats.get("nodes-created"), Some(&Value::Int(2)));
+    assert_eq!(stats.get("relationships-created"), Some(&Value::Int(1)));
+
+    pull_all(&mut stream, "CREATE (c:Company {name: 'NamiDB'})").await;
+    pull_all(
+        &mut stream,
+        "MATCH (a:Person {name:'Alice'}),(c:Company {name:'NamiDB'}) \
+         CREATE (a)-[:WORKS_AT {role: 'founder'}]->(c)",
+    )
+    .await;
+
+    // db.labels()
+    let (_f, rows) = pull_all(&mut stream, "CALL db.labels()").await;
+    assert!(rows
+        .iter()
+        .any(|r| r.get("label") == Some(&Value::String("Person".into()))));
+
+    // apoc.meta.nodeTypeProperties(): APOC shape, propertyTypes is a list.
+    let (fields, rows) = pull_all(&mut stream, "CALL apoc.meta.nodeTypeProperties()").await;
+    assert!(fields.iter().any(|f| f == "nodeLabels"));
+    let person_name = rows
+        .iter()
+        .find(|r| {
+            r.get("propertyName") == Some(&Value::String("name".into()))
+                && matches!(
+                    r.get("nodeLabels"),
+                    Some(Value::List(l)) if l.contains(&Value::String("Person".into()))
+                )
+        })
+        .expect("Person.name row present");
+    assert!(
+        matches!(person_name.get("propertyTypes"), Some(Value::List(_))),
+        "apoc propertyTypes must be a list, got {:?}",
+        person_name.get("propertyTypes")
+    );
+
+    // apoc.meta.relTypeProperties(): endpoint labels populated.
+    let (_f, rows) = pull_all(&mut stream, "CALL apoc.meta.relTypeProperties()").await;
+    let works = rows
+        .iter()
+        .find(|r| r.get("relType") == Some(&Value::String(":`WORKS_AT`".into())))
+        .expect("WORKS_AT row present");
+    assert!(matches!(
+        works.get("sourceNodeLabels"),
+        Some(Value::List(l)) if l.contains(&Value::String("Person".into()))
+    ));
+    assert!(matches!(
+        works.get("targetNodeLabels"),
+        Some(Value::List(l)) if l.contains(&Value::String("Company".into()))
+    ));
+
+    // SHOW DATABASES resolves the default database name.
+    let (_f, rows) = pull_all(&mut stream, "SHOW DATABASES").await;
+    assert!(rows
+        .iter()
+        .any(|r| r.get("name") == Some(&Value::String("neo4j".into()))));
+
+    // elementId() returns a non-empty id string (G.V() uses it to fetch
+    // and expand nodes/edges).
+    let (_f, rows) = pull_all(
+        &mut stream,
+        "MATCH (n:Person {name:'Alice'}) RETURN elementId(n) AS eid",
+    )
+    .await;
+    assert!(
+        matches!(rows.first().and_then(|r| r.get("eid")), Some(Value::String(s)) if !s.is_empty()),
+        "elementId(n) should be a non-empty string: {rows:?}"
+    );
+
+    goodbye(&mut stream).await;
+    stream.shutdown().await.ok();
+    server_task.abort();
+}


### PR DESCRIPTION
Completes G.V() (gdotv) compatibility so it works through both the **Memgraph**
and **Neo4j** connection types, with no client-side changes.

## What's in here

**Neo4j connection type** (`introspect.rs`): answer the introspection set the
Neo4j type fires on connect, alongside the existing Memgraph procedures:
`db.labels` / `db.relationshipTypes` / `db.propertyKeys`,
`apoc.meta.nodeTypeProperties` (bare and `{includeLabels}`),
`apoc.meta.relTypeProperties` (with endpoint labels + sampled edge properties),
`SHOW PROCEDURES/FUNCTIONS/DATABASES`, `dbms.components`. No real APOC needed.

**Write counters** (`namidb-bolt`): emit `stats` in the closing PULL summary so
a write reports nodes/relationships created/deleted (was computed but dropped).

**elementId point lookup** (`optimize/unique_lookup.rs`): rewrite
`WHERE elementId(n) = <expr>` / `WHERE id(n) = <expr>` over a bare scan into a
`NodeById` UUID point lookup (label-scoped or fanned across observed labels via
`scan_node_for_id`; `NodeById.label` is now `Option<String>`). This is G.V()'s
node fetch and expand shape — ~0.45 ms vs ~12 ms on a six-figure graph.

Also: `schema.rel_type_properties` now samples real edge properties.

## Test plan

- New: `bolt_neo4j_type_introspection_and_counters` (db.labels, apoc.meta.*,
  SHOW DATABASES, write `stats`, elementId), `element_id_filter_lowers_to_point_lookup`.
- Full suites green (namidb-query, namidb-bolt, namidb-server), fmt + clippy clean.
- Verified live against G.V() 3.61.129: both connection types connect, schema
  panel populates, graph renders, node expand works, writes report counters.