### PR TITLE
fix(query): use is_none_or to satisfy clippy unnecessary_map_or

### DIFF
--- a/crates/namidb-query/src/plan/explain.rs
+++ b/crates/namidb-query/src/plan/explain.rs
@@ -332,9 +332,9 @@ fn plan_has_stats(plan: &LogicalPlan, catalog: &StatsCatalog) -> bool {
             .and_then(|l| catalog.label(l))
             .map(|l| l.node_count > 0)
             .unwrap_or(false),
-        LogicalPlan::NodeById { label, .. } => label.as_deref().map_or(true, |l| {
-            catalog.label(l).map(|x| x.node_count > 0).unwrap_or(false)
-        }),
+        LogicalPlan::NodeById { label, .. } => label
+            .as_deref()
+            .is_none_or(|l| catalog.label(l).map(|x| x.node_count > 0).unwrap_or(false)),
         LogicalPlan::NodeByPropertyValue { label, .. } => catalog
             .label(label)
             .map(|l| l.node_count > 0)


### PR DESCRIPTION
Fast-follow: `map_or(true, ...)` -> `is_none_or` on the NodeById has-rows check (clippy `-D warnings` on main). Local clippy with the exact CI flags is clean.