### PR TITLE
feat(query): use the equality index for non-unique indexed properties (planner)

### DIFF
--- a/crates/namidb-query/src/cost/cardinality.rs
+++ b/crates/namidb-query/src/cost/cardinality.rs
@@ -933,6 +933,7 @@ mod tests {
             max: Some(StatScalar::Int64(100)),
             ndv: Some(50),
             unique: false,
+            indexed: false,
         };
         let person = LabelStats {
             name: "Person".into(),

--- a/crates/namidb-query/src/cost/selectivity.rs
+++ b/crates/namidb-query/src/cost/selectivity.rs
@@ -542,6 +542,7 @@ mod tests {
                 max: Some(StatScalar::Int64(max)),
                 ndv,
                 unique: false,
+                indexed: false,
             },
         );
         LabelStats {

--- a/crates/namidb-query/src/cost/stats.rs
+++ b/crates/namidb-query/src/cost/stats.rs
@@ -60,6 +60,10 @@ pub struct PropStats {
     /// reads this to rewrite `Filter(prop = literal)` on top of
     /// `NodeScan(label)` into `NodeByPropertyValue` (point lookup).
     pub unique: bool,
+    /// Mirrors `PropertyDef::indexed` — the optimizer reads this to
+    /// rewrite an equality filter on a non-unique indexed property into a
+    /// `NodeByPropertyValue { multi: true }` index lookup.
+    pub indexed: bool,
 }
 
 /// Per-edge-type aggregate stats.
@@ -140,6 +144,7 @@ impl StatsCatalog {
                     .entry(pd.name.clone())
                     .or_insert_with(|| PropStats {
                         unique: pd.unique,
+                        indexed: pd.indexed,
                         ..Default::default()
                     });
             }

--- a/crates/namidb-query/src/exec/walker.rs
+++ b/crates/namidb-query/src/exec/walker.rs
@@ -300,13 +300,32 @@ pub(crate) fn execute_inner_with_routing<'a>(
                 alias,
                 property,
                 value,
+                multi,
             } => {
                 let input_rows =
                     execute_inner_with_routing(input, snapshot, params, outer, routing).await?;
                 let mut out = Vec::with_capacity(input_rows.len());
                 for row in input_rows {
                     let lookup_val = evaluate(value, &row, params)?;
-                    if let Some(view) =
+                    if *multi {
+                        // Non-unique indexed property: fan out one row per
+                        // matching node.
+                        for view in lookup_nodes_by_property_via_scan(
+                            snapshot,
+                            label,
+                            property,
+                            &lookup_val,
+                        )
+                        .await?
+                        {
+                            let mut new_row = row.clone();
+                            new_row.set(
+                                alias.clone(),
+                                RuntimeValue::Node(Box::new(NodeValue::from(view))),
+                            );
+                            out.push(new_row);
+                        }
+                    } else if let Some(view) =
                         lookup_node_by_property_via_scan(snapshot, label, property, &lookup_val)
                             .await?
                     {
@@ -1707,6 +1726,38 @@ pub(crate) async fn lookup_node_by_property_via_scan(
     Ok(candidates.into_iter().next())
 }
 
+/// Multi-match variant of [`lookup_node_by_property_via_scan`] for a
+/// non-unique `indexed` property: returns every node carrying `value`. A
+/// String key resolves through the equality posting-list sidecar; other
+/// scalar types fall back to a full label scan filtered by exact value
+/// (no typed sidecar yet).
+pub(crate) async fn lookup_nodes_by_property_via_scan(
+    snapshot: &Snapshot<'_>,
+    label: &str,
+    property: &str,
+    value: &RuntimeValue,
+) -> Result<Vec<namidb_storage::NodeView>, ExecError> {
+    if let RuntimeValue::String(s) = value {
+        return snapshot
+            .lookup_nodes_by_property(label, property, s)
+            .await
+            .map_err(ExecError::Storage);
+    }
+    let all = snapshot
+        .scan_label(label)
+        .await
+        .map_err(ExecError::Storage)?;
+    Ok(all
+        .into_iter()
+        .filter(|view| {
+            view.properties
+                .get(property)
+                .map(|cv| RuntimeValue::from(cv.clone()) == *value)
+                .unwrap_or(false)
+        })
+        .collect())
+}
+
 // ────────────────────────── Factor path ────────────────────────
 //
 // `execute_factor_inner` mirrors `execute_inner` but operates on
@@ -1812,6 +1863,7 @@ pub(crate) fn execute_factor_inner_with_routing<'a>(
                 alias,
                 property,
                 value,
+                multi,
             } => {
                 let input_set =
                     execute_factor_inner_with_routing(input, snapshot, params, outer, routing)
@@ -1823,7 +1875,22 @@ pub(crate) fn execute_factor_inner_with_routing<'a>(
                 for leaf in input_set.leaves {
                     let row = arena_view.materialize(leaf, None);
                     let lookup_val = evaluate(value, &row, params)?;
-                    if let Some(view) =
+                    if *multi {
+                        for view in lookup_nodes_by_property_via_scan(
+                            snapshot,
+                            label,
+                            property,
+                            &lookup_val,
+                        )
+                        .await?
+                        {
+                            let slot = Slot {
+                                name: alias_arc.clone(),
+                                value: RuntimeValue::Node(Box::new(NodeValue::from(view))),
+                            };
+                            out_leaves.push(next_arena.push(leaf, vec![slot]));
+                        }
+                    } else if let Some(view) =
                         lookup_node_by_property_via_scan(snapshot, label, property, &lookup_val)
                             .await?
                     {

--- a/crates/namidb-query/src/exec/writer.rs
+++ b/crates/namidb-query/src/exec/writer.rs
@@ -327,19 +327,37 @@ fn execute_write_inner<'a>(
                 alias,
                 property,
                 value,
+                multi,
             } => {
                 let input_rows = execute_write_inner(input, writer, params, outcome).await?;
                 let snap = writer.snapshot();
                 let mut out = Vec::with_capacity(input_rows.len());
                 for row in input_rows {
                     let lookup_val = evaluate(value, &row, params)?;
-                    if let Some(view) = crate::exec::walker::lookup_node_by_property_via_scan(
-                        &snap,
-                        label,
-                        property,
-                        &lookup_val,
-                    )
-                    .await?
+                    if *multi {
+                        for view in crate::exec::walker::lookup_nodes_by_property_via_scan(
+                            &snap,
+                            label,
+                            property,
+                            &lookup_val,
+                        )
+                        .await?
+                        {
+                            let mut new_row = row.clone();
+                            new_row.set(
+                                alias.clone(),
+                                RuntimeValue::Node(Box::new(NodeValue::from(view))),
+                            );
+                            out.push(new_row);
+                        }
+                    } else if let Some(view) =
+                        crate::exec::walker::lookup_node_by_property_via_scan(
+                            &snap,
+                            label,
+                            property,
+                            &lookup_val,
+                        )
+                        .await?
                     {
                         let mut new_row = row;
                         new_row.set(

--- a/crates/namidb-query/src/optimize/decorrelation.rs
+++ b/crates/namidb-query/src/optimize/decorrelation.rs
@@ -242,12 +242,14 @@ fn replace_argument(plan: LogicalPlan, x: &str, label: &str) -> LogicalPlan {
             alias,
             property,
             value,
+            multi,
         } => LogicalPlan::NodeByPropertyValue {
             input: Box::new(replace_argument(*input, x, label)),
             label: l,
             alias,
             property,
             value,
+            multi,
         },
         LogicalPlan::Expand {
             input,
@@ -325,12 +327,14 @@ fn recurse_children(plan: LogicalPlan, catalog: &StatsCatalog) -> LogicalPlan {
             alias,
             property,
             value,
+            multi,
         } => LogicalPlan::NodeByPropertyValue {
             input: Box::new(convert_semi_apply_to_hash_semi_join(*input, catalog)),
             label,
             alias,
             property,
             value,
+            multi,
         },
         LogicalPlan::Expand {
             input,

--- a/crates/namidb-query/src/optimize/join_conversion.rs
+++ b/crates/namidb-query/src/optimize/join_conversion.rs
@@ -51,12 +51,14 @@ fn recurse_children(plan: LogicalPlan, catalog: &StatsCatalog) -> LogicalPlan {
             alias,
             property,
             value,
+            multi,
         } => LogicalPlan::NodeByPropertyValue {
             input: Box::new(convert_cross_to_hash(*input, catalog)),
             label,
             alias,
             property,
             value,
+            multi,
         },
         LogicalPlan::Expand {
             input,
@@ -409,6 +411,7 @@ mod tests {
                 max: Some(StatScalar::Utf8("Zoe".into())),
                 ndv: Some(ndv),
                 unique: false,
+                indexed: false,
             },
         );
         props.insert(
@@ -420,6 +423,7 @@ mod tests {
                 max: Some(StatScalar::Int64(99)),
                 ndv: Some(ndv),
                 unique: false,
+                indexed: false,
             },
         );
         cat.__test_insert_label(LabelStats {
@@ -592,6 +596,7 @@ mod tests {
                         max: None,
                         ndv: Some(10),
                         unique: false,
+                        indexed: false,
                     },
                 );
                 m
@@ -611,6 +616,7 @@ mod tests {
                         max: None,
                         ndv: Some(1000),
                         unique: false,
+                        indexed: false,
                     },
                 );
                 m

--- a/crates/namidb-query/src/optimize/join_reorder.rs
+++ b/crates/namidb-query/src/optimize/join_reorder.rs
@@ -88,12 +88,14 @@ fn recurse(plan: LogicalPlan, catalog: &StatsCatalog) -> LogicalPlan {
             alias,
             property,
             value,
+            multi,
         } => LogicalPlan::NodeByPropertyValue {
             input: Box::new(recurse(*input, catalog)),
             label,
             alias,
             property,
             value,
+            multi,
         },
         LogicalPlan::Expand {
             input,

--- a/crates/namidb-query/src/optimize/multiway_join.rs
+++ b/crates/namidb-query/src/optimize/multiway_join.rs
@@ -386,12 +386,14 @@ fn recurse_children(plan: LogicalPlan) -> LogicalPlan {
             alias,
             property,
             value,
+            multi,
         } => LogicalPlan::NodeByPropertyValue {
             input: Box::new(rewrite(*input)),
             label,
             alias,
             property,
             value,
+            multi,
         },
         LogicalPlan::Expand {
             input,

--- a/crates/namidb-query/src/optimize/normalize.rs
+++ b/crates/namidb-query/src/optimize/normalize.rs
@@ -42,12 +42,14 @@ fn recurse_children(plan: LogicalPlan) -> LogicalPlan {
             alias,
             property,
             value,
+            multi,
         } => LogicalPlan::NodeByPropertyValue {
             input: Box::new(normalize_filters(*input)),
             label,
             alias,
             property,
             value,
+            multi,
         },
         LogicalPlan::Expand {
             input,

--- a/crates/namidb-query/src/optimize/projection_pushdown.rs
+++ b/crates/namidb-query/src/optimize/projection_pushdown.rs
@@ -537,12 +537,14 @@ fn rewrite(plan: LogicalPlan, req: &RequiredSet) -> LogicalPlan {
             alias,
             property,
             value,
+            multi,
         } => LogicalPlan::NodeByPropertyValue {
             input: Box::new(rewrite(*input, req)),
             label,
             alias,
             property,
             value,
+            multi,
         },
         LogicalPlan::Expand {
             input,

--- a/crates/namidb-query/src/optimize/pushdown.rs
+++ b/crates/namidb-query/src/optimize/pushdown.rs
@@ -99,6 +99,7 @@ fn pushdown_at(plan: LogicalPlan, pending: Vec<Expression>) -> LogicalPlan {
             alias,
             property,
             value,
+            multi,
         } => {
             let mut introduced = BTreeSet::new();
             introduced.insert(alias.clone());
@@ -111,6 +112,7 @@ fn pushdown_at(plan: LogicalPlan, pending: Vec<Expression>) -> LogicalPlan {
                     alias,
                     property,
                     value,
+                    multi,
                 },
                 stay,
             )

--- a/crates/namidb-query/src/optimize/unique_lookup.rs
+++ b/crates/namidb-query/src/optimize/unique_lookup.rs
@@ -49,18 +49,22 @@ fn rewrite(plan: LogicalPlan, catalog: &StatsCatalog) -> LogicalPlan {
             {
                 if predicates.is_empty() && projection.is_none() {
                     if let Some((prop, value_expr)) = extract_eq_on_prop(&predicate, alias) {
-                        if catalog
-                            .label(label)
-                            .and_then(|l| l.properties.get(&prop))
-                            .map(|p| p.unique)
-                            .unwrap_or(false)
-                        {
+                        let pstats = catalog.label(label).and_then(|l| l.properties.get(&prop));
+                        let is_unique = pstats.map(|p| p.unique).unwrap_or(false);
+                        // A non-unique `indexed` property resolves through the
+                        // equality posting-list sidecar and may match many
+                        // nodes (`multi`). No cost gate yet: `ndv` is unseeded
+                        // so the index always wins the fallback estimate; a
+                        // selectivity gate is a follow-up.
+                        let is_indexed = pstats.map(|p| p.indexed && !p.unique).unwrap_or(false);
+                        if is_unique || is_indexed {
                             return LogicalPlan::NodeByPropertyValue {
                                 input: Box::new(LogicalPlan::Empty),
                                 label: label.clone(),
                                 alias: alias.clone(),
                                 property: prop,
                                 value: value_expr,
+                                multi: is_indexed,
                             };
                         }
                     }
@@ -119,12 +123,14 @@ fn rewrite(plan: LogicalPlan, catalog: &StatsCatalog) -> LogicalPlan {
             alias,
             property,
             value,
+            multi,
         } => LogicalPlan::NodeByPropertyValue {
             input: Box::new(rewrite(*input, catalog)),
             label,
             alias,
             property,
             value,
+            multi,
         },
         LogicalPlan::Expand {
             input,
@@ -351,4 +357,79 @@ fn is_node_id_call(expr: &Expression, alias: &str) -> bool {
         return false;
     }
     matches!(&args[0].kind, ExpressionKind::Variable(id) if id.name == alias)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cost::{LabelStats, PropStats, StatsCatalog};
+    use crate::parser::parse;
+    use crate::plan::lower;
+    use std::collections::BTreeMap;
+
+    fn catalog_with_city(unique: bool, indexed: bool) -> StatsCatalog {
+        let mut cat = StatsCatalog::empty();
+        let mut props = BTreeMap::new();
+        props.insert(
+            "city".to_string(),
+            PropStats {
+                unique,
+                indexed,
+                ..Default::default()
+            },
+        );
+        cat.__test_insert_label(LabelStats {
+            name: "Person".into(),
+            node_count: 1000,
+            properties: props,
+        });
+        cat
+    }
+
+    /// `multi` of the first `NodeByPropertyValue` in the plan, if any.
+    fn find_lookup(plan: &LogicalPlan) -> Option<bool> {
+        if let LogicalPlan::NodeByPropertyValue { multi, .. } = plan {
+            return Some(*multi);
+        }
+        plan.children().into_iter().find_map(find_lookup)
+    }
+
+    fn rewrite_query(q: &str, cat: &StatsCatalog) -> LogicalPlan {
+        let parsed = parse(q).unwrap();
+        let plan = lower(&parsed).unwrap();
+        apply_unique_property_lookup(plan, cat)
+    }
+
+    #[test]
+    fn indexed_non_unique_property_emits_multi_index_lookup() {
+        let cat = catalog_with_city(false, true);
+        let plan = rewrite_query("MATCH (p:Person {city: 'LA'}) RETURN p", &cat);
+        assert_eq!(
+            find_lookup(&plan),
+            Some(true),
+            "an indexed non-unique property should emit a multi index lookup"
+        );
+    }
+
+    #[test]
+    fn unique_property_emits_point_lookup() {
+        let cat = catalog_with_city(true, false);
+        let plan = rewrite_query("MATCH (p:Person {city: 'LA'}) RETURN p", &cat);
+        assert_eq!(
+            find_lookup(&plan),
+            Some(false),
+            "a unique property should stay a single point lookup"
+        );
+    }
+
+    #[test]
+    fn unindexed_property_stays_a_scan() {
+        let cat = catalog_with_city(false, false);
+        let plan = rewrite_query("MATCH (p:Person {city: 'LA'}) RETURN p", &cat);
+        assert_eq!(
+            find_lookup(&plan),
+            None,
+            "an un-indexed property must keep the full scan + filter"
+        );
+    }
 }

--- a/crates/namidb-query/src/plan/explain.rs
+++ b/crates/namidb-query/src/plan/explain.rs
@@ -1041,6 +1041,7 @@ TopN keys=[b DESC] limit=10
             max: Some(StatScalar::Int64(99)),
             ndv: Some(50),
             unique: false,
+            indexed: false,
         };
         let mut props = std::collections::BTreeMap::new();
         props.insert("age".into(), age);
@@ -1121,6 +1122,7 @@ TopN keys=[b DESC] limit=10
             max: None,
             ndv: Some(1000),
             unique: false,
+            indexed: false,
         };
         props.insert("age".into(), age);
         cat.__test_insert_label(crate::cost::stats::LabelStats {

--- a/crates/namidb-query/src/plan/logical.rs
+++ b/crates/namidb-query/src/plan/logical.rs
@@ -75,6 +75,11 @@ pub enum LogicalPlan {
         alias: String,
         property: String,
         value: Expression,
+        /// `false`: a *unique* property — at most one match, resolved
+        /// through the unique sidecar (point lookup). `true`: a non-unique
+        /// `indexed` property — fan out one row per match, resolved through
+        /// the equality posting-list sidecar.
+        multi: bool,
     },
 
     /// Expand `source` across an edge to produce `target_alias`.

--- a/crates/namidb-query/tests/exec_match_expand.rs
+++ b/crates/namidb-query/tests/exec_match_expand.rs
@@ -14,7 +14,7 @@ use namidb_storage::{EdgeWriteRecord, NamespacePaths, NodeWriteRecord, WriterSes
 use object_store::memory::InMemory;
 use object_store::ObjectStore;
 
-use namidb_query::{execute, lower, parse, Params, RuntimeValue};
+use namidb_query::{execute, explain, lower, optimize, parse, Params, RuntimeValue, StatsCatalog};
 
 fn store() -> Arc<dyn ObjectStore> {
     Arc::new(InMemory::new())
@@ -47,6 +47,28 @@ fn person(name: &str, age: i32) -> NodeWriteRecord {
     let mut props: BTreeMap<String, CoreValue> = BTreeMap::new();
     props.insert("name".into(), CoreValue::Str(name.into()));
     props.insert("age".into(), CoreValue::I64(age as i64));
+    NodeWriteRecord {
+        properties: props,
+        schema_version: 1,
+    }
+}
+
+fn indexed_city_label() -> LabelDef {
+    LabelDef {
+        name: "Person".into(),
+        properties: vec![
+            PropertyDef::new("name", DataType::Utf8, false).unwrap(),
+            PropertyDef::new("city", DataType::Utf8, true)
+                .unwrap()
+                .with_indexed(true),
+        ],
+    }
+}
+
+fn person_city(name: &str, city: &str) -> NodeWriteRecord {
+    let mut props: BTreeMap<String, CoreValue> = BTreeMap::new();
+    props.insert("name".into(), CoreValue::Str(name.into()));
+    props.insert("city".into(), CoreValue::Str(city.into()));
     NodeWriteRecord {
         properties: props,
         schema_version: 1,
@@ -979,4 +1001,58 @@ async fn element_id_filter_lowers_to_point_lookup() {
         }
         other => panic!("expected the looked-up node, got {other:?}"),
     }
+}
+
+#[tokio::test]
+async fn indexed_property_match_uses_index_and_returns_all_matches() {
+    // End-to-end: an equality MATCH on a non-unique `indexed` property is
+    // rewritten by the optimizer into the index lookup and the executor
+    // fans out one row per match.
+    let mut writer = WriterSession::open(store(), paths("exec-eqidx"))
+        .await
+        .unwrap();
+    let ids: [NodeId; 3] = std::array::from_fn(|_| NodeId::new());
+    let names = ["Ann", "Bob", "Cy"];
+    let cities = ["LA", "LA", "NYC"];
+    for ((id, name), city) in ids.iter().zip(names).zip(cities) {
+        writer
+            .upsert_node("Person", *id, &person_city(name, city))
+            .unwrap();
+    }
+    writer.commit_batch().await.unwrap();
+    // Flush with the indexed schema so the equality sidecar and the schema
+    // (with `city` indexed) both land in the manifest.
+    let schema = SchemaBuilder::new()
+        .label(indexed_city_label())
+        .unwrap()
+        .build();
+    writer.flush(schema).await.unwrap();
+    let snapshot = writer.snapshot();
+
+    // The catalog (built from the manifest) sees `city` as indexed, so the
+    // optimizer rewrites the filter into the index lookup rather than a
+    // full label scan.
+    let catalog = StatsCatalog::from_manifest(&snapshot.manifest().manifest);
+    let q = parse("MATCH (p:Person {city: 'LA'}) RETURN p.name AS name").unwrap();
+    let plan = optimize(lower(&q).unwrap(), &catalog);
+    let rendered = explain(&plan);
+    assert!(
+        rendered.contains("NodeByPropertyValue"),
+        "expected the index lookup in the optimized plan, got:\n{rendered}"
+    );
+
+    let rows = execute(&plan, &snapshot, &Params::new()).await.unwrap();
+    let mut got: Vec<String> = rows
+        .iter()
+        .filter_map(|r| match r.get("name") {
+            Some(RuntimeValue::String(s)) => Some(s.clone()),
+            _ => None,
+        })
+        .collect();
+    got.sort();
+    assert_eq!(
+        got,
+        vec!["Ann".to_string(), "Bob".to_string()],
+        "both LA persons must come back, not the NYC one"
+    );
 }


### PR DESCRIPTION
Completes roadmap C2 (phase 1). The previous PR added the storage half of a secondary equality index; this wires the **planner + executor** so an equality `MATCH` on a non-unique `indexed` property actually resolves through the index instead of a full label scan + filter.

## Change
- **cost** `PropStats` gains `indexed`, seeded from `PropertyDef.indexed`.
- **plan** `NodeByPropertyValue` gains a `multi` flag: `false` keeps the unique point lookup (the existing path), `true` fans out one row per match through the equality posting-list sidecar.
- **optimize/unique_lookup** when an equality filter targets a non-unique `indexed` property, emit `NodeByPropertyValue { multi: true }`. (No cost gate yet — `ndv` is unseeded so the index always wins the fallback estimate; a selectivity gate is a follow-up.)
- **exec** the flat and factor executor paths, plus the write path, fan out 1→N for a multi lookup via `Snapshot::lookup_nodes_by_property`; a non-string indexed key falls back to a scan + exact-value filter.

The `multi` flag (rather than a brand-new operator) keeps the ripple to threading one field through the ~10 existing `NodeByPropertyValue` recursion arms and branching the executor, reusing the cardinality/explain handling.

## Tests
- Optimizer-rewrite unit test: indexed non-unique → `multi: true` lookup; unique → point lookup; un-indexed → stays a scan.
- **End-to-end**: flush an `indexed` city schema, optimize the query, assert the plan contains the index op (via `explain`) AND the executor returns *every* match (both LA persons, not the NYC one). This proves the full query → optimizer → executor → index chain.

Query suite green (435 + integration), storage green (275), downstream crates build, `cargo fmt --check` clean, no new clippy warnings.

## Deferred (noted in code)
A selectivity cost gate (use `node_count / ndv` once HLL seeds `ndv`), typed non-string index keys, and range/vector indexes.