### PR TITLE
feat(storage): add inert manifest fields for multi-label nodes

### DIFF
--- a/crates/namidb-query/src/cost/stats.rs
+++ b/crates/namidb-query/src/cost/stats.rs
@@ -584,6 +584,7 @@ mod tests {
             bloom: None,
             unique_property_indices: Vec::new(),
             equality_property_indices: Vec::new(),
+            label_index: None,
         }
     }
 
@@ -619,6 +620,7 @@ mod tests {
             bloom: None,
             unique_property_indices: Vec::new(),
             equality_property_indices: Vec::new(),
+            label_index: None,
         }
     }
 
@@ -652,6 +654,7 @@ mod tests {
             schema,
             ssts: vec![],
             wal_segments: vec![],
+            label_dict: Default::default(),
         };
         let cat = StatsCatalog::from_manifest(&m);
         let p = cat.label("Person").expect("Person seeded");
@@ -693,6 +696,7 @@ mod tests {
             schema,
             ssts: vec![sst1, sst2],
             wal_segments: vec![],
+            label_dict: Default::default(),
         };
         let cat = StatsCatalog::from_manifest(&m);
         let p = cat.label("Person").unwrap();
@@ -745,6 +749,7 @@ mod tests {
             schema,
             ssts: vec![fwd, inv],
             wal_segments: vec![],
+            label_dict: Default::default(),
         };
         let cat = StatsCatalog::from_manifest(&m);
         let k = cat.edge_type("KNOWS").unwrap();
@@ -775,6 +780,7 @@ mod tests {
             schema: Schema::empty(),
             ssts: vec![sst],
             wal_segments: vec![],
+            label_dict: Default::default(),
         };
         let cat = StatsCatalog::from_manifest(&m);
         let u = cat.label("Unknown").unwrap();
@@ -800,6 +806,7 @@ mod tests {
             schema,
             ssts: vec![],
             wal_segments: vec![],
+            label_dict: Default::default(),
         };
         let cat = StatsCatalog::from_manifest(&m);
         let names: Vec<_> = cat.label_names().collect();

--- a/crates/namidb-storage/src/compact.rs
+++ b/crates/namidb-storage/src/compact.rs
@@ -511,6 +511,7 @@ async fn put_node_sst_l1(
         bloom: bloom_descriptor,
         unique_property_indices,
         equality_property_indices,
+        label_index: None,
     };
     Ok((descriptor, wrote_bloom))
 }
@@ -577,6 +578,7 @@ async fn put_edge_sst_l1(
         bloom: bloom_descriptor,
         unique_property_indices: Vec::new(),
         equality_property_indices: Vec::new(),
+        label_index: None,
     };
     Ok((descriptor, wrote_bloom))
 }

