### PR TITLE
refactor(storage): make NodeView carry a set of labels

### DIFF
--- a/crates/namidb-query/src/exec/value.rs
+++ b/crates/namidb-query/src/exec/value.rs
@@ -89,9 +89,13 @@ pub struct RelValue {
 
 impl From<NodeView> for NodeValue {
     fn from(v: NodeView) -> Self {
+        // NodeValue is still single-label here; collapse the set to its
+        // representative (lowest) label. The NodeValue multi-label flip is a
+        // later step in the series.
+        let label = v.labels.into_iter().next().unwrap_or_default();
         NodeValue {
             id: v.id,
-            label: v.label,
+            label,
             properties: v
                 .properties
                 .into_iter()

--- a/crates/namidb-storage/src/node_cache.rs
+++ b/crates/namidb-storage/src/node_cache.rs
@@ -205,7 +205,7 @@ impl NodeViewCache {
     }
 }
 
-/// Conservative size estimate for a [`CachedNodeView`]. Counts label +
+/// Conservative size estimate for a [`CachedNodeView`]. Counts labels +
 /// property name + per-value allowance + invariant overhead. Used for
 /// budget accounting — exact tracking would require deep `Value` walks
 /// which are not worth it.
@@ -218,14 +218,14 @@ fn approx_size(view: &CachedNodeView) -> usize {
                 .keys()
                 .map(|k| k.capacity() + 64) // 64 = rough Value enum size
                 .sum();
-            v.label.capacity() + prop_bytes + 128
+            v.labels.iter().map(|l| l.capacity()).sum::<usize>() + prop_bytes + 128
         }
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use std::collections::BTreeMap;
+    use std::collections::{BTreeMap, BTreeSet};
 
     use namidb_core::Value;
     use uuid::Uuid;
@@ -243,7 +243,7 @@ mod tests {
         props.insert("name".to_string(), Value::Str(name.into()));
         NodeView {
             id: nid(1),
-            label: "Person".into(),
+            labels: BTreeSet::from(["Person".to_string()]),
             properties: props,
             lsn: 10,
             schema_version: 1,

--- a/crates/namidb-storage/src/read.rs
+++ b/crates/namidb-storage/src/read.rs
@@ -43,7 +43,7 @@
 //! relevant for selective predicate push-down rather than
 //! correctness.
 
-use std::collections::{BTreeMap, HashMap};
+use std::collections::{BTreeMap, BTreeSet, HashMap};
 use std::sync::{Arc, Mutex};
 
 use arrow_array::RecordBatch;
@@ -80,10 +80,15 @@ use crate::sst::nodes::{
 use crate::sst::predicates::{eval_against_value, ScanPredicate};
 
 /// Projection of a node row materialised by the read path.
+///
+/// A node carries a *set* of labels. Today the set always has exactly one
+/// member (the SST scope it was read from); multi-label nodes will populate it
+/// from the on-row label column in a later step. Storing a set now lets the
+/// query layer match `(n:A:B)` as set-membership without another type flip.
 #[derive(Debug, Clone, PartialEq)]
 pub struct NodeView {
     pub id: NodeId,
-    pub label: String,
+    pub labels: BTreeSet<String>,
     pub properties: BTreeMap<String, Value>,
     pub lsn: u64,
     pub schema_version: u64,
@@ -1449,7 +1454,7 @@ impl<'mt> Snapshot<'mt> {
                     }
                     let view = NodeView {
                         id: row_id,
-                        label: label.to_string(),
+                        labels: BTreeSet::from([label.to_string()]),
                         properties,
                         lsn,
                         schema_version: sv_col.value(row),
@@ -2339,7 +2344,7 @@ fn node_view_from_payload(
     let rec = NodeWriteRecord::decode(payload)?;
     Ok(NodeView {
         id,
-        label,
+        labels: BTreeSet::from([label]),
         properties: rec.properties,
         lsn,
         schema_version: rec.schema_version,
@@ -2441,7 +2446,7 @@ fn find_node_row_in_batches(
                 lsn,
                 Some(NodeView {
                     id: target,
-                    label: label.to_string(),
+                    labels: BTreeSet::from([label.to_string()]),
                     properties,
                     lsn,
                     schema_version,
@@ -2524,7 +2529,7 @@ fn batch_harvest_node_rows(
                 let id = NodeId::from_uuid(Uuid::from_bytes(row_id));
                 Some(NodeView {
                     id,
-                    label: label.to_string(),
+                    labels: BTreeSet::from([label.to_string()]),
                     properties,
                     lsn,
                     schema_version,


### PR DESCRIPTION
PR2.1 of the multi-label series. Flips the read-path node projection to a *set* of labels, ahead of the id-primary storage core. Pure structural change, no behaviour difference.

## What

- `NodeView.label: String` -> `labels: BTreeSet<String>`.
- Every construction site fills the set with the single label it reads today (the SST scope / memtable key), so a node still has exactly one label end to end.
- The `NodeView -> NodeValue` conversion collapses the set back to its representative (lowest) label, since the query-runtime value (`NodeValue`) stays single-label until a later step.
- `node_cache` weight accounting sums label capacities instead of one string.

## Why now

The atomic id-primary core (next PR) is large; landing the type flip on its own keeps that diff focused on behaviour rather than mechanical signature churn. The compiler confirmed exactly one consumer outside storage (`exec/value.rs`), so the surface is tiny.

## Tests

Parity: the full workspace suite passes unchanged (1025 tests, 0 failures). Since `{scope}` is the one label today, behaviour is identical on current single-label data — that equality is the proof this is a pure flip.

Series: core #56 -> storage prep #57 -> **NodeView set (this)** -> atomic id-primary core -> query -> exec -> interfaces -> docs.