### PR TITLE
fix(py): adapt Python bindings to the NodeView label set

### DIFF
--- a/crates/namidb-py/src/lib.rs
+++ b/crates/namidb-py/src/lib.rs
@@ -796,7 +796,13 @@ fn value_to_py(py: Python<'_>, v: &Value) -> PyResult<Py<PyAny>> {
 fn node_view_to_py<'py>(py: Python<'py>, v: &NodeView) -> PyResult<Bound<'py, PyDict>> {
     let d = PyDict::new_bound(py);
     d.set_item("id", v.id.to_string())?;
-    d.set_item("label", &v.label)?;
+    // NodeView carries a label set now; emit the representative label to keep
+    // the single-label Python contract until the plural switch later in the
+    // multi-label series.
+    d.set_item(
+        "label",
+        v.labels.iter().next().map(String::as_str).unwrap_or(""),
+    )?;
     d.set_item("lsn", v.lsn)?;
     d.set_item("schema_version", v.schema_version)?;
     let props = PyDict::new_bound(py);
@@ -1065,7 +1071,7 @@ fn build_node_views_table(
 
     let labels = PyList::empty_bound(py);
     for v in views {
-        labels.append(&v.label)?;
+        labels.append(v.labels.iter().next().map(String::as_str).unwrap_or(""))?;
     }
     arrays.append(pyarrow.call_method1("array", (labels,))?)?;
 


### PR DESCRIPTION
Follow-up to #58. That PR flipped `NodeView.label: String` -> `labels: BTreeSet<String>`, but the Python bindings (`crates/namidb-py`) still read `.label` and failed to compile.

The standard CI gates run with `--exclude namidb-py` (the crate links against libpython and is built separately by the wheel job via maturin), so the break only showed up in the wheel builds, after merge. `cargo check -p namidb-py` reproduces it locally without linking.

## Fix

The two `NodeView` read sites (`node_view_to_py` dict key, and the Arrow `label` column builder) now emit the representative (lowest) label from the set. `node_value_to_py` reads `NodeValue.label`, which is unchanged, so it was already fine.

This keeps the single-label Python contract intact (today every node has one label, so the representative label is that label). The switch to a plural `labels` shape lands with the interface step of the multi-label series.

## Verification

`cargo check -p namidb-py` clean. The wheel builds (which also run the pytest suite) are the real gate here and will confirm.