### PR TITLE
feat(core): add LabelId and LabelDictionary for multi-label nodes

### DIFF
--- a/crates/namidb-core/src/id.rs
+++ b/crates/namidb-core/src/id.rs
@@ -1,7 +1,11 @@
-//! Identifier types: [`NodeId`], [`EdgeId`], [`NamespaceId`].
+//! Identifier types: [`NodeId`], [`EdgeId`], [`NamespaceId`], plus the small
+//! interned [`LabelId`].
 //!
-//! Identifiers are 128-bit ULIDs (encoded as UUIDv7) — they sort by creation
-//! time, which the storage layer exploits for LSM key ordering.
+//! [`NodeId`] and [`EdgeId`] are 128-bit ULIDs (encoded as UUIDv7) — they sort
+//! by creation time, which the storage layer exploits for LSM key ordering.
+//! [`LabelId`] is a different beast: a compact `u32` handed out by a
+//! [`LabelDictionary`](crate::schema::LabelDictionary) so a node's set of labels
+//! can ride on-row as a packed `List<UInt32>` instead of a list of strings.
 
 use std::fmt;
 use std::str::FromStr;
@@ -106,6 +110,34 @@ impl FromStr for EdgeId {
     }
 }
 
+/// Compact, stable identifier for a node label.
+///
+/// Unlike [`NodeId`]/[`EdgeId`], a `LabelId` is not a ULID: it is a small
+/// `u32` minted by a [`LabelDictionary`](crate::schema::LabelDictionary), which
+/// assigns ids in first-seen order and never reuses them. That stability is
+/// what lets the storage layer carry a node's label set on-row as a packed
+/// `List<UInt32>` and the query layer intersect label sets without touching
+/// strings: a `LabelId` minted in one manifest commit means the same label in
+/// every later one.
+#[derive(Clone, Copy, Eq, PartialEq, Hash, Ord, PartialOrd, Debug, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct LabelId(pub u32);
+
+impl LabelId {
+    pub fn new(raw: u32) -> Self {
+        LabelId(raw)
+    }
+    pub fn get(self) -> u32 {
+        self.0
+    }
+}
+
+impl fmt::Display for LabelId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        fmt::Display::fmt(&self.0, f)
+    }
+}
+
 /// Identifier of a tenant namespace.
 ///
 /// A namespace is the unit of multi-tenancy: one namespace == one logical
@@ -188,6 +220,23 @@ mod tests {
         // UUIDv7's first 48 bits are millisecond timestamp → strictly
         // ordered for samples >1ms apart.
         assert!(a < b, "{a} should sort before {b}");
+    }
+
+    #[test]
+    fn label_id_serializes_transparently() {
+        // `#[serde(transparent)]` means a LabelId is just its number on the
+        // wire — that's the contract the on-row `List<UInt32>` relies on.
+        let id = LabelId::new(7);
+        assert_eq!(serde_json::to_string(&id).unwrap(), "7");
+        let back: LabelId = serde_json::from_str("7").unwrap();
+        assert_eq!(back, id);
+        assert_eq!(id.get(), 7);
+    }
+
+    #[test]
+    fn label_id_orders_by_value() {
+        assert!(LabelId::new(0) < LabelId::new(1));
+        assert_eq!(LabelId::new(42).to_string(), "42");
     }
 
     #[test]

--- a/crates/namidb-core/src/lib.rs
+++ b/crates/namidb-core/src/lib.rs
@@ -16,6 +16,8 @@ pub mod schema;
 pub mod value;
 
 pub use error::{Error, Result};
-pub use id::{EdgeId, NamespaceId, NodeId};
-pub use schema::{DataType, EdgeTypeDef, LabelDef, PropertyDef, Schema, SchemaBuilder};
+pub use id::{EdgeId, LabelId, NamespaceId, NodeId};
+pub use schema::{
+    DataType, EdgeTypeDef, LabelDef, LabelDictionary, PropertyDef, Schema, SchemaBuilder,
+};
 pub use value::Value;

--- a/crates/namidb-core/src/schema.rs
+++ b/crates/namidb-core/src/schema.rs
@@ -11,6 +11,7 @@ use arrow_schema::{DataType as ArrowDataType, Field};
 use serde::{Deserialize, Serialize};
 
 use crate::error::{Error, Result};
+use crate::id::LabelId;
 
 /// A subset of Arrow's logical type system that maps cleanly to Cypher and to
 /// JSON ingest.
@@ -229,6 +230,90 @@ pub struct LabelDef {
     pub properties: Vec<PropertyDef>,
 }
 