--- a/crates/namidb-storage/src/flush.rs
+++ b/crates/namidb-storage/src/flush.rs
@@ -606,6 +606,7 @@ fn prepare_node_pending(
         bloom: bloom_descriptor,
         unique_property_indices,
         equality_property_indices,
+        label_index: None,
     };
 
     Ok(PendingSst {
@@ -823,6 +824,7 @@ fn prepare_edge_pending(
         bloom: bloom_descriptor,
         unique_property_indices: Vec::new(),
         equality_property_indices: Vec::new(),
+        label_index: None,
     };
 
     PendingSst {

--- a/crates/namidb-storage/src/manifest.rs
+++ b/crates/namidb-storage/src/manifest.rs
@@ -28,7 +28,7 @@ use serde::{Deserialize, Serialize};
 use tracing::{debug, instrument, warn};
 use uuid::Uuid;
 
-use namidb_core::Schema;
+use namidb_core::{LabelDictionary, Schema};
 
 use crate::error::{Error, Result};
 use crate::fence::{Epoch, WriterFence};
@@ -57,6 +57,14 @@ pub struct Manifest {
     /// flushed into SSTs yet).
     #[serde(default)]
     pub wal_segments: Vec<WalSegmentDescriptor>,
+    /// Namespace-wide dictionary mapping every label name to a stable,
+    /// compact [`LabelId`](namidb_core::LabelId). A multi-label node carries
+    /// its labels on-row as packed `LabelId`s; this is the source of truth
+    /// that resolves them back to names. Append-only, cloned forward on every
+    /// commit. Empty for older manifests (`serde(default)` round-trips them
+    /// unchanged).
+    #[serde(default)]
+    pub label_dict: LabelDictionary,
 }
 
 impl Manifest {
@@ -70,6 +78,7 @@ impl Manifest {
             schema: Schema::empty(),
             ssts: Vec::new(),
             wal_segments: Vec::new(),
+            label_dict: LabelDictionary::new(),
         }
     }
 
@@ -85,6 +94,7 @@ impl Manifest {
             schema: self.schema.clone(),
             ssts: self.ssts.clone(),
             wal_segments: self.wal_segments.clone(),
+            label_dict: self.label_dict.clone(),
         }
     }
 }
@@ -214,6 +224,15 @@ pub struct SstDescriptor {
     // SSTs and older manifests (`serde(default)`).
     #[serde(default)]
     pub equality_property_indices: Vec<EqualityIndexDescriptor>,
+    // Label-index side-car pointer (multi-label nodes). Once node SSTs stop
+    // being partitioned by label, `scan_label(L)` can no longer just read the
+    // SSTs whose scope is `L`; instead each node SST ships one sidecar mapping
+    // `LabelId → posting list of NodeIds` so the reader can union across SSTs
+    // and confirm by id. `None` for edge SSTs and for legacy single-label node
+    // SSTs (whose `scope` still names their one label); `serde(default)` keeps
+    // older manifests loading unchanged.
+    #[serde(default)]
+    pub label_index: Option<LabelIndexDescriptor>,
 }
 
 /// Side-car pointer for a single `(SST, unique property)` pair. The
@@ -252,6 +271,27 @@ pub struct EqualityIndexDescriptor {
     pub size_bytes: u64,
     /// Number of distinct values in the sidecar (posting-list keys).
     pub distinct_values: u64,
+}
+
+/// Side-car pointer for a node SST's label index. The sidecar body is a
+/// bincode-serialised `BTreeMap<u32, Vec<[u8; 16]>>` — a posting list of
+/// NodeIds per [`LabelId`](namidb_core::LabelId), with both the keys and each
+/// posting list sorted. It replaces the old "the SST partition IS the label
+/// index" arrangement once a single node SST spans every label: the reader
+/// resolves `scan_label(L)` by unioning the posting lists for `L`'s id across
+/// all node SSTs (plus the memtable) and confirming each candidate by id.
+/// Tombstones contribute nothing; last-LSN-wins at confirm time handles
+/// removal.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct LabelIndexDescriptor {
+    /// Object-store path relative to the namespace prefix.
+    pub path: String,
+    /// On-disk size of the sidecar body.
+    pub size_bytes: u64,
+    /// Number of distinct labels (posting-list keys) in the sidecar.
+    pub label_count: u64,
+    /// Total number of `(label, NodeId)` postings across every key.
+    pub posting_count: u64,
 }
 
 /// JSON serde helper: `[u8; 16]` ↔ base64-standard string.
@@ -953,6 +993,7 @@ mod tests {
             }),
             unique_property_indices: Vec::new(),
             equality_property_indices: Vec::new(),
+            label_index: None,
         }
     }
 
@@ -985,6 +1026,7 @@ mod tests {
             bloom: None, // small SST → no side-car
             unique_property_indices: Vec::new(),
             equality_property_indices: Vec::new(),
+            label_index: None,
         }
     }
 