+/// Bidirectional, append-only mapping between label names and compact
+/// [`LabelId`]s.
+///
+/// A node carries its labels on-row as a set of [`LabelId`]s; this dictionary
+/// is the per-namespace source of truth that resolves those ids back to names
+/// and back again. Ids are handed out in first-seen order and never change or
+/// get reused, so a `LabelId` minted in one manifest commit means the same
+/// label in every later one — that stability is what lets the storage layer
+/// store labels as a packed `List<UInt32>` rather than repeating strings.
+///
+/// On the wire the dictionary is just the ordered list of names: a label's id
+/// is its index in that list, and the reverse lookup is rebuilt on load.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(from = "Vec<String>", into = "Vec<String>")]
+pub struct LabelDictionary {
+    /// `names[i]` is the label carrying `LabelId(i as u32)`. Append-only.
+    names: Vec<String>,
+    /// Reverse index (name -> id). Derived from `names`, never serialised.
+    ids: BTreeMap<String, LabelId>,
+}
+
+impl LabelDictionary {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Resolve a name to its id, minting a fresh one on first sight.
+    ///
+    /// Idempotent: interning the same name twice yields the same id.
+    pub fn intern(&mut self, name: &str) -> LabelId {
+        if let Some(id) = self.ids.get(name) {
+            return *id;
+        }
+        let id = LabelId(self.names.len() as u32);
+        self.names.push(name.to_string());
+        self.ids.insert(name.to_string(), id);
+        id
+    }
+
+    /// Resolve a name to its id without minting one.
+    pub fn id(&self, name: &str) -> Option<LabelId> {
+        self.ids.get(name).copied()
+    }
+
+    /// Resolve an id back to its label name.
+    pub fn name(&self, id: LabelId) -> Option<&str> {
+        self.names.get(id.0 as usize).map(String::as_str)
+    }
+
+    pub fn len(&self) -> usize {
+        self.names.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.names.is_empty()
+    }
+
+    /// Iterate `(id, name)` pairs in id order.
+    pub fn iter(&self) -> impl Iterator<Item = (LabelId, &str)> {
+        self.names
+            .iter()
+            .enumerate()
+            .map(|(i, n)| (LabelId(i as u32), n.as_str()))
+    }
+}
+
+impl From<Vec<String>> for LabelDictionary {
+    fn from(names: Vec<String>) -> Self {
+        // Names persist in id order, so the index is the id. Build the reverse
+        // map keeping the first occurrence should a stale list carry a dup.
+        let mut ids = BTreeMap::new();
+        for (i, name) in names.iter().enumerate() {
+            ids.entry(name.clone()).or_insert(LabelId(i as u32));
+        }
+        LabelDictionary { names, ids }
+    }
+}
+
+impl From<LabelDictionary> for Vec<String> {
+    fn from(dict: LabelDictionary) -> Self {
+        dict.names
+    }
+}
+
 /// Definition of a directed edge type between two labels.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct EdgeTypeDef {
@@ -434,5 +519,66 @@ mod tests {
         let bad_json = r#"{"name":"node_id","data_type":"Utf8","nullable":false}"#;
         let res: std::result::Result<PropertyDef, _> = serde_json::from_str(bad_json);
         assert!(res.is_err(), "serde must reject reserved property names");
+    }
+
+    #[test]
+    fn label_dictionary_interns_in_first_seen_order() {
+        let mut dict = LabelDictionary::new();
+        assert!(dict.is_empty());
+        let person = dict.intern("Person");
+        let employee = dict.intern("Employee");
+        assert_eq!(person, LabelId::new(0));
+        assert_eq!(employee, LabelId::new(1));
+        // Idempotent: re-interning returns the same id, no new slot.
+        assert_eq!(dict.intern("Person"), person);
+        assert_eq!(dict.len(), 2);
+    }
+
+    #[test]
+    fn label_dictionary_resolves_both_directions() {
+        let mut dict = LabelDictionary::new();
+        let id = dict.intern("Person");
+        assert_eq!(dict.id("Person"), Some(id));
+        assert_eq!(dict.name(id), Some("Person"));
+        assert_eq!(dict.id("Missing"), None);
+        assert_eq!(dict.name(LabelId::new(99)), None);
+    }
+
+    #[test]
+    fn label_dictionary_iterates_in_id_order() {
+        let mut dict = LabelDictionary::new();
+        dict.intern("A");
+        dict.intern("B");
+        dict.intern("C");
+        let pairs: Vec<_> = dict.iter().collect();
+        assert_eq!(
+            pairs,
+            vec![
+                (LabelId::new(0), "A"),
+                (LabelId::new(1), "B"),
+                (LabelId::new(2), "C"),
+            ]
+        );
+    }
+
+    #[test]
+    fn label_dictionary_round_trips_and_keeps_ids_stable() {
+        let mut dict = LabelDictionary::new();
+        dict.intern("Person");
+        dict.intern("Employee");
+        dict.intern("Manager");
+
+        // On the wire it's just the ordered name list.
+        let json = serde_json::to_string(&dict).unwrap();
+        assert_eq!(json, r#"["Person","Employee","Manager"]"#);
+
+        let round: LabelDictionary = serde_json::from_str(&json).unwrap();
+        assert_eq!(round, dict);
+        // Ids survive the round-trip, and a re-intern of an existing name
+        // reuses its id rather than appending.
+        assert_eq!(round.id("Employee"), Some(LabelId::new(1)));
+        let mut round = round;
+        assert_eq!(round.intern("Person"), LabelId::new(0));
+        assert_eq!(round.intern("New"), LabelId::new(3));
     }
 }


### PR DESCRIPTION
First step of multi-label node support (C1). Adds the shared vocabulary the rest of the series builds on, with no behaviour change yet.

## What

- `LabelId(u32)`: a compact, serde-transparent newtype for a label. It is just a number on the wire, which is what lets a node carry its labels on-row as a packed `List<UInt32>` instead of repeating strings.
- `LabelDictionary`: an append-only `name <-> id` map. Ids are handed out in first-seen order and never reused, so an id minted in one manifest commit means the same label in every later one. It serialises as the ordered list of names (a label's id is its index in that list) and rebuilds the reverse lookup on load.

## Why now

The id-primary multi-label model needs a stable, compact label id and one place to resolve ids back to names. Landing the types on their own keeps each later PR focused: the storage half wires the dictionary into the manifest and adds the `__labels` column on the node row, then query/exec/interfaces follow.

## Tests

5 new unit tests cover interning order, idempotency, both-direction resolution, id-order iteration, and JSON round-trip with id stability. Full workspace suite green (1070 tests).

Part of the C1 multi-label series: **core (this)** -> storage -> query lowering/plan -> executor -> SET/REMOVE -> interfaces -> tests/docs.