@@ -1032,6 +1074,32 @@ mod tests {
         let bytes = serde_json::to_vec(&m).unwrap();
         let back: Manifest = serde_json::from_slice(&bytes).unwrap();
         assert_eq!(m, back);
+    }
+
+    #[test]
+    fn manifest_without_multilabel_fields_loads_with_defaults() {
+        // Back-compat contract of the inert prep step: a manifest written
+        // before multi-label has no top-level `label_dict`, and its SST
+        // descriptors have no `label_index`. Both must default cleanly (empty
+        // dict / None) via `serde(default)` so existing namespaces keep
+        // loading unchanged.
+        let mut m = Manifest::empty(Epoch::ZERO, Uuid::now_v7());
+        m.ssts.push(sample_node_descriptor());
+        let mut value = serde_json::to_value(&m).unwrap();
+        let obj = value.as_object_mut().unwrap();
+        obj.remove("label_dict");
+        for sst in obj["ssts"].as_array_mut().unwrap() {
+            sst.as_object_mut().unwrap().remove("label_index");
+        }
+        let back: Manifest = serde_json::from_value(value).unwrap();
+        assert!(
+            back.label_dict.is_empty(),
+            "missing label_dict must default empty"
+        );
+        assert!(
+            back.ssts[0].label_index.is_none(),
+            "missing label_index must default to None"
+        );
     }
 
     #[test]

--- a/crates/namidb-storage/src/read.rs
+++ b/crates/namidb-storage/src/read.rs
@@ -4221,6 +4221,7 @@ mod tests {
             bloom: Some(bloom_desc),
             unique_property_indices: Vec::new(),
             equality_property_indices: Vec::new(),
+            label_index: None,
         };
 
         let empty = Memtable::new();
@@ -4245,6 +4246,7 @@ mod tests {
             bloom: None,
             unique_property_indices: Vec::new(),
             equality_property_indices: Vec::new(),
+            label_index: None,
             ..descriptor.clone()
         };
         assert!(snap
@@ -4573,6 +4575,7 @@ mod tests {
             bloom: None::<BloomDescriptor>,
             unique_property_indices: Vec::new(),
             equality_property_indices: Vec::new(),
+            label_index: None,
         });
         let mt = Memtable::new();
         let view = mt.snapshot_view();


### PR DESCRIPTION
Prep step (PR2.0) for the multi-label storage rewrite. Adds the manifest-level structures the rewrite will populate, all as `serde(default)` no-ops, so this lands green on its own and keeps the upcoming atomic format-flip commit focused on behaviour.

## What

- `Manifest.label_dict: LabelDictionary` — the namespace-wide `name <-> id` dictionary (from #56) that a multi-label node's on-row `LabelId`s resolve against. Cloned forward on each commit, like `schema`.
- `SstDescriptor.label_index: Option<LabelIndexDescriptor>` — pointer to a per-SST `label -> node ids` sidecar. Replaces "the SST partition *is* the label index" once a single node SST spans every label. `None` for edges and legacy single-label node SSTs.
- `LabelIndexDescriptor` — the sidecar descriptor (path/size/label_count/posting_count), mirroring `EqualityIndexDescriptor`.

## Why inert / why now

The storage core (memtable re-key, ingest, flush, sst, manifest, compact, read) is internally atomic: dropping `label` from `MemKey::Node` breaks bucketing, every read-path match, and every test at once. The only cleanly separable seams are (a) this inert manifest prep and (b) the `NodeView` signature flip. Landing them first shrinks and de-risks the atomic commit.

Nothing populates or reads the new fields yet.

## Tests

`manifest_without_multilabel_fields_loads_with_defaults` asserts a manifest serialized before multi-label (no `label_dict`, SSTs with no `label_index`) still deserializes, defaulting the dict empty and the index to `None`. Full workspace suite green (0 failures).

Series: core #56 (merged) -> **storage prep (this)** -> NodeView flip -> atomic format core -> query -> exec -> interfaces -> docs.