### PR TITLE
feat(storage): id-primary multi-label node core (PR2.2)

### DIFF
--- a/crates/namidb-bench/src/loader.rs
+++ b/crates/namidb-bench/src/loader.rs
@@ -168,6 +168,7 @@ fn load_persons(writer: &mut WriterSession, path: &Path) -> Result<()> {
             &NodeWriteRecord {
                 properties: props,
                 schema_version: 1,
+                ..Default::default()
             },
         )?;
     }
@@ -197,6 +198,7 @@ fn load_posts(writer: &mut WriterSession, path: &Path) -> Result<()> {
             &NodeWriteRecord {
                 properties: props,
                 schema_version: 1,
+                ..Default::default()
             },
         )?;
     }
@@ -226,6 +228,7 @@ fn load_comments(writer: &mut WriterSession, path: &Path) -> Result<()> {
             &NodeWriteRecord {
                 properties: props,
                 schema_version: 1,
+                ..Default::default()
             },
         )?;
     }

--- a/crates/namidb-markdown/src/load.rs
+++ b/crates/namidb-markdown/src/load.rs
@@ -435,6 +435,7 @@ async fn load_graph_inner(
         let record = NodeWriteRecord {
             properties: note.properties.clone(),
             schema_version: 1,
+            ..Default::default()
         };
         writer.upsert_node(opts.label.clone(), note.id, &record)?;
         outcome.notes_loaded += 1;
@@ -453,6 +454,7 @@ async fn load_graph_inner(
         let record = NodeWriteRecord {
             properties: props,
             schema_version: 1,
+            ..Default::default()
         };
         writer.upsert_node(opts.label.clone(), *id, &record)?;
         outcome.placeholders_created += 1;
@@ -488,6 +490,7 @@ async fn load_graph_inner(
         let record = NodeWriteRecord {
             properties: props,
             schema_version: 1,
+            ..Default::default()
         };
         writer.upsert_node(TAG_LABEL, *tag_id, &record)?;
         outcome.tags_loaded += 1;

--- a/crates/namidb-py/src/lib.rs
+++ b/crates/namidb-py/src/lib.rs
@@ -91,6 +91,7 @@ impl Client {
         let record = NodeWriteRecord {
             properties: props,
             schema_version: 0,
+            ..Default::default()
         };
         self.runtime.block_on(async {
             let mut session = self.session.lock().await;
@@ -285,6 +286,7 @@ impl Client {
                 let record = NodeWriteRecord {
                     properties: props.clone(),
                     schema_version: 0,
+                    ..Default::default()
                 };
                 guard
                     .upsert_node(&label, *id, &record)

--- a/crates/namidb-query/src/cost/stats.rs
+++ b/crates/namidb-query/src/cost/stats.rs
@@ -14,7 +14,7 @@
 
 use std::collections::BTreeMap;
 
-use namidb_core::Schema;
+use namidb_core::{LabelDictionary, LabelId, Schema};
 use namidb_storage::manifest::KindSpecificStats;
 use namidb_storage::sst::hll::Hll;
 use namidb_storage::sst::stats::{HllSketchBytes, StatScalar};
@@ -176,6 +176,7 @@ impl StatsCatalog {
                 SstKind::Nodes => merge_node_sst(
                     sst,
                     &m.schema,
+                    &m.label_dict,
                     &mut labels,
                     &mut total_nodes,
                     &mut hll_merge,
@@ -303,46 +304,97 @@ impl StatsCatalog {
 fn merge_node_sst(
     sst: &SstDescriptor,
     schema: &Schema,
+    label_dict: &LabelDictionary,
     labels: &mut BTreeMap<String, LabelStats>,
     total_nodes: &mut u64,
     hll_merge: &mut BTreeMap<(String, String), HllMerge>,
 ) {
-    let label = &sst.scope;
     let tombstones = match sst.kind_specific {
         KindSpecificStats::Nodes { tombstone_count } => tombstone_count,
         _ => 0,
     };
     let live = sst.row_count.saturating_sub(tombstones);
-    let entry = labels.entry(label.clone()).or_insert_with(|| LabelStats {
-        name: label.clone(),
-        ..Default::default()
-    });
-    entry.node_count = entry.node_count.saturating_add(live);
+    // `total_nodes` is the distinct node-row count (one row per node) — a
+    // multi-label node counts once here even though it appears under each of
+    // its labels below. This keeps `node_count(L) <= total_nodes` for every L.
     *total_nodes = total_nodes.saturating_add(live);
 
-    for col in &sst.property_stats {
-        let logical_name = strip_prop_prefix(&col.name).to_string();
-        // Some columns are emitted under the schema-declared name; the
-        // declared LabelDef is authoritative for whether the property
-        // is known. We still ingest unknown columns to keep the
-        // optimizer robust against schemaless ingest.
-        let _declared = schema.label(label).map(|l| {
-            l.properties
-                .iter()
-                .any(|p| p.name == logical_name || col.name == format!("prop_{}", p.name))
+    // Per-label `node_count`. id-primary node SSTs are no longer partitioned by
+    // label (`scope == ""`); they carry per-label live counts in the
+    // label-index sidecar descriptor, keyed by `LabelId`. Sum those across SSTs,
+    // resolving each id through the namespace dictionary. Legacy single-label
+    // SSTs predate the sidecar (`label_index == None`) and name their one label
+    // in `scope`, so attribute `live` there.
+    match sst.label_index.as_ref() {
+        Some(li) if !li.per_label_counts.is_empty() => {
+            for &(lid, count) in &li.per_label_counts {
+                let Some(name) = label_dict.name(LabelId(lid)) else {
+                    // Id absent from the dictionary (corrupt/forward-version
+                    // manifest): we can't name the label, so skip rather than
+                    // bucket it under a wrong name.
+                    continue;
+                };
+                let entry = labels
+                    .entry(name.to_string())
+                    .or_insert_with(|| LabelStats {
+                        name: name.to_string(),
+                        ..Default::default()
+                    });
+                entry.node_count = entry.node_count.saturating_add(count);
+            }
+        }
+        _ => {
+            // Legacy single-label SSTs (and the brief pre-release window where
+            // id-primary SSTs shipped a label index without `per_label_counts`)
+            // land here. For a named scope this is exact; for an empty scope the
+            // count is parked under "" until the next flush/compaction rewrites
+            // the descriptor with `per_label_counts`. Only matters for in-flight
+            // dev data on this branch — no released manifest has an empty scope.
+            let label = &sst.scope;
+            let entry = labels.entry(label.clone()).or_insert_with(|| LabelStats {
+                name: label.clone(),
+                ..Default::default()
+            });
+            entry.node_count = entry.node_count.saturating_add(live);
+        }
+    }
+
+    // Per-column property stats stay keyed by `scope`. Under id-primary every
+    // property rides in one `__overflow_json` column, so `property_stats` is
+    // empty and this is a no-op (min/max/ndv stay `None`, and the optimizer
+    // uses its documented fallbacks); per-label column stats return with the
+    // typed-column layout. Legacy typed-column SSTs still populate their one
+    // label's stats here via `scope`.
+    if !sst.property_stats.is_empty() {
+        let label = &sst.scope;
+        let entry = labels.entry(label.clone()).or_insert_with(|| LabelStats {
+            name: label.clone(),
+            ..Default::default()
         });
+        for col in &sst.property_stats {
+            let logical_name = strip_prop_prefix(&col.name).to_string();
+            // Some columns are emitted under the schema-declared name; the
+            // declared LabelDef is authoritative for whether the property
+            // is known. We still ingest unknown columns to keep the
+            // optimizer robust against schemaless ingest.
+            let _declared = schema.label(label).map(|l| {
+                l.properties
+                    .iter()
+                    .any(|p| p.name == logical_name || col.name == format!("prop_{}", p.name))
+            });
 
-        let prop = entry.properties.entry(logical_name.clone()).or_default();
-        prop.null_count = prop.null_count.saturating_add(col.null_count);
-        prop.min = merge_min(prop.min.take(), col.min.clone());
-        prop.max = merge_max(prop.max.take(), col.max.clone());
+            let prop = entry.properties.entry(logical_name.clone()).or_default();
+            prop.null_count = prop.null_count.saturating_add(col.null_count);
+            prop.min = merge_min(prop.min.take(), col.min.clone());
+            prop.max = merge_max(prop.max.take(), col.max.clone());
 
-        absorb_hll_sketch(
-            hll_merge,
-            label.clone(),
-            logical_name,
-            col.ndv_estimate.as_ref(),
-        );
+            absorb_hll_sketch(
+                hll_merge,
+                label.clone(),
+                logical_name,
+                col.ndv_estimate.as_ref(),
+            );
+        }
     }
 }
 

--- a/crates/namidb-query/src/exec/writer.rs
+++ b/crates/namidb-query/src/exec/writer.rs
@@ -488,6 +488,7 @@ fn apply_create(
                 let record = NodeWriteRecord {
                     properties: core_props,
                     schema_version: 1,
+                    ..Default::default()
                 };
                 writer
                     .upsert_node(label.clone(), id, &record)
@@ -606,6 +607,7 @@ fn apply_set(
                     let record = NodeWriteRecord {
                         properties: core_props,
                         schema_version: 1,
+                        ..Default::default()
                     };
                     writer
                         .upsert_node(n.label.clone(), n.id, &record)
@@ -687,6 +689,7 @@ fn apply_remove(
                 let record = NodeWriteRecord {
                     properties: core_props,
                     schema_version: 1,
+                    ..Default::default()
                 };
                 writer
                     .upsert_node(n.label.clone(), n.id, &record)

--- a/crates/namidb-query/src/profile.rs
+++ b/crates/namidb-query/src/profile.rs
@@ -188,6 +188,7 @@ mod tests {
                 &NodeWriteRecord {
                     properties: p,
                     schema_version: 1,
+                    ..Default::default()
                 },
             )
             .unwrap();
@@ -246,6 +247,7 @@ mod tests {
                     &NodeWriteRecord {
                         properties: p,
                         schema_version: 1,
+                        ..Default::default()
                     },
                 )
                 .unwrap();

--- a/crates/namidb-query/tests/cost_smoke.rs
+++ b/crates/namidb-query/tests/cost_smoke.rs
@@ -264,6 +264,166 @@ async fn catalog_from_manifest_captures_label_counts() {
 }
 
 #[tokio::test]
+async fn catalog_counts_multi_label_nodes_under_each_label() {
+    // Multi-label core (the reason this branch exists): a node carrying
+    // {Person, Admin} must count under BOTH labels, while `total_nodes` counts
+    // it once. id-primary node SSTs have an empty scope, so per-label
+    // `node_count` is recovered from the label-index posting counts — a path
+    // the single-label micro-graph never exercises.
+    let mut writer = WriterSession::open(store(), paths("ml-counts"))
+        .await
+        .unwrap();
+    // 3 plain :Person, 2 :Person:Admin, 1 plain :Admin → 6 distinct nodes.
+    for i in 0..3 {
+        writer
+            .upsert_node_with_labels(
+                ["Person".to_string()],
+                NodeId::new(),
+                &person(&format!("p{i}"), "x", 30),
+            )
+            .unwrap();
+    }
+    for i in 0..2 {
+        writer
+            .upsert_node_with_labels(
+                ["Person".to_string(), "Admin".to_string()],
+                NodeId::new(),
+                &person(&format!("pa{i}"), "x", 30),
+            )
+            .unwrap();
+    }
+    writer
+        .upsert_node_with_labels(["Admin".to_string()], NodeId::new(), &person("a0", "x", 30))
+        .unwrap();
+    writer.flush(schema()).await.expect("flush");
+
+    let snap = writer.snapshot();
+    let cat = StatsCatalog::from_manifest(&snap.manifest().manifest);
+
+    let person = cat.label("Person").expect("Person present");
+    let admin = cat.label("Admin").expect("Admin present");
+    assert_eq!(person.node_count, 5, "3 plain Person + 2 Person+Admin");
+    assert_eq!(admin.node_count, 3, "2 Person+Admin + 1 plain Admin");
+    // Distinct node rows: each counted once, including the multi-label ones.
+    assert_eq!(cat.total_nodes(), 6, "6 distinct nodes");
+    // The per-label populations sum to more than the distinct count precisely
+    // because two nodes are double-labelled...
+    assert!(
+        person.node_count + admin.node_count > cat.total_nodes(),
+        "multi-label overlap should make the per-label sum exceed total_nodes"
+    );
+    // ...yet each label's population stays bounded by the distinct count, the
+    // invariant every selectivity ratio in the cost model relies on.
+    assert!(person.node_count <= cat.total_nodes());
+    assert!(admin.node_count <= cat.total_nodes());
+}
+
+#[tokio::test]
+async fn per_label_counts_survive_compaction() {
+    // Compaction rebuilds the label-index sidecar (with per-label counts) on the
+    // merged L1 SST. Without that, post-compaction `from_manifest` would read an
+    // empty scope and reset every per-label `node_count` to 0 — reviving the
+    // optimizer-pruning regression after the first maintenance tick.
+    let mut writer = WriterSession::open(store(), paths("ml-compact"))
+        .await
+        .unwrap();
+    // Two flushed batches → two L0 node SSTs in the (empty-scope) node bucket.
+    for batch in 0..2 {
+        for i in 0..3 {
+            let label = if i == 0 {
+                vec!["Person".to_string(), "Admin".to_string()]
+            } else {
+                vec!["Person".to_string()]
+            };
+            writer
+                .upsert_node_with_labels(
+                    label,
+                    NodeId::new(),
+                    &person(&format!("b{batch}n{i}"), "x", 30),
+                )
+                .unwrap();
+        }
+        writer.flush(schema()).await.expect("flush");
+    }
+
+    // 6 Person (2 of them also Admin), 2 Admin, 6 distinct nodes — before compaction.
+    let pre = StatsCatalog::from_manifest(&writer.snapshot().manifest().manifest);
+    assert_eq!(pre.label("Person").unwrap().node_count, 6);
+    assert_eq!(pre.label("Admin").unwrap().node_count, 2);
+    assert_eq!(pre.total_nodes(), 6);
+
+    writer.compact_l0(&schema()).await.expect("compact");
+
+    // Counts must be unchanged after the L0s collapse into one L1 SST.
+    let post = StatsCatalog::from_manifest(&writer.snapshot().manifest().manifest);
+    assert_eq!(
+        post.label("Person").unwrap().node_count,
+        6,
+        "Person count must survive compaction"
+    );
+    assert_eq!(
+        post.label("Admin").unwrap().node_count,
+        2,
+        "Admin count must survive compaction"
+    );
+    assert_eq!(post.total_nodes(), 6, "total_nodes must survive compaction");
+}
+
+#[tokio::test]
+async fn multi_label_scan_with_projection_pushdown_returns_correct_rows() {
+    // End-to-end guard for the __labels-in-projection fix on the multi-label
+    // path. A projected scan that elides __labels would make every row decode
+    // an empty label set, so the `:Admin` / `:Person` filter would drop all of
+    // them and the optimized query would return 0 rows.
+    let mut writer = WriterSession::open(store(), paths("ml-proj"))
+        .await
+        .unwrap();
+    // alice & bob are :Person:Admin; carol & dave are :Person only.
+    let mut mk = |labels: &[&str], name: &str| {
+        writer
+            .upsert_node_with_labels(
+                labels.iter().map(|s| s.to_string()),
+                NodeId::new(),
+                &person(name, "x", 30),
+            )
+            .unwrap();
+    };
+    mk(&["Person", "Admin"], "Alice");
+    mk(&["Person", "Admin"], "Bob");
+    mk(&["Person"], "Carol");
+    mk(&["Person"], "Dave");
+    writer.flush(schema()).await.expect("flush");
+    let snap = writer.snapshot();
+    let catalog = StatsCatalog::from_manifest(&snap.manifest().manifest);
+
+    for (q_text, expected) in [
+        ("MATCH (a:Admin) RETURN a.firstName", 2usize),
+        ("MATCH (a:Person) RETURN a.firstName", 4usize),
+        (
+            "MATCH (a:Admin) WHERE a.firstName = 'Alice' RETURN a.firstName",
+            1usize,
+        ),
+    ] {
+        let q = parse(q_text).unwrap();
+        let raw = lower(&q).unwrap();
+        let opt = optimize(raw.clone(), &catalog);
+        let rows_raw = execute(&raw, &snap, &Params::default()).await.unwrap();
+        let rows_opt = execute(&opt, &snap, &Params::default()).await.unwrap();
+        assert_eq!(
+            rows_opt.len(),
+            expected,
+            "optimized `{q_text}` should return {expected} rows, got {}",
+            rows_opt.len()
+        );
+        assert_eq!(
+            rows_raw.len(),
+            rows_opt.len(),
+            "raw/opt parity for `{q_text}`"
+        );
+    }
+}
+
+#[tokio::test]
 async fn catalog_from_manifest_captures_edge_avg_degree() {
     let mut writer = WriterSession::open(store(), paths("stats02"))
         .await
@@ -292,45 +452,48 @@ async fn property_stats_are_present_after_flush() {
     let cat = StatsCatalog::from_manifest(&snap.manifest().manifest);
 
     let p = cat.label("Person").unwrap();
-    // The writer now reads Parquet footer column statistics and ships
-    // real min/max/null_count to the catalog. Ages in the micro-graph
-    // range 25..=40 (Bob=25, Eve=40).
+    // Each declared property is still present as a catalog entry (seeded from
+    // the schema), so the optimizer knows the column exists. Under the
+    // id-primary layout every property rides in a single `__overflow_json`
+    // column rather than a typed `prop_*` column, so the writer emits no
+    // per-column Parquet statistics: min/max/ndv come back `None` and the
+    // optimizer uses its documented fallbacks. Precise per-label column stats
+    // (min/max=25/40, firstName=Alice..Frank, real ndv) return with the
+    // typed-column layout (RFC-pending); this test guards the current contract.
     assert!(p.properties.contains_key("age"), "age stats present");
     assert!(p.properties.contains_key("firstName"));
     assert!(p.properties.contains_key("lastName"));
     let age = &p.properties["age"];
-    match (&age.min, &age.max) {
-        (
-            Some(namidb_storage::sst::stats::StatScalar::Int64(mn)),
-            Some(namidb_storage::sst::stats::StatScalar::Int64(mx)),
-        ) => {
-            assert_eq!(*mn, 25, "Bob (25) is the youngest");
-            assert_eq!(*mx, 40, "Eve (40) is the oldest");
-        }
-        other => panic!("unexpected age stats: {:?}", other),
-    }
-    assert_eq!(age.null_count, 0, "no NULL ages in the fixture");
+    assert!(
+        age.min.is_none() && age.max.is_none(),
+        "id-primary: no per-column min/max until the typed-column layout, got {:?}/{:?}",
+        age.min,
+        age.max
+    );
+    assert!(age.ndv.is_none(), "id-primary: no per-column ndv yet");
+    // No per-column null statistics either: null_count stays 0 and
+    // non_null_count backfills to the label's node_count (6 Persons).
+    assert_eq!(
+        age.null_count, 0,
+        "no per-column null stats under id-primary"
+    );
+    assert_eq!(age.non_null_count, 6, "non_null backfills to node_count");
 
-    // firstName covers Alice..Frank lexicographically.
     let first = &p.properties["firstName"];
-    match (&first.min, &first.max) {
-        (
-            Some(namidb_storage::sst::stats::StatScalar::Utf8(mn)),
-            Some(namidb_storage::sst::stats::StatScalar::Utf8(mx)),
-        ) => {
-            assert_eq!(mn, "Alice");
-            assert_eq!(mx, "Frank");
-        }
-        other => panic!("unexpected firstName stats: {:?}", other),
-    }
+    assert!(
+        first.min.is_none() && first.max.is_none(),
+        "id-primary: no per-column min/max for firstName yet"
+    );
 }
 
 #[tokio::test]
 async fn filter_estimate_uses_real_min_max_after_writer_fix() {
-    // With real min/max, range selectivity uses the precise
-    // formula (lit-min)/(max-min) instead of falling back to 0.33.
-    // Ages min=25, max=40; lit=30 → below=(30-25)/(40-25)=0.333.
-    // Gt → 1-below = 0.666... → 6 * 0.667 = 4.0.
+    // Range selectivity with real min/max would use the precise formula
+    // (lit-min)/(max-min): ages min=25,max=40,lit=30 → 6 * 0.667 = 4.0.
+    // Under id-primary there are no per-column min/max (properties live in
+    // `__overflow_json`), so range selectivity falls back to the documented
+    // 0.33 constant → 6 * 0.33 ≈ 1.98. The precise estimate returns with the
+    // typed-column layout; results are unaffected either way.
     let mut writer = WriterSession::open(store(), paths("stats06b"))
         .await
         .unwrap();
@@ -344,11 +507,16 @@ async fn filter_estimate_uses_real_min_max_after_writer_fix() {
     let rows = execute(&plan, &snap, &Params::new()).await.unwrap();
 
     assert_eq!(rows.len(), 3, "Carol(35), Eve(40), Frank(33)");
-    // Estimate ≈ 4.0. Without this, it fell back to 6 * 0.33 = 1.98.
+    // Fallback: 6 * 0.33 ≈ 1.98. The filter still drops the estimate below the
+    // 6-row scan cardinality, which is the property the optimizer relies on.
     assert!(
-        (card.rows - 4.0).abs() < 0.5,
-        "with real min/max, estimate {} should be ~4 (close to actual 3)",
+        (card.rows - 2.0).abs() < 0.6,
+        "fallback range selectivity should give ~2 (6 * 0.33), got {}",
         card.rows
+    );
+    assert!(
+        card.rows < 6.0,
+        "filter must still drop below scan cardinality"
     );
 }
 
@@ -803,28 +971,25 @@ async fn catalog_materializes_real_ndv_after_flush() {
     let cat = StatsCatalog::from_manifest(&snap.manifest().manifest);
 
     let person = cat.label("Person").expect("Person label");
-    // ndv_estimate is populated for every scalar property
-    // declared in the schema.
+    // The HLL pipeline only runs over typed `prop_*` columns. Under id-primary
+    // every property rides in `__overflow_json`, so no sketch is emitted and
+    // `ndv` is `None` for every property; equality/IN selectivity falls back to
+    // the documented constants. Real per-column ndv (≈6 distinct firstNames in
+    // the Alice..Frank fixture) returns with the typed-column layout.
     let first = person
         .properties
         .get("firstName")
         .expect("firstName stats present");
-    let ndv = first.ndv.expect("ndv populated by the HLL pipeline");
-    // 6 distinct firstNames in the fixture (Alice..Frank). HLL with
-    // p=10 has ~3.2 % expected error on 6 items but rounded should be
-    // in [5, 8].
     assert!(
-        (5..=8).contains(&ndv),
-        "firstName ndv {} not close to 6",
-        ndv
+        first.ndv.is_none(),
+        "id-primary: no per-column ndv until the typed-column layout, got {:?}",
+        first.ndv
     );
 
     let age = person.properties.get("age").expect("age stats present");
-    let age_ndv = age.ndv.expect("age ndv populated");
     assert!(
-        (5..=8).contains(&age_ndv),
-        "age ndv {} not close to 6",
-        age_ndv
+        age.ndv.is_none(),
+        "id-primary: no per-column ndv for age yet"
     );
 }
 
@@ -918,10 +1083,15 @@ async fn hash_join_executes_correctly() {
 
 #[tokio::test]
 async fn hash_join_estimate_matches_actual_within_micro_graph() {
-    // HashJoin estimate uses Selinger '79 with real ndv from HLL:
+    // HashJoin uses Selinger '79:
     //   rows = (|build| * |probe|) / max(ndv(build_key), ndv(probe_key))
-    // With ndv(firstName) ≈ 6 and |build| = |probe| = 6, we expect
-    // estimate ≈ 6. Compare to actual rows.
+    // The join key here is the property `firstName`. With a real ndv ≈ 6 the
+    // divisor would tighten the estimate to ≈ 6 (the actual). Under id-primary
+    // `firstName` has no per-column ndv (it lives in `__overflow_json`), so the
+    // divisor falls back to 1 and the estimate is the cartesian upper bound
+    // |build| * |probe| = 36 — loose but still a valid over-estimate. The tight
+    // estimate returns with the typed-column layout. Either way execution is
+    // correct (each Person matches only itself; distinct names → 6 rows).
     let mut writer = WriterSession::open(store(), paths("s123-hj03"))
         .await
         .unwrap();
@@ -935,13 +1105,15 @@ async fn hash_join_estimate_matches_actual_within_micro_graph() {
     let opt_est = estimate(&optimized, &cat).rows;
     let rows = execute(&optimized, &snap, &Params::new()).await.unwrap();
     let actual = rows.len() as f64;
-    let err = (opt_est - actual).abs() / actual.max(1.0);
+    assert_eq!(actual, 6.0, "6 Persons, each joins only to itself");
+    // Cartesian fallback: 6 * 6 = 36, and it must remain a valid upper bound.
     assert!(
-        err < 0.30,
-        "HashJoin estimate {} far from actual {} (rel err {})",
-        opt_est,
-        actual,
-        err
+        opt_est >= actual,
+        "estimate {opt_est} must not under-count actual {actual}"
+    );
+    assert!(
+        (opt_est - 36.0).abs() < 1.0,
+        "without per-column ndv the estimate is the cartesian bound 36, got {opt_est}"
     );
 }
 

--- a/crates/namidb-query/tests/cost_smoke.rs
+++ b/crates/namidb-query/tests/cost_smoke.rs
@@ -101,6 +101,7 @@ fn person(first: &str, last: &str, age: i32) -> NodeWriteRecord {
     NodeWriteRecord {
         properties: p,
         schema_version: 1,
+        ..Default::default()
     }
 }
 
@@ -111,6 +112,7 @@ fn message(content: &str, creation_date: i64) -> NodeWriteRecord {
     NodeWriteRecord {
         properties: p,
         schema_version: 1,
+        ..Default::default()
     }
 }
 

--- a/crates/namidb-query/tests/exec_alternation.rs
+++ b/crates/namidb-query/tests/exec_alternation.rs
@@ -75,6 +75,7 @@ fn person(name: &str) -> NodeWriteRecord {
     NodeWriteRecord {
         properties: p,
         schema_version: 1,
+        ..Default::default()
     }
 }
 

--- a/crates/namidb-query/tests/exec_factor_parity.rs
+++ b/crates/namidb-query/tests/exec_factor_parity.rs
@@ -53,6 +53,7 @@ fn person(first: &str, last: &str) -> NodeWriteRecord {
     NodeWriteRecord {
         properties: p,
         schema_version: 1,
+        ..Default::default()
     }
 }
 
@@ -63,6 +64,7 @@ fn post(content: &str, date: i64) -> NodeWriteRecord {
     NodeWriteRecord {
         properties: p,
         schema_version: 1,
+        ..Default::default()
     }
 }
 

--- a/crates/namidb-query/tests/exec_ldbc_snb.rs
+++ b/crates/namidb-query/tests/exec_ldbc_snb.rs
@@ -69,6 +69,7 @@ fn person(first: &str, last: &str, age: i32) -> NodeWriteRecord {
     NodeWriteRecord {
         properties: p,
         schema_version: 1,
+        ..Default::default()
     }
 }
 
@@ -79,6 +80,7 @@ fn message(content: &str, creation_date: i64) -> NodeWriteRecord {
     NodeWriteRecord {
         properties: p,
         schema_version: 1,
+        ..Default::default()
     }
 }
 
@@ -89,6 +91,7 @@ fn comment(content: &str, creation_date: i64) -> NodeWriteRecord {
     NodeWriteRecord {
         properties: p,
         schema_version: 1,
+        ..Default::default()
     }
 }
 

--- a/crates/namidb-query/tests/exec_ldbc_snb_updates.rs
+++ b/crates/namidb-query/tests/exec_ldbc_snb_updates.rs
@@ -42,6 +42,7 @@ async fn seed_person(writer: &mut WriterSession, first: &str, last: &str, age: i
             &NodeWriteRecord {
                 properties: p,
                 schema_version: 1,
+                ..Default::default()
             },
         )
         .unwrap();
@@ -60,6 +61,7 @@ async fn seed_message(writer: &mut WriterSession, content: &str, creation_date: 
             &NodeWriteRecord {
                 properties: p,
                 schema_version: 1,
+                ..Default::default()
             },
         )
         .unwrap();

--- a/crates/namidb-query/tests/exec_limit_pushdown.rs
+++ b/crates/namidb-query/tests/exec_limit_pushdown.rs
@@ -34,6 +34,7 @@ fn node_with(prop: &str, v: i64) -> NodeWriteRecord {
     NodeWriteRecord {
         properties: props,
         schema_version: 1,
+        ..Default::default()
     }
 }
 

--- a/crates/namidb-query/tests/exec_match_expand.rs
+++ b/crates/namidb-query/tests/exec_match_expand.rs
@@ -50,6 +50,7 @@ fn person(name: &str, age: i32) -> NodeWriteRecord {
     NodeWriteRecord {
         properties: props,
         schema_version: 1,
+        ..Default::default()
     }
 }
 
@@ -72,6 +73,7 @@ fn person_city(name: &str, city: &str) -> NodeWriteRecord {
     NodeWriteRecord {
         properties: props,
         schema_version: 1,
+        ..Default::default()
     }
 }
 
@@ -685,6 +687,7 @@ async fn match_without_label_scans_every_observed_label() {
             &NodeWriteRecord {
                 properties: post_props,
                 schema_version: 1,
+                ..Default::default()
             },
         )
         .unwrap();

--- a/crates/namidb-query/tests/exec_multiway_join.rs
+++ b/crates/namidb-query/tests/exec_multiway_join.rs
@@ -34,6 +34,7 @@ fn person(name: &str) -> NodeWriteRecord {
     NodeWriteRecord {
         properties: props,
         schema_version: 1,
+        ..Default::default()
     }
 }
 

--- a/crates/namidb-query/tests/exec_multiway_join_e2e.rs
+++ b/crates/namidb-query/tests/exec_multiway_join_e2e.rs
@@ -68,6 +68,7 @@ fn person(name: &str) -> NodeWriteRecord {
     NodeWriteRecord {
         properties: p,
         schema_version: 1,
+        ..Default::default()
     }
 }
 

--- a/crates/namidb-query/tests/exec_multiway_join_stress.rs
+++ b/crates/namidb-query/tests/exec_multiway_join_stress.rs
@@ -74,6 +74,7 @@ fn person(name: &str) -> NodeWriteRecord {
     NodeWriteRecord {
         properties: p,
         schema_version: 1,
+        ..Default::default()
     }
 }
 

--- a/crates/namidb-query/tests/exec_plan_aware_routing.rs
+++ b/crates/namidb-query/tests/exec_plan_aware_routing.rs
@@ -57,6 +57,7 @@ fn person(name: &str) -> NodeWriteRecord {
     NodeWriteRecord {
         properties: props,
         schema_version: 1,
+        ..Default::default()
     }
 }
 

--- a/crates/namidb-query/tests/exec_shortest_path.rs
+++ b/crates/namidb-query/tests/exec_shortest_path.rs
@@ -40,6 +40,7 @@ fn person(name: &str) -> NodeWriteRecord {
     NodeWriteRecord {
         properties: props,
         schema_version: 1,
+        ..Default::default()
     }
 }
 

--- a/crates/namidb-query/tests/exec_writes.rs
+++ b/crates/namidb-query/tests/exec_writes.rs
@@ -65,6 +65,7 @@ async fn match_then_create_relationship() {
             &NodeWriteRecord {
                 properties: p_alice,
                 schema_version: 1,
+                ..Default::default()
             },
         )
         .unwrap();
@@ -75,6 +76,7 @@ async fn match_then_create_relationship() {
             &NodeWriteRecord {
                 properties: p_bob,
                 schema_version: 1,
+                ..Default::default()
             },
         )
         .unwrap();
@@ -119,6 +121,7 @@ async fn two_match_clauses_then_create_relationship() {
             &NodeWriteRecord {
                 properties: p_alice,
                 schema_version: 1,
+                ..Default::default()
             },
         )
         .unwrap();
@@ -129,6 +132,7 @@ async fn two_match_clauses_then_create_relationship() {
             &NodeWriteRecord {
                 properties: p_bob,
                 schema_version: 1,
+                ..Default::default()
             },
         )
         .unwrap();
@@ -166,6 +170,7 @@ async fn set_property_round_trips() {
             &NodeWriteRecord {
                 properties: p,
                 schema_version: 1,
+                ..Default::default()
             },
         )
         .unwrap();
@@ -203,6 +208,7 @@ async fn remove_property() {
             &NodeWriteRecord {
                 properties: p,
                 schema_version: 1,
+                ..Default::default()
             },
         )
         .unwrap();
@@ -237,6 +243,7 @@ async fn detach_delete_removes_node_and_edges() {
             &NodeWriteRecord {
                 properties: BTreeMap::new(),
                 schema_version: 1,
+                ..Default::default()
             },
         )
         .unwrap();
@@ -247,6 +254,7 @@ async fn detach_delete_removes_node_and_edges() {
             &NodeWriteRecord {
                 properties: BTreeMap::new(),
                 schema_version: 1,
+                ..Default::default()
             },
         )
         .unwrap();
@@ -293,6 +301,7 @@ async fn merge_match_path_runs_on_match_sets() {
             &NodeWriteRecord {
                 properties: p,
                 schema_version: 1,
+                ..Default::default()
             },
         )
         .unwrap();

--- a/crates/namidb-server/tests/background_maintenance.rs
+++ b/crates/namidb-server/tests/background_maintenance.rs
@@ -49,12 +49,15 @@ async fn flush(state: &namidb_server::AppState) {
     state.snapshot.store(w.owned_snapshot());
 }
 
-fn person_ssts(snap: &OwnedSnapshot, level: SstLevel) -> usize {
+// id-primary node SSTs are no longer partitioned by label (`scope == ""`), so
+// count the whole node bucket at a level. The fixture only writes Person nodes,
+// so this is exactly the count of Person SSTs.
+fn node_ssts(snap: &OwnedSnapshot, level: SstLevel) -> usize {
     snap.manifest()
         .manifest
         .ssts
         .iter()
-        .filter(|d| d.kind == SstKind::Nodes && d.scope == "Person" && d.level == level)
+        .filter(|d| d.kind == SstKind::Nodes && d.level == level)
         .count()
 }
 
@@ -96,9 +99,9 @@ async fn compaction_collapses_l0_and_sweep_reclaims_orphans() {
 
     let before = state.snapshot.load();
     assert!(
-        person_ssts(&before, SstLevel::L0) >= 2,
+        node_ssts(&before, SstLevel::L0) >= 2,
         "expected >= 2 L0 Person SSTs before compaction, got {}",
-        person_ssts(&before, SstLevel::L0)
+        node_ssts(&before, SstLevel::L0)
     );
     assert_eq!(count_persons(&before).await, total, "baseline count");
 
@@ -126,12 +129,12 @@ async fn compaction_collapses_l0_and_sweep_reclaims_orphans() {
 
     let after = state.snapshot.load();
     assert_eq!(
-        person_ssts(&after, SstLevel::L0),
+        node_ssts(&after, SstLevel::L0),
         0,
         "no L0 Person SSTs should remain after compaction"
     );
     assert_eq!(
-        person_ssts(&after, SstLevel(1)),
+        node_ssts(&after, SstLevel(1)),
         1,
         "the bucket should collapse to a single L1 SST"
     );

--- a/crates/namidb-storage/src/compact.rs
+++ b/crates/namidb-storage/src/compact.rs
@@ -35,7 +35,9 @@
 
 use std::collections::{BTreeMap, HashSet};
 
-use arrow_array::{Array, BooleanArray, FixedSizeBinaryArray, StringArray, UInt64Array};
+use arrow_array::{
+    Array, BooleanArray, FixedSizeBinaryArray, ListArray, StringArray, UInt32Array, UInt64Array,
+};
 use bytes::Bytes;
 use chrono::Utc;
 use object_store::path::Path;
@@ -59,8 +61,8 @@ use crate::sst::edges::reader::EdgeSstReader;
 use crate::sst::edges::writer::{EdgeRecord, EdgeSstFinish};
 use crate::sst::edges::EdgeDirection;
 use crate::sst::nodes::{
-    prop_column_name, NodeSstFinish, NodeSstReader, COL_LSN, COL_NODE_ID, COL_TOMBSTONE,
-    OVERFLOW_JSON, SCHEMA_VERSION,
+    prop_column_name, NodeSstFinish, NodeSstReader, COL_LABELS, COL_LSN, COL_NODE_ID,
+    COL_TOMBSTONE, OVERFLOW_JSON, SCHEMA_VERSION,
 };
 
 /// Outcome of [`compact_l0_to_l1`].
@@ -343,6 +345,10 @@ fn extract_node_rows_from_reader(
             let payload = NodeWriteRecord {
                 properties,
                 schema_version,
+                // Preserve the on-row label set (raw LabelIds) so the merged L1
+                // SST keeps it. Legacy SSTs have no __labels column and yield an
+                // empty set; their L1 stays scope-typed and reads via fallback.
+                labels: raw_labels_from_batch(&batch, row),
             }
             .encode()?;
             out.push(NodeRow {
@@ -353,6 +359,27 @@ fn extract_node_rows_from_reader(
         }
     }
     Ok(out)
+}
+
+/// Read a node row's `__labels` column as raw `LabelId` values. Empty when the
+/// SST predates the column (legacy single-label).
+fn raw_labels_from_batch(batch: &arrow_array::RecordBatch, row: usize) -> Vec<u32> {
+    let Some(list) = batch
+        .column_by_name(COL_LABELS)
+        .and_then(|c| c.as_any().downcast_ref::<ListArray>())
+    else {
+        return Vec::new();
+    };
+    if list.is_null(row) {
+        return Vec::new();
+    }
+    match list.value(row).as_any().downcast_ref::<UInt32Array>() {
+        Some(a) => (0..a.len())
+            .filter(|&i| !a.is_null(i))
+            .map(|i| a.value(i))
+            .collect(),
+        None => Vec::new(),
+    }
 }
 
 fn compact_edge_ssts(
@@ -702,6 +729,7 @@ mod tests {
         NodeWriteRecord {
             properties: props,
             schema_version: 1,
+            ..Default::default()
         }
         .encode()
         .unwrap()
@@ -733,10 +761,7 @@ mod tests {
         let alice = sorted_node_id(1);
         let mut mt1 = Memtable::new();
         mt1.apply(
-            MemKey::Node {
-                label: "Person".into(),
-                id: alice,
-            },
+            MemKey::Node { id: alice },
             10,
             MemOp::Upsert(node_payload("Alice", Some(30))),
         );
@@ -746,10 +771,7 @@ mod tests {
         let bob = sorted_node_id(2);
         let mut mt2 = Memtable::new();
         mt2.apply(
-            MemKey::Node {
-                label: "Person".into(),
-                id: bob,
-            },
+            MemKey::Node { id: bob },
             20,
             MemOp::Upsert(node_payload("Bob", None)),
         );
@@ -788,10 +810,7 @@ mod tests {
         let alice = sorted_node_id(1);
         let mut mt = Memtable::new();
         mt.apply(
-            MemKey::Node {
-                label: "Person".into(),
-                id: alice,
-            },
+            MemKey::Node { id: alice },
             10,
             MemOp::Upsert(node_payload("Alice", Some(30))),
         );
@@ -855,10 +874,7 @@ mod tests {
         // L0 SST #1: alice@v1, name=Alice
         let mut mt1 = Memtable::new();
         mt1.apply(
-            MemKey::Node {
-                label: "Person".into(),
-                id: alice,
-            },
+            MemKey::Node { id: alice },
             5,
             MemOp::Upsert(node_payload("Alice", Some(30))),
         );
@@ -868,10 +884,7 @@ mod tests {
         // L0 SST #2: alice@v2, name=Alicia, with a later LSN — it wins.
         let mut mt2 = Memtable::new();
         mt2.apply(
-            MemKey::Node {
-                label: "Person".into(),
-                id: alice,
-            },
+            MemKey::Node { id: alice },
             12,
             MemOp::Upsert(node_payload("Alicia", Some(31))),
         );
@@ -911,10 +924,7 @@ mod tests {
         // L0 SST #1: alice upsert at LSN 5.
         let mut mt1 = Memtable::new();
         mt1.apply(
-            MemKey::Node {
-                label: "Person".into(),
-                id: alice,
-            },
+            MemKey::Node { id: alice },
             5,
             MemOp::Upsert(node_payload("Alice", Some(30))),
         );
@@ -923,14 +933,7 @@ mod tests {
 
         // L0 SST #2: alice tombstone at LSN 9 — wins.
         let mut mt2 = Memtable::new();
-        mt2.apply(
-            MemKey::Node {
-                label: "Person".into(),
-                id: alice,
-            },
-            9,
-            MemOp::Tombstone,
-        );
+        mt2.apply(MemKey::Node { id: alice }, 9, MemOp::Tombstone);
         let frozen2 = mt2.freeze();
         let after2 = flush(&ms, &fence, &after1.committed, &frozen2, schema())
             .await

--- a/crates/namidb-storage/src/compact.rs
+++ b/crates/namidb-storage/src/compact.rs
@@ -511,6 +511,18 @@ async fn put_node_sst_l1(
             merged_rows,
         )?;
     index_sidecars.extend(equality_sidecars);
+    // Rebuild the label-index sidecar from the reconciled rows. id-primary
+    // buckets (scope == "") carry per-row label sets in `merged_rows`, so this
+    // re-emits the `LabelId -> [NodeId]` postings (with per-label counts) the
+    // cost model needs; without it, every compaction would silently reset
+    // per-label `node_count` to 0 and the optimizer would prune non-empty
+    // labels again. Legacy per-label buckets have empty label sets and yield
+    // `None` here, falling back to `scope`-based counting downstream.
+    let (label_index, label_sidecar) =
+        crate::flush::prepare_label_index_sidecar(paths, level.as_u32(), &id, merged_rows)?;
+    if let Some(sidecar) = label_sidecar {
+        index_sidecars.push(sidecar);
+    }
     for (path, body) in &index_sidecars {
         put_create(store, path, body.clone()).await?;
     }
@@ -538,7 +550,7 @@ async fn put_node_sst_l1(
         bloom: bloom_descriptor,
         unique_property_indices,
         equality_property_indices,
-        label_index: None,
+        label_index,
     };
     Ok((descriptor, wrote_bloom))
 }

--- a/crates/namidb-storage/src/compact.rs
+++ b/crates/namidb-storage/src/compact.rs
@@ -729,7 +729,9 @@ mod tests {
         NodeWriteRecord {
             properties: props,
             schema_version: 1,
-            ..Default::default()
+            // Single label "Person" -> LabelId(0) on a fresh dict, carried
+            // on-row so the id-primary read path resolves the node to "Person".
+            labels: vec![0],
         }
         .encode()
         .unwrap()
@@ -755,7 +757,10 @@ mod tests {
         let s = store();
         let p = paths("compact-nodes");
         let ms = ManifestStore::new(s.clone(), p.clone());
-        let base = ms.bootstrap(Uuid::now_v7()).await.unwrap();
+        let mut base = ms.bootstrap(Uuid::now_v7()).await.unwrap();
+        // Seed the dict so the on-row LabelId(0) resolves to "Person" through
+        // both flushes and the L0->L1 compaction (the dict is cloned forward).
+        base.manifest.label_dict.intern("Person");
         let fence = WriterFence::new(base.manifest.epoch);
 
         let alice = sorted_node_id(1);
@@ -866,7 +871,9 @@ mod tests {
         let s = store();
         let p = paths("compact-overlap");
         let ms = ManifestStore::new(s.clone(), p.clone());
-        let base = ms.bootstrap(Uuid::now_v7()).await.unwrap();
+        let mut base = ms.bootstrap(Uuid::now_v7()).await.unwrap();
+        // Seed the dict so the on-row LabelId(0) resolves to "Person".
+        base.manifest.label_dict.intern("Person");
         let fence = WriterFence::new(base.manifest.epoch);
 
         let alice = sorted_node_id(1);

--- a/crates/namidb-storage/src/flush.rs
+++ b/crates/namidb-storage/src/flush.rs
@@ -1281,7 +1281,7 @@ pub mod builder {
     use bytes::Bytes;
     use object_store::path::Path;
 
-    use namidb_core::{Schema, Value};
+    use namidb_core::{LabelDef, LabelDictionary, Schema, Value};
 
     use crate::error::Result;
     use crate::manifest::SstDescriptor;
@@ -1291,8 +1291,8 @@ pub mod builder {
     use crate::sst::edges::EdgeDirection;
 
     use super::{
-        build_edge_stream_rows, prepare_edge_pending, prepare_node_pending,
-        schema_label_or_synthetic, EdgeRow, EdgeWriteRecord, NodeRow, NodeWriteRecord, PendingSst,
+        build_edge_stream_rows, prepare_edge_pending, prepare_node_pending, union_indexed_props,
+        EdgeRow, EdgeWriteRecord, NodeRow, NodeWriteRecord, PendingSst,
     };
 
     /// One node to ingest. `id` is the ALREADY-MINTED 16-byte NodeId — the
@@ -1336,9 +1336,18 @@ pub mod builder {
     #[derive(Debug)]
     pub struct BuiltSst {
         inner: PendingSst,
+        /// Label names this SST's nodes carry (empty for edge SSTs). The
+        /// builder interned them into on-row `LabelId`s; `attach_ssts` re-interns
+        /// the names into the namespace dictionary so those ids resolve.
+        label_dict: LabelDictionary,
     }
 
     impl BuiltSst {
+        /// Label names carried by this SST's nodes (empty for edge SSTs).
+        pub(crate) fn label_names(&self) -> Vec<String> {
+            self.label_dict.iter().map(|(_, n)| n.to_string()).collect()
+        }
+
         /// Highest LSN carried by this SST (the `next_lsn` floor after attach).
         #[must_use]
         pub fn max_lsn(&self) -> u64 {
@@ -1409,7 +1418,10 @@ pub mod builder {
             return Ok(None);
         }
         let rows = dedup_keep_last_node(rows);
-        let label_def = schema_label_or_synthetic(schema, label);
+        // Intern the label so records carry its LabelId; the dict travels with
+        // the BuiltSst and `attach_ssts` installs it in the manifest.
+        let mut node_dict = LabelDictionary::new();
+        let lid = node_dict.intern(label).get();
         let node_rows: Vec<NodeRow> = rows
             .into_iter()
             .enumerate()
@@ -1421,7 +1433,7 @@ pub mod builder {
                         NodeWriteRecord {
                             properties: n.properties,
                             schema_version: 0,
-                            ..Default::default()
+                            labels: vec![lid],
                         }
                         .encode()?,
                     )
@@ -1434,9 +1446,19 @@ pub mod builder {
             })
             .collect::<Result<_>>()?;
 
-        let finish = super::build_node_sst(&label_def, &node_rows)?;
-        let pending = prepare_node_pending(paths, &label_def, &node_rows, finish)?;
-        Ok(Some(BuiltSst { inner: pending }))
+        // Build with the fixed empty-LabelDef layout (matching `flush()`), and
+        // harvest equality sidecars from the schema's indexed properties.
+        let column_label = LabelDef {
+            name: String::new(),
+            properties: Vec::new(),
+        };
+        let index_props = union_indexed_props(schema);
+        let finish = super::build_node_sst(&column_label, &node_rows)?;
+        let pending = prepare_node_pending(paths, &index_props, &node_rows, finish)?;
+        Ok(Some(BuiltSst {
+            inner: pending,
+            label_dict: node_dict,
+        }))
     }
 
     /// Build BOTH the forward and inverse CSR SSTs for `edge_type`, owning the
@@ -1500,9 +1522,11 @@ pub mod builder {
         Ok(vec![
             BuiltSst {
                 inner: prepare_edge_pending(paths, edge_type, EdgeDirection::Forward, fwd),
+                label_dict: LabelDictionary::new(),
             },
             BuiltSst {
                 inner: prepare_edge_pending(paths, edge_type, EdgeDirection::Inverse, inv),
+                label_dict: LabelDictionary::new(),
             },
         ])
     }
@@ -1746,7 +1770,18 @@ mod tests {
             .paths()
             .sst_object(node_d.level.as_u32(), file_basename(&node_d.path));
         let body = store.get(&abs).await.unwrap().bytes().await.unwrap();
-        let reader = NodeSstReader::open(person_label(), body).unwrap();
+        // Id-primary node SSTs use the fixed layout (an empty `LabelDef`, no
+        // `prop_*` columns; every property rides in `__overflow_json`), so the
+        // reader must be opened with that same empty layout — mirroring the
+        // production read path's `label_def_for_node_sst` for an empty scope.
+        let reader = NodeSstReader::open(
+            LabelDef {
+                name: String::new(),
+                properties: Vec::new(),
+            },
+            body,
+        )
+        .unwrap();
         let batches = reader.scan().unwrap();
         let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
         assert_eq!(total_rows, 3);

--- a/crates/namidb-storage/src/flush.rs
+++ b/crates/namidb-storage/src/flush.rs
@@ -391,17 +391,6 @@ fn union_indexed_props(schema: &Schema) -> LabelDef {
     }
 }
 
-/// Lookup the [`LabelDef`] in the schema, or fall back to a synthetic
-/// empty-property label so untyped writes still flow through the path.
-/// Declared properties always win at the SST level; anything else lands in
-/// `__overflow_json` (see RFC-002 §2.1).
-fn schema_label_or_synthetic(schema: &Schema, label: &str) -> LabelDef {
-    schema.label(label).cloned().unwrap_or_else(|| LabelDef {
-        name: label.to_string(),
-        properties: Vec::new(),
-    })
-}
-
 // ── Node SST building ──────────────────────────────────────────────────
 
 pub(crate) fn build_node_sst(label: &LabelDef, rows: &[NodeRow]) -> Result<NodeSstFinish> {
@@ -682,15 +671,20 @@ fn prepare_node_pending(
 /// posting lists come out id-sorted; tombstones contribute nothing
 /// (last-LSN-wins at read time handles removal). Returns `(None, None)` when no
 /// live labelled node is present.
+/// Output of [`prepare_label_index_sidecar`]: the manifest descriptor plus the
+/// `(path, body)` to PUT next to the SST. Aliased to keep clippy's
+/// type-complexity lint happy, mirroring the unique/equality sidecar aliases.
+type LabelIndexSidecar = (
+    Option<crate::manifest::LabelIndexDescriptor>,
+    Option<(Path, Bytes)>,
+);
+
 fn prepare_label_index_sidecar(
     paths: &NamespacePaths,
     level: u32,
     sst_id: &Uuid,
     rows: &[NodeRow],
-) -> Result<(
-    Option<crate::manifest::LabelIndexDescriptor>,
-    Option<(Path, Bytes)>,
-)> {
+) -> Result<LabelIndexSidecar> {
     let mut index: BTreeMap<u32, Vec<[u8; 16]>> = BTreeMap::new();
     for row in rows {
         if let MemOp::Upsert(payload) = &row.op {

--- a/crates/namidb-storage/src/flush.rs
+++ b/crates/namidb-storage/src/flush.rs
@@ -47,8 +47,8 @@ use std::sync::Arc;
 
 use arrow_array::builder::{
     BinaryBuilder, BooleanBuilder, Date32Builder, FixedSizeBinaryBuilder, FixedSizeListBuilder,
-    Float32Builder, Float64Builder, Int32Builder, Int64Builder, LargeStringBuilder, StringBuilder,
-    TimestampMicrosecondBuilder, UInt64Builder,
+    Float32Builder, Float64Builder, Int32Builder, Int64Builder, LargeStringBuilder, ListBuilder,
+    StringBuilder, TimestampMicrosecondBuilder, UInt32Builder, UInt64Builder,
 };
 use arrow_array::{ArrayRef, RecordBatch};
 use bytes::Bytes;
@@ -87,6 +87,13 @@ pub struct NodeWriteRecord {
     pub properties: BTreeMap<String, Value>,
     #[serde(default)]
     pub schema_version: u64,
+    /// The node's label set as interned [`LabelId`](namidb_core::LabelId)
+    /// values, sorted and deduped. Carried in the value (not the key) so the
+    /// id-primary memtable/SST keep one row per id regardless of label count.
+    /// Empty for older payloads (`serde(default)`); the read path then falls
+    /// back to the SST scope for legacy single-label data.
+    #[serde(default)]
+    pub labels: Vec<u32>,
 }
 
 impl NodeWriteRecord {
@@ -160,7 +167,7 @@ pub async fn flush(
         });
     }
 
-    let (node_buckets, edge_buckets) = bucket_by_scope(frozen);
+    let (node_rows, edge_buckets) = bucket_nodes_and_edges(frozen);
 
     let store = manifest_store.store().clone();
     let paths = manifest_store.paths();
@@ -170,11 +177,27 @@ pub async fn flush(
     // threads here; this is the same work as before, just decoupled
     // from the I/O.
     let mut pendings: Vec<PendingSst> = Vec::new();
-    for (label, rows) in node_buckets {
-        let label_def = schema_label_or_synthetic(&schema, &label);
-        let finish = build_node_sst(&label_def, &rows)?;
+    // Nodes: one identity-partitioned SST spanning every label, built with an
+    // empty LabelDef (fixed layout — no prop_* columns; every property rides in
+    // __overflow_json), plus a label->node-ids sidecar so `scan_label` resolves
+    // without per-label partitions.
+    if !node_rows.is_empty() {
+        // Columns: fixed layout, built from an empty LabelDef (no prop_*
+        // columns; every property rides in __overflow_json).
+        let column_label = LabelDef {
+            name: String::new(),
+            properties: Vec::new(),
+        };
+        // Equality-index sidecars are harvested from the record values keyed by
+        // the schema's `indexed` properties, so the secondary index (the
+        // non-unique equality index) survives the id-primary move.
+        let index_props = union_indexed_props(&schema);
+        let finish = build_node_sst(&column_label, &node_rows)?;
         pendings.push(prepare_node_pending(
-            paths, &label, &label_def, &rows, finish,
+            paths,
+            &index_props,
+            &node_rows,
+            finish,
         )?);
     }
     for (edge_type, rows) in edge_buckets {
@@ -305,21 +328,20 @@ pub(crate) struct EdgeRow {
     pub(crate) op: MemOp,
 }
 
-/// Convert the frozen memtable into ordered, per-scope buckets. Memtable
-/// iteration order (BTreeMap) guarantees the rows in each bucket are
-/// already sorted by `node_id` (nodes) or `(src, dst)` (edges).
-fn bucket_by_scope(
+/// Convert the frozen memtable into ordered buckets. Nodes are id-primary, so
+/// they collapse into ONE bucket spanning every label (a node's label set
+/// rides in its value); memtable order (BTreeMap, nodes sort before edges and
+/// by id within nodes) keeps that bucket node_id-ascending for free. Edges
+/// still bucket by type, already sorted by `(src, dst)`.
+fn bucket_nodes_and_edges(
     frozen: &FrozenMemtable,
-) -> (
-    BTreeMap<String, Vec<NodeRow>>,
-    BTreeMap<String, Vec<EdgeRow>>,
-) {
-    let mut nodes: BTreeMap<String, Vec<NodeRow>> = BTreeMap::new();
+) -> (Vec<NodeRow>, BTreeMap<String, Vec<EdgeRow>>) {
+    let mut nodes: Vec<NodeRow> = Vec::new();
     let mut edges: BTreeMap<String, Vec<EdgeRow>> = BTreeMap::new();
     for (k, e) in frozen.iter() {
         match k {
-            MemKey::Node { label, id } => {
-                nodes.entry(label.clone()).or_default().push(NodeRow {
+            MemKey::Node { id } => {
+                nodes.push(NodeRow {
                     id: *id.as_bytes(),
                     lsn: e.lsn,
                     op: e.op.clone(),
@@ -340,6 +362,33 @@ fn bucket_by_scope(
         }
     }
     (nodes, edges)
+}
+
+/// Union of every `indexed` property across all schema labels, as a synthetic
+/// `LabelDef` used ONLY to harvest a node SST's equality-index sidecars (the
+/// columns themselves are built from an empty `LabelDef`). The equality index
+/// is rebuilt from the record values, so it survives the id-primary move.
+///
+/// `unique` is intentionally cleared: a single-value unique sidecar cannot
+/// represent per-label uniqueness across a multi-label SST, so unique-property
+/// lookups fall back to a (correct) scan rather than risk a false negative.
+fn union_indexed_props(schema: &Schema) -> LabelDef {
+    let mut by_name: BTreeMap<String, PropertyDef> = BTreeMap::new();
+    for label in schema.labels.values() {
+        for p in &label.properties {
+            if p.indexed {
+                by_name.entry(p.name.clone()).or_insert_with(|| {
+                    let mut p = p.clone();
+                    p.unique = false;
+                    p
+                });
+            }
+        }
+    }
+    LabelDef {
+        name: String::new(),
+        properties: by_name.into_values().collect(),
+    }
 }
 
 /// Lookup the [`LabelDef`] in the schema, or fall back to a synthetic
@@ -379,6 +428,7 @@ fn build_node_record_batch(
     let mut node_id_b = FixedSizeBinaryBuilder::with_capacity(n, 16);
     let mut tomb_b = BooleanBuilder::with_capacity(n);
     let mut lsn_b = UInt64Builder::with_capacity(n);
+    let mut labels_b = ListBuilder::new(UInt32Builder::new());
     let mut prop_builders: Vec<PropertyBuilder> = label
         .properties
         .iter()
@@ -398,6 +448,10 @@ fn build_node_record_batch(
                 let rec = NodeWriteRecord::decode(bytes)?;
                 tomb_b.append_value(false);
                 lsn_b.append_value(row.lsn);
+                for &lid in &rec.labels {
+                    labels_b.values().append_value(lid);
+                }
+                labels_b.append(true);
 
                 for (idx, p) in label.properties.iter().enumerate() {
                     let value = rec.properties.get(&p.name);
@@ -420,6 +474,7 @@ fn build_node_record_batch(
             MemOp::Tombstone => {
                 tomb_b.append_value(true);
                 lsn_b.append_value(row.lsn);
+                labels_b.append(true); // empty label list on a tombstone row
                 for b in &mut prop_builders {
                     b.append_null();
                 }
@@ -433,6 +488,7 @@ fn build_node_record_batch(
     columns.push(Arc::new(node_id_b.finish()));
     columns.push(Arc::new(tomb_b.finish()));
     columns.push(Arc::new(lsn_b.finish()));
+    columns.push(Arc::new(labels_b.finish()));
     for b in &mut prop_builders {
         columns.push(b.finish());
     }
@@ -543,7 +599,6 @@ pub(crate) fn build_edge_sst(
 
 fn prepare_node_pending(
     paths: &NamespacePaths,
-    label: &str,
     label_def: &LabelDef,
     rows: &[NodeRow],
     finish: NodeSstFinish,
@@ -551,10 +606,9 @@ fn prepare_node_pending(
     let id = Uuid::now_v7();
     let level = SstLevel::L0;
     let file_name = format!(
-        "{}-{}-{}.parquet",
+        "{}-{}.parquet",
         uuid_path_id(&id),
-        SstKind::Nodes.path_tag(),
-        label
+        SstKind::Nodes.path_tag()
     );
     let body_path = paths.sst_object(level.as_u32(), &file_name);
     let relative_path = relative_sst_path(level.as_u32(), &file_name);
@@ -565,29 +619,32 @@ fn prepare_node_pending(
         level.as_u32(),
         &id,
         SstKind::Nodes.path_tag(),
-        label,
+        "",
         finish.bloom,
     );
 
-    // Per-property unique sidecars (RFC-pending): for each declared
-    // `unique` property emit a `value_string → NodeId` map serialised to
-    // bincode. The reader probes these instead of full-scanning the SST
-    // to resolve `MATCH (a:Label {prop: 'X'})`.
+    // Node SSTs are no longer partitioned by label and are built with an empty
+    // LabelDef, so the declared-property sidecars harvest nothing; the calls
+    // stay wired for symmetry and a future typed-column layout.
     let (unique_property_indices, mut index_sidecars) =
-        prepare_unique_property_sidecars(paths, level.as_u32(), &id, label, label_def, rows)?;
-    // Per-property equality sidecars (RFC-pending): for each declared
-    // `indexed` (non-unique) property emit a `value_string → [NodeId, ...]`
-    // posting map. The reader unions these across SSTs and confirms each
-    // candidate against the node's current value.
+        prepare_unique_property_sidecars(paths, level.as_u32(), &id, "", label_def, rows)?;
     let (equality_property_indices, equality_sidecars) =
-        prepare_equality_property_sidecars(paths, level.as_u32(), &id, label, label_def, rows)?;
+        prepare_equality_property_sidecars(paths, level.as_u32(), &id, "", label_def, rows)?;
     index_sidecars.extend(equality_sidecars);
+
+    // The label index (`LabelId -> [NodeId, ...]`) replaces "the SST partition
+    // IS the label index" now that one node SST spans every label.
+    let (label_index, label_sidecar) =
+        prepare_label_index_sidecar(paths, level.as_u32(), &id, rows)?;
+    if let Some(sidecar) = label_sidecar {
+        index_sidecars.push(sidecar);
+    }
 
     let stats = finish.stats;
     let descriptor = SstDescriptor {
         id,
         kind: SstKind::Nodes,
-        scope: label.to_string(),
+        scope: String::new(),
         level,
         path: relative_path,
         size_bytes: body_len,
@@ -606,7 +663,7 @@ fn prepare_node_pending(
         bloom: bloom_descriptor,
         unique_property_indices,
         equality_property_indices,
-        label_index: None,
+        label_index,
     };
 
     Ok(PendingSst {
@@ -617,6 +674,57 @@ fn prepare_node_pending(
         bloom_body,
         index_sidecars,
     })
+}
+
+/// Build the per-SST label index sidecar: `LabelId -> [NodeId, ...]` posting
+/// lists, bincode-serialised, mirroring the equality-index sidecar. Walks
+/// `rows` (already id-ascending) decoding each upsert's label set, so the
+/// posting lists come out id-sorted; tombstones contribute nothing
+/// (last-LSN-wins at read time handles removal). Returns `(None, None)` when no
+/// live labelled node is present.
+fn prepare_label_index_sidecar(
+    paths: &NamespacePaths,
+    level: u32,
+    sst_id: &Uuid,
+    rows: &[NodeRow],
+) -> Result<(
+    Option<crate::manifest::LabelIndexDescriptor>,
+    Option<(Path, Bytes)>,
+)> {
+    let mut index: BTreeMap<u32, Vec<[u8; 16]>> = BTreeMap::new();
+    for row in rows {
+        if let MemOp::Upsert(payload) = &row.op {
+            let rec = NodeWriteRecord::decode(payload)?;
+            for &lid in &rec.labels {
+                let ids = index.entry(lid).or_default();
+                if !ids.contains(&row.id) {
+                    ids.push(row.id);
+                }
+            }
+        }
+    }
+    if index.is_empty() {
+        return Ok((None, None));
+    }
+    let label_count = index.len() as u64;
+    let posting_count = index.values().map(|v| v.len() as u64).sum();
+    let body_bytes = bincode::serialize(&index)
+        .map_err(|e| Error::invariant(format!("label-index bincode: {e}")))?;
+    let body = Bytes::from(body_bytes);
+    let file_name = format!(
+        "{}-{}.labelidx.bin",
+        uuid_path_id(sst_id),
+        SstKind::Nodes.path_tag()
+    );
+    let object_path = paths.sst_object(level, &file_name);
+    let relative = relative_sst_path(level, &file_name);
+    let descriptor = crate::manifest::LabelIndexDescriptor {
+        path: relative,
+        size_bytes: body.len() as u64,
+        label_count,
+        posting_count,
+    };
+    Ok((Some(descriptor), Some((object_path, body))))
 }
 
 /// Parallel outputs of [`prepare_unique_property_sidecars`]: the
@@ -1313,6 +1421,7 @@ pub mod builder {
                         NodeWriteRecord {
                             properties: n.properties,
                             schema_version: 0,
+                            ..Default::default()
                         }
                         .encode()?,
                     )
@@ -1326,7 +1435,7 @@ pub mod builder {
             .collect::<Result<_>>()?;
 
         let finish = super::build_node_sst(&label_def, &node_rows)?;
-        let pending = prepare_node_pending(paths, label, &label_def, &node_rows, finish)?;
+        let pending = prepare_node_pending(paths, &label_def, &node_rows, finish)?;
         Ok(Some(BuiltSst { inner: pending }))
     }
 
@@ -1478,6 +1587,7 @@ mod tests {
         NodeWriteRecord {
             properties: props,
             schema_version: 1,
+            ..Default::default()
         }
         .encode()
         .unwrap()
@@ -1512,6 +1622,7 @@ mod tests {
         let r = NodeWriteRecord {
             properties: props,
             schema_version: 7,
+            ..Default::default()
         };
         let bytes = r.encode().unwrap();
         let back = NodeWriteRecord::decode(&bytes).unwrap();
@@ -1569,29 +1680,16 @@ mod tests {
 
         let mut mt = Memtable::new();
         mt.apply(
-            MemKey::Node {
-                label: "Person".into(),
-                id: alice,
-            },
+            MemKey::Node { id: alice },
             10,
             MemOp::Upsert(node_payload("Alice", Some(30))),
         );
         mt.apply(
-            MemKey::Node {
-                label: "Person".into(),
-                id: bob,
-            },
+            MemKey::Node { id: bob },
             11,
             MemOp::Upsert(node_payload("Bob", None)),
         );
-        mt.apply(
-            MemKey::Node {
-                label: "Person".into(),
-                id: carol,
-            },
-            12,
-            MemOp::Tombstone,
-        );
+        mt.apply(MemKey::Node { id: carol }, 12, MemOp::Tombstone);
         mt.apply(
             MemKey::Edge {
                 edge_type: "KNOWS".into(),
@@ -1715,10 +1813,7 @@ mod tests {
         let alice = sorted_node_id(1);
         let mut mt = Memtable::new();
         mt.apply(
-            MemKey::Node {
-                label: "Person".into(),
-                id: alice,
-            },
+            MemKey::Node { id: alice },
             10,
             MemOp::Upsert(node_payload("Alice", Some(30))),
         );
@@ -1751,10 +1846,7 @@ mod tests {
         let alice = sorted_node_id(1);
         let mut mt = Memtable::new();
         mt.apply(
-            MemKey::Node {
-                label: "Person".into(),
-                id: alice,
-            },
+            MemKey::Node { id: alice },
             10,
             MemOp::Upsert(node_payload("Alice", Some(30))),
         );

--- a/crates/namidb-storage/src/flush.rs
+++ b/crates/namidb-storage/src/flush.rs
@@ -679,7 +679,7 @@ type LabelIndexSidecar = (
     Option<(Path, Bytes)>,
 );
 
-fn prepare_label_index_sidecar(
+pub(crate) fn prepare_label_index_sidecar(
     paths: &NamespacePaths,
     level: u32,
     sst_id: &Uuid,
@@ -700,8 +700,15 @@ fn prepare_label_index_sidecar(
     if index.is_empty() {
         return Ok((None, None));
     }
+    // `per_label_counts` mirrors each posting list's length so the cost model
+    // can recover per-label `node_count` from the manifest alone (no sidecar
+    // body read); `posting_count` is just their sum.
+    let per_label_counts: Vec<(u32, u64)> = index
+        .iter()
+        .map(|(&lid, ids)| (lid, ids.len() as u64))
+        .collect();
     let label_count = index.len() as u64;
-    let posting_count = index.values().map(|v| v.len() as u64).sum();
+    let posting_count = per_label_counts.iter().map(|(_, c)| *c).sum();
     let body_bytes = bincode::serialize(&index)
         .map_err(|e| Error::invariant(format!("label-index bincode: {e}")))?;
     let body = Bytes::from(body_bytes);
@@ -717,6 +724,7 @@ fn prepare_label_index_sidecar(
         size_bytes: body.len() as u64,
         label_count,
         posting_count,
+        per_label_counts,
     };
     Ok((Some(descriptor), Some((object_path, body))))
 }

--- a/crates/namidb-storage/src/ingest.rs
+++ b/crates/namidb-storage/src/ingest.rs
@@ -52,7 +52,7 @@ use object_store::ObjectStore;
 use tracing::{debug, instrument};
 use uuid::Uuid;
 
-use namidb_core::{NodeId, Schema};
+use namidb_core::{LabelDictionary, NodeId, Schema};
 
 use crate::adjacency::{adjacency_budget_bytes, adjacency_enabled, AdjacencyCache};
 use crate::cache::{sst_cache_budget_bytes, sst_cache_enabled, SstCache};
@@ -155,6 +155,10 @@ pub struct WriterSession {
     /// further object-store writes and mints no new orphan segments.
     /// Only a fresh [`Self::open`] clears it.
     poisoned: bool,
+    /// Namespace label dictionary. Seeded from the manifest at `open` and
+    /// extended as `upsert_node*` interns new label names; stamped onto every
+    /// committed manifest so a node's on-row `LabelId`s always resolve to names.
+    label_dict: LabelDictionary,
 }
 
 impl std::fmt::Debug for WriterSession {
@@ -239,6 +243,7 @@ impl WriterSession {
             manifest_store,
             wal_store,
             fence,
+            label_dict: current.manifest.label_dict.clone(),
             current,
             memtable: recovered.memtable,
             published_memtable,
@@ -399,19 +404,43 @@ impl WriterSession {
         snap
     }
 
-    /// Queue a node upsert. Allocates an LSN and appends the entry to
-    /// the pending WAL batch. Returns the LSN.
+    /// Queue a single-label node upsert. Convenience wrapper over
+    /// [`upsert_node_with_labels`](Self::upsert_node_with_labels); kept so the
+    /// many single-label call sites stay unchanged.
     pub fn upsert_node(
         &mut self,
         label: impl Into<String>,
         id: NodeId,
         record: &NodeWriteRecord,
     ) -> Result<u64> {
+        self.upsert_node_with_labels(std::iter::once(label.into()), id, record)
+    }
+
+    /// Queue a node upsert carrying a full label set. Allocates an LSN, interns
+    /// every label name into the namespace dictionary, stamps the resulting
+    /// (sorted, deduped) [`LabelId`](namidb_core::LabelId) values onto the
+    /// record, keys the row by `id` alone, and appends to the pending WAL
+    /// batch. Returns the LSN.
+    pub fn upsert_node_with_labels<I>(
+        &mut self,
+        labels: I,
+        id: NodeId,
+        record: &NodeWriteRecord,
+    ) -> Result<u64>
+    where
+        I: IntoIterator<Item = String>,
+    {
         let lsn = self.alloc_lsn();
-        let key = MemKey::Node {
-            label: label.into(),
-            id,
-        };
+        let mut label_ids: Vec<u32> = labels
+            .into_iter()
+            .map(|name| self.label_dict.intern(&name).get())
+            .collect();
+        label_ids.sort_unstable();
+        label_ids.dedup();
+
+        let mut record = record.clone();
+        record.labels = label_ids;
+        let key = MemKey::Node { id };
         let payload = record.encode()?;
         let entry = WalEntry {
             key: key.clone(),
@@ -422,13 +451,12 @@ impl WriterSession {
         Ok(lsn)
     }
 
-    /// Queue a node tombstone. Returns the LSN.
-    pub fn tombstone_node(&mut self, label: impl Into<String>, id: NodeId) -> Result<u64> {
+    /// Queue a node tombstone. Keyed by `id` alone: a tombstone removes the node
+    /// from every label scan regardless of which labels it carried, so the
+    /// `label` argument is vestigial (kept for call-site compatibility).
+    pub fn tombstone_node(&mut self, _label: impl Into<String>, id: NodeId) -> Result<u64> {
         let lsn = self.alloc_lsn();
-        let key = MemKey::Node {
-            label: label.into(),
-            id,
-        };
+        let key = MemKey::Node { id };
         let entry = WalEntry {
             key: key.clone(),
             op: WalOp::Tombstone,
@@ -678,6 +706,8 @@ impl WriterSession {
     fn build_next(&self, seq: u64, last_lsn: u64) -> Manifest {
         let segment_path = self.wal_store.paths().wal_segment(seq);
         let mut next = self.current.manifest.next_version(self.fence.writer_id);
+        // Persist any label names interned since the last commit.
+        next.label_dict = self.label_dict.clone();
         next.wal_segments.push(WalSegmentDescriptor {
             seq,
             path: segment_path.as_ref().to_string(),
@@ -872,6 +902,7 @@ impl WriterSession {
         // 3. Commit phase — one new manifest version (mirrors flush()).
         let mut next = self.current.manifest.next_version(self.fence.writer_id);
         next.schema = schema; // REPLACE (fresh-namespace-only)
+        next.label_dict = self.label_dict.clone();
         next.ssts.extend(descriptors); // extend == set on a fresh base
         next.wal_segments.clear();
         let committed = self
@@ -970,6 +1001,7 @@ mod tests {
         NodeWriteRecord {
             properties: props,
             schema_version: 1,
+            ..Default::default()
         }
     }
 
@@ -1322,7 +1354,6 @@ mod tests {
             lsn: 1,
             payload: WalEntry {
                 key: MemKey::Node {
-                    label: "Person".into(),
                     id: sorted_node_id(99),
                 },
                 op: WalOp::Upsert(b"ghost".to_vec()),
@@ -1476,7 +1507,6 @@ mod tests {
             lsn: 1,
             payload: WalEntry {
                 key: MemKey::Node {
-                    label: "Person".into(),
                     id: sorted_node_id(99),
                 },
                 op: WalOp::Upsert(b"ghost".to_vec()),
@@ -1539,7 +1569,6 @@ mod tests {
             lsn: 1,
             payload: WalEntry {
                 key: MemKey::Node {
-                    label: "Person".into(),
                     id: sorted_node_id(99),
                 },
                 op: WalOp::Upsert(b"ghost".to_vec()),

--- a/crates/namidb-storage/src/ingest.rs
+++ b/crates/namidb-storage/src/ingest.rs
@@ -870,6 +870,13 @@ impl WriterSession {
         let mut bloom_count = 0usize;
         let mut attached_max_lsn = 0u64;
         for b in built {
+            // Install the SST's label names into the namespace dictionary so the
+            // on-row LabelIds (baked at build time) resolve. Fresh-namespace
+            // attach starts from an empty dict, so a single-label-per-SST batch
+            // keeps id 0 == that label, matching the baked `__labels`.
+            for name in b.label_names() {
+                self.label_dict.intern(&name);
+            }
             let (body_path, body, bloom, sidecars, descriptor) = b.into_parts();
             attached_max_lsn = attached_max_lsn.max(descriptor.max_lsn);
             let store_ref = store.clone();

--- a/crates/namidb-storage/src/janitor.rs
+++ b/crates/namidb-storage/src/janitor.rs
@@ -197,6 +197,7 @@ mod tests {
         NodeWriteRecord {
             properties: props,
             schema_version: 1,
+            ..Default::default()
         }
         .encode()
         .unwrap()
@@ -218,14 +219,7 @@ mod tests {
         lsn: u64,
     ) -> crate::manifest::LoadedManifest {
         let mut mt = Memtable::new();
-        mt.apply(
-            MemKey::Node {
-                label: "Person".into(),
-                id,
-            },
-            lsn,
-            MemOp::Upsert(node_payload(name)),
-        );
+        mt.apply(MemKey::Node { id }, lsn, MemOp::Upsert(node_payload(name)));
         let frozen = mt.freeze();
         flush(ms, fence, base, &frozen, schema.clone())
             .await

--- a/crates/namidb-storage/src/janitor.rs
+++ b/crates/namidb-storage/src/janitor.rs
@@ -108,6 +108,20 @@ pub async fn sweep_orphans(
         if let Some(b) = &desc.bloom {
             referenced.insert(b.path.clone());
         }
+        // Side-car bodies live in the same `sst/level{N}/` prefix the sweep
+        // scans, so they must be marked live too — otherwise the sweep deletes
+        // unique/equality/label-index side-cars that the current manifest still
+        // references, breaking point lookups and (with the typed-column layout)
+        // label scans.
+        for u in &desc.unique_property_indices {
+            referenced.insert(u.path.clone());
+        }
+        for e in &desc.equality_property_indices {
+            referenced.insert(e.path.clone());
+        }
+        if let Some(li) = &desc.label_index {
+            referenced.insert(li.path.clone());
+        }
     }
 
     let store = manifest_store.store().clone();

--- a/crates/namidb-storage/src/manifest.rs
+++ b/crates/namidb-storage/src/manifest.rs
@@ -793,6 +793,35 @@ impl DescriptorIndex {
             .map(|v| v.as_slice())
             .unwrap_or(&[])
     }
+
+    /// All node-SST descriptor indices across every scope: the id-primary
+    /// partition (`scope = ""`) plus any legacy per-label scopes. Now that
+    /// nodes are not partitioned by label, the read path scans the union and
+    /// filters by each row's decoded label set.
+    pub fn node_descriptors(&self) -> Vec<usize> {
+        let mut out: Vec<usize> = self
+            .buckets
+            .iter()
+            .filter(|((kind, _), _)| *kind == SstKind::Nodes)
+            .flat_map(|(_, v)| v.iter().copied())
+            .collect();
+        out.sort_unstable();
+        out
+    }
+
+    /// Node-SST candidate indices whose `(min_key, max_key)` straddles
+    /// `target`, across every node scope. The scope-agnostic analogue of
+    /// [`lookup_candidates`] for id-primary point lookups.
+    pub fn node_candidates(&self, ssts: &[SstDescriptor], target: &[u8; 16]) -> Vec<usize> {
+        let mut out = Vec::new();
+        for (kind, scope) in self.buckets.keys() {
+            if *kind != SstKind::Nodes {
+                continue;
+            }
+            out.extend(self.lookup_candidates(ssts, SstKind::Nodes, scope, target));
+        }
+        out
+    }
 }
 
 #[cfg(test)]

--- a/crates/namidb-storage/src/manifest.rs
+++ b/crates/namidb-storage/src/manifest.rs
@@ -292,6 +292,16 @@ pub struct LabelIndexDescriptor {
     pub label_count: u64,
     /// Total number of `(label, NodeId)` postings across every key.
     pub posting_count: u64,
+    /// Live posting count per `LabelId` — the length of each label's posting
+    /// list in the sidecar (tombstones already excluded by the builder). Sorted
+    /// by label id. Now that node SSTs are no longer partitioned by label
+    /// (`scope` is empty), the cost model recovers each label's `node_count` by
+    /// summing these across node SSTs and resolving the id via the manifest's
+    /// `label_dict` — a manifest-only, `O(|ssts|)` derivation that needs no
+    /// sidecar body read. Empty for manifests written before this field existed
+    /// (`serde(default)` round-trips them unchanged).
+    #[serde(default)]
+    pub per_label_counts: Vec<(u32, u64)>,
 }
 
 /// JSON serde helper: `[u8; 16]` ↔ base64-standard string.

--- a/crates/namidb-storage/src/memtable.rs
+++ b/crates/namidb-storage/src/memtable.rs
@@ -26,12 +26,16 @@ use serde::{Deserialize, Serialize};
 
 use namidb_core::NodeId;
 
-/// Key into the memtable. Sorts by (kind, label/type, id, …) so iteration
-/// produces SST-friendly runs per scope.
+/// Key into the memtable.
+///
+/// Nodes are keyed by `id` alone (id-primary): a node's label set rides in the
+/// value (the encoded `NodeWriteRecord`), not the key, so the same id is one
+/// row regardless of how many labels it carries. Edges still key by
+/// `(edge_type, src, dst)`. Node keys sort before edge keys (variant order),
+/// and within nodes by `id`, which keeps flush output id-ascending for free.
 #[derive(Debug, Clone, PartialEq, Eq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
 pub enum MemKey {
     Node {
-        label: String,
         id: NodeId,
     },
     Edge {
@@ -42,15 +46,17 @@ pub enum MemKey {
 }
 
 impl MemKey {
+    /// Scope string used by the flush/manifest layer. Nodes are no longer
+    /// partitioned by label, so their scope is empty; edges scope by type.
     pub fn scope(&self) -> &str {
         match self {
-            MemKey::Node { label, .. } => label,
+            MemKey::Node { .. } => "",
             MemKey::Edge { edge_type, .. } => edge_type,
         }
     }
     fn approx_bytes(&self) -> usize {
         match self {
-            MemKey::Node { label, .. } => label.len() + 16,
+            MemKey::Node { .. } => 16,
             MemKey::Edge { edge_type, .. } => edge_type.len() + 32,
         }
     }
@@ -132,22 +138,18 @@ impl Memtable {
         self.inner.iter()
     }
 
-    /// Iterate entries restricted to a single label.
-    pub fn iter_label<'a>(
-        &'a self,
-        label: &'a str,
-    ) -> impl Iterator<Item = (&'a MemKey, &'a MemEntry)> + 'a {
+    /// Iterate every node entry (all `MemKey::Node`) in id order. Nodes sort
+    /// before edges and the read path filters by decoding each value's label
+    /// set, since the label is no longer in the key.
+    pub fn iter_nodes(&self) -> impl Iterator<Item = (&MemKey, &MemEntry)> {
         let start = MemKey::Node {
-            label: label.to_string(),
             id: NodeId::from_uuid(uuid::Uuid::nil()),
         };
         let end = MemKey::Node {
-            label: label.to_string(),
             id: NodeId::from_uuid(uuid::Uuid::max()),
         };
         self.inner
             .range((Bound::Included(start), Bound::Included(end)))
-            .filter(move |(k, _)| matches!(k, MemKey::Node { label: l, .. } if l == label))
     }
 
     /// Iterate entries restricted to a single edge type.
@@ -190,7 +192,7 @@ impl Memtable {
 ///
 /// Built by [`Memtable::snapshot_view`] and shared across concurrent
 /// readers via `Arc`. Exposes the same read API a `&Memtable` did
-/// (`iter`, `get`, `iter_label`, `iter_edge_type`), with no mutation
+/// (`iter`, `get`, `iter_nodes`, `iter_edge_type`), with no mutation
 /// surface. See RFC-021.
 #[derive(Debug, Default, Clone)]
 pub struct MemtableSnapshot {
@@ -219,21 +221,17 @@ impl MemtableSnapshot {
         self.inner.iter()
     }
 
-    pub fn iter_label<'a>(
-        &'a self,
-        label: &'a str,
-    ) -> impl Iterator<Item = (&'a MemKey, &'a MemEntry)> + 'a {
+    /// Iterate every node entry (all `MemKey::Node`) in id order. The read
+    /// path decodes each value's label set to filter by label.
+    pub fn iter_nodes(&self) -> impl Iterator<Item = (&MemKey, &MemEntry)> {
         let start = MemKey::Node {
-            label: label.to_string(),
             id: NodeId::from_uuid(uuid::Uuid::nil()),
         };
         let end = MemKey::Node {
-            label: label.to_string(),
             id: NodeId::from_uuid(uuid::Uuid::max()),
         };
         self.inner
             .range((Bound::Included(start), Bound::Included(end)))
-            .filter(move |(k, _)| matches!(k, MemKey::Node { label: l, .. } if l == label))
     }
 
     pub fn iter_edge_type<'a>(
@@ -280,10 +278,7 @@ mod tests {
     #[test]
     fn upsert_replaces_previous_value() {
         let mut mt = Memtable::new();
-        let key = MemKey::Node {
-            label: "Person".into(),
-            id: nid(1),
-        };
+        let key = MemKey::Node { id: nid(1) };
         let prev = mt.apply(key.clone(), 1, MemOp::Upsert(Bytes::from_static(b"v1")));
         assert!(prev.is_none());
 
@@ -303,10 +298,7 @@ mod tests {
     #[test]
     fn tombstone_overrides_upsert() {
         let mut mt = Memtable::new();
-        let key = MemKey::Node {
-            label: "Person".into(),
-            id: nid(1),
-        };
+        let key = MemKey::Node { id: nid(1) };
         mt.apply(key.clone(), 1, MemOp::Upsert(Bytes::from_static(b"v1")));
         mt.apply(key.clone(), 2, MemOp::Tombstone);
         assert_eq!(mt.get(&key).unwrap().op, MemOp::Tombstone);
@@ -315,10 +307,7 @@ mod tests {
     #[test]
     fn bytes_estimate_tracks_replacements_and_deletes() {
         let mut mt = Memtable::new();
-        let key = MemKey::Node {
-            label: "Person".into(),
-            id: nid(1),
-        };
+        let key = MemKey::Node { id: nid(1) };
         mt.apply(key.clone(), 1, MemOp::Upsert(Bytes::from_static(b"v1")));
         let after_first = mt.bytes_estimate();
         mt.apply(
@@ -337,18 +326,9 @@ mod tests {
     fn iter_yields_keys_in_order() {
         let mut mt = Memtable::new();
         let keys = [
-            MemKey::Node {
-                label: "Person".into(),
-                id: nid(3),
-            },
-            MemKey::Node {
-                label: "Person".into(),
-                id: nid(1),
-            },
-            MemKey::Node {
-                label: "Person".into(),
-                id: nid(2),
-            },
+            MemKey::Node { id: nid(3) },
+            MemKey::Node { id: nid(1) },
+            MemKey::Node { id: nid(2) },
         ];
         for (i, k) in keys.iter().enumerate() {
             mt.apply(k.clone(), i as u64, MemOp::Upsert(Bytes::from_static(b"x")));
@@ -364,21 +344,15 @@ mod tests {
     }
 
     #[test]
-    fn iter_label_scopes_correctly() {
+    fn iter_nodes_and_edge_type_scope_correctly() {
         let mut mt = Memtable::new();
         mt.apply(
-            MemKey::Node {
-                label: "Person".into(),
-                id: nid(1),
-            },
+            MemKey::Node { id: nid(1) },
             1,
             MemOp::Upsert(Bytes::from_static(b"a")),
         );
         mt.apply(
-            MemKey::Node {
-                label: "Company".into(),
-                id: nid(2),
-            },
+            MemKey::Node { id: nid(2) },
             2,
             MemOp::Upsert(Bytes::from_static(b"b")),
         );
@@ -392,9 +366,9 @@ mod tests {
             MemOp::Upsert(Bytes::from_static(b"c")),
         );
 
-        assert_eq!(mt.iter_label("Person").count(), 1);
-        assert_eq!(mt.iter_label("Company").count(), 1);
-        assert_eq!(mt.iter_label("Unknown").count(), 0);
+        // Nodes are no longer scoped by label in the key; iter_nodes yields
+        // every node entry regardless of label (two distinct ids inserted).
+        assert_eq!(mt.iter_nodes().count(), 2);
         assert_eq!(mt.iter_edge_type("KNOWS").count(), 1);
         assert_eq!(mt.iter_edge_type("OTHER").count(), 0);
     }
@@ -404,10 +378,7 @@ mod tests {
         let mut mt = Memtable::new();
         for i in 0..5 {
             mt.apply(
-                MemKey::Node {
-                    label: "Person".into(),
-                    id: nid(i),
-                },
+                MemKey::Node { id: nid(i) },
                 i as u64,
                 MemOp::Upsert(Bytes::from_static(b"x")),
             );

--- a/crates/namidb-storage/src/parquet_loader.rs
+++ b/crates/namidb-storage/src/parquet_loader.rs
@@ -196,6 +196,7 @@ fn ingest_batch(
         let record = NodeWriteRecord {
             properties,
             schema_version: 1,
+            ..Default::default()
         };
         writer.upsert_node(label, id, &record)?;
         outcome.rows_loaded += 1;

--- a/crates/namidb-storage/src/read.rs
+++ b/crates/namidb-storage/src/read.rs
@@ -49,8 +49,8 @@ use std::sync::{Arc, Mutex};
 use arrow_array::RecordBatch;
 use arrow_array::{
     Array, BinaryArray, BooleanArray, Date32Array, FixedSizeBinaryArray, FixedSizeListArray,
-    Float32Array, Float64Array, Int32Array, Int64Array, LargeStringArray, StringArray,
-    TimestampMicrosecondArray, UInt64Array,
+    Float32Array, Float64Array, Int32Array, Int64Array, LargeStringArray, ListArray, StringArray,
+    TimestampMicrosecondArray, UInt32Array, UInt64Array,
 };
 use bytes::Bytes;
 use object_store::path::Path;
@@ -58,7 +58,7 @@ use object_store::{ObjectStore, ObjectStoreExt};
 use tracing::instrument;
 use uuid::Uuid;
 
-use namidb_core::{DataType, LabelDef, NodeId, Value};
+use namidb_core::{DataType, LabelDef, LabelDictionary, LabelId, NodeId, Value};
 
 use crate::adjacency::{
     adjacency_enabled, build_adjacency, AdjacencyCache, AdjacencyKey, EdgeAdjacency,
@@ -74,8 +74,8 @@ use crate::sst::bloom::BloomFilter;
 use crate::sst::edges::reader::EdgeSstReader;
 use crate::sst::edges::EdgeDirection;
 use crate::sst::nodes::{
-    prop_column_name, targeted_scan_async as node_targeted_scan_async, NodeSstReader, COL_LSN,
-    COL_NODE_ID, COL_TOMBSTONE, OVERFLOW_JSON, SCHEMA_VERSION,
+    prop_column_name, targeted_scan_async as node_targeted_scan_async, NodeSstReader, COL_LABELS,
+    COL_LSN, COL_NODE_ID, COL_TOMBSTONE, OVERFLOW_JSON, SCHEMA_VERSION,
 };
 use crate::sst::predicates::{eval_against_value, ScanPredicate};
 
@@ -349,11 +349,7 @@ impl<'mt> Snapshot<'mt> {
         // every candidate SST carries the sidecar for `property`, we
         // can resolve the lookup with one bincode decode per SST
         // instead of a full label scan.
-        let sst_idxs: Vec<usize> = self
-            .manifest
-            .index
-            .scope_descriptors(SstKind::Nodes, label)
-            .to_vec();
+        let sst_idxs: Vec<usize> = self.manifest.index.node_descriptors();
         let all_have_sidecar = !sst_idxs.is_empty()
             && sst_idxs.iter().all(|i| {
                 self.manifest.manifest.ssts[*i]
@@ -374,21 +370,23 @@ impl<'mt> Snapshot<'mt> {
             // — bounded by memtable size, not the SST.
             let mut winner: Option<(u64, namidb_core::id::NodeId, bool)> = None;
             for (mk, e) in self.memtable.iter() {
-                if let MemKey::Node { label: mlabel, id } = mk {
-                    if mlabel != label {
-                        continue;
-                    }
+                if let MemKey::Node { id } = mk {
                     match &e.op {
                         MemOp::Upsert(payload) => {
                             let rec = NodeWriteRecord::decode(payload)?;
-                            if let Some(namidb_core::Value::Str(s)) = rec.properties.get(property) {
-                                if s == value {
-                                    let bump = winner
-                                        .as_ref()
-                                        .map(|(lsn, _, _)| e.lsn > *lsn)
-                                        .unwrap_or(true);
-                                    if bump {
-                                        winner = Some((e.lsn, *id, false));
+                            if record_carries_label(&rec, label, &self.manifest.manifest.label_dict)
+                            {
+                                if let Some(namidb_core::Value::Str(s)) =
+                                    rec.properties.get(property)
+                                {
+                                    if s == value {
+                                        let bump = winner
+                                            .as_ref()
+                                            .map(|(lsn, _, _)| e.lsn > *lsn)
+                                            .unwrap_or(true);
+                                        if bump {
+                                            winner = Some((e.lsn, *id, false));
+                                        }
                                     }
                                 }
                             }
@@ -513,11 +511,7 @@ impl<'mt> Snapshot<'mt> {
     ) -> Result<Vec<NodeView>> {
         namidb_core::profile_scope!("Snapshot::lookup_nodes_by_property");
 
-        let sst_idxs: Vec<usize> = self
-            .manifest
-            .index
-            .scope_descriptors(SstKind::Nodes, label)
-            .to_vec();
+        let sst_idxs: Vec<usize> = self.manifest.index.node_descriptors();
         let all_have_sidecar = !sst_idxs.is_empty()
             && sst_idxs.iter().all(|i| {
                 self.manifest.manifest.ssts[*i]
@@ -545,15 +539,14 @@ impl<'mt> Snapshot<'mt> {
         let mut candidates: std::collections::BTreeSet<namidb_core::id::NodeId> =
             std::collections::BTreeSet::new();
         for (mk, e) in self.memtable.iter() {
-            if let MemKey::Node { label: mlabel, id } = mk {
-                if mlabel != label {
-                    continue;
-                }
+            if let MemKey::Node { id } = mk {
                 if let MemOp::Upsert(payload) = &e.op {
                     let rec = NodeWriteRecord::decode(payload)?;
-                    if let Some(namidb_core::Value::Str(s)) = rec.properties.get(property) {
-                        if s == value {
-                            candidates.insert(*id);
+                    if record_carries_label(&rec, label, &self.manifest.manifest.label_dict) {
+                        if let Some(namidb_core::Value::Str(s)) = rec.properties.get(property) {
+                            if s == value {
+                                candidates.insert(*id);
+                            }
                         }
                     }
                 }
@@ -682,9 +675,16 @@ impl<'mt> Snapshot<'mt> {
         // nodes) skip the SST lookup entirely.
         let mut mem_node_label: BTreeMap<NodeId, String> = BTreeMap::new();
         for (key, entry) in self.memtable.iter() {
-            if let MemKey::Node { label, id } = key {
-                if matches!(entry.op, MemOp::Upsert(_)) {
-                    mem_node_label.insert(*id, label.clone());
+            if let MemKey::Node { id } = key {
+                if let MemOp::Upsert(payload) = &entry.op {
+                    let rec = NodeWriteRecord::decode(payload)?;
+                    if let Some(name) = rec
+                        .labels
+                        .first()
+                        .and_then(|&lid| self.manifest.manifest.label_dict.name(LabelId::new(lid)))
+                    {
+                        mem_node_label.insert(*id, name.to_string());
+                    }
                 }
             }
         }
@@ -813,13 +813,15 @@ impl<'mt> Snapshot<'mt> {
             .keys()
             .cloned()
             .collect();
-        for (key, _) in self.memtable.iter() {
-            if let MemKey::Node { label, .. } = key {
-                set.insert(label.clone());
-            }
+        // The dictionary holds every label name ever interned in this
+        // namespace (memtable writes intern into it before commit).
+        for (_, name) in self.manifest.manifest.label_dict.iter() {
+            set.insert(name.to_string());
         }
+        // Legacy node SSTs still carry their single label as the scope; id-
+        // primary SSTs use an empty scope and contribute nothing here.
         for sst in &self.manifest.manifest.ssts {
-            if matches!(sst.kind, SstKind::Nodes) {
+            if matches!(sst.kind, SstKind::Nodes) && !sst.scope.is_empty() {
                 set.insert(sst.scope.clone());
             }
         }
@@ -917,8 +919,12 @@ impl<'mt> Snapshot<'mt> {
             }
         }
 
-        // L3: cold SST walk.
-        let result = self.lookup_node_uncached(label, id).await?;
+        // L3: cold SST walk. Resolve the id-primary record, then keep it only
+        // if it actually carries `label` (the cache slot is per `(label, id)`).
+        let result = self
+            .lookup_node_by_id(id)
+            .await?
+            .filter(|v| v.labels.contains(label));
         // Insert into L1.
         self.node_cache
             .lock()
@@ -1032,17 +1038,15 @@ impl<'mt> Snapshot<'mt> {
         // 1. Memtable: probe each pending id.
         for id_bytes in &pending {
             let id = NodeId::from_uuid(Uuid::from_bytes(*id_bytes));
-            if let Some(entry) = self.memtable.get(&MemKey::Node {
-                label: label.to_string(),
-                id,
-            }) {
+            if let Some(entry) = self.memtable.get(&MemKey::Node { id }) {
                 let view = match &entry.op {
                     MemOp::Tombstone => None,
                     MemOp::Upsert(payload) => Some(node_view_from_payload(
                         id,
-                        label.to_string(),
                         entry.lsn,
                         payload,
+                        &self.manifest.manifest.label_dict,
+                        "",
                     )?),
                 };
                 // Inline last-LSN-wins: equivalent to update_node_winner
@@ -1057,24 +1061,10 @@ impl<'mt> Snapshot<'mt> {
             }
         }
 
-        // 2. SST pass: iterate every `(Nodes, label)` descriptor exactly
-        // once, decode its body, and harvest every pending id in one
-        // sweep over the record batches.
-        let label_def = self
-            .manifest
-            .manifest
-            .schema
-            .label(label)
-            .cloned()
-            .unwrap_or_else(|| LabelDef {
-                name: label.to_string(),
-                properties: vec![],
-            });
-        let sst_idxs: Vec<usize> = self
-            .manifest
-            .index
-            .scope_descriptors(SstKind::Nodes, label)
-            .to_vec();
+        // 2. SST pass: iterate every node descriptor (id-primary partition +
+        // any legacy per-label SSTs) exactly once, decode its body, and harvest
+        // every pending id in one sweep over the record batches.
+        let sst_idxs: Vec<usize> = self.manifest.index.node_descriptors();
         for idx in sst_idxs {
             let desc = &self.manifest.manifest.ssts[idx];
             // Cheap pre-filter: skip the SST if its [min_key, max_key]
@@ -1106,7 +1096,7 @@ impl<'mt> Snapshot<'mt> {
                 b
             } else {
                 let body = self.get_sst_body(desc).await?;
-                let reader = NodeSstReader::open(label_def.clone(), body)?;
+                let reader = NodeSstReader::open(self.label_def_for_node_sst(desc), body)?;
                 let decoded = Arc::new(reader.scan()?);
                 // Re-acquire the lock to insert — last write wins on
                 // a race because both threads decoded identical bytes.
@@ -1116,7 +1106,14 @@ impl<'mt> Snapshot<'mt> {
                     .insert(absolute.clone(), decoded.clone());
                 decoded
             };
-            batch_harvest_node_rows(&batches, &label_def, label, &pending, &mut winners)?;
+            batch_harvest_node_rows(
+                &batches,
+                &self.label_def_for_node_sst(desc),
+                &self.manifest.manifest.label_dict,
+                &desc.scope,
+                &pending,
+                &mut winners,
+            )?;
         }
 
         // 3. Push every (resolved or negative) outcome into the output
@@ -1125,7 +1122,11 @@ impl<'mt> Snapshot<'mt> {
         let manifest_version = self.manifest.manifest.version;
         let mut cache_l1 = self.node_cache.lock().unwrap();
         for id_bytes in &pending {
-            let view = winners.remove(id_bytes).map(|(_, v)| v).unwrap_or(None);
+            let view = winners
+                .remove(id_bytes)
+                .map(|(_, v)| v)
+                .unwrap_or(None)
+                .filter(|v| v.labels.contains(label));
             for &i in &id_to_outputs[id_bytes] {
                 out[i] = view.clone();
             }
@@ -1152,56 +1153,66 @@ impl<'mt> Snapshot<'mt> {
         label: &str,
         id: NodeId,
     ) -> Result<Option<NodeView>> {
-        self.lookup_node_uncached(label, id).await
+        Ok(self
+            .lookup_node_by_id(id)
+            .await?
+            .filter(|v| v.labels.contains(label)))
     }
 
-    async fn lookup_node_uncached(&self, label: &str, id: NodeId) -> Result<Option<NodeView>> {
-        namidb_core::profile_scope!("Snapshot::lookup_node_uncached");
+    /// The `LabelDef` to open a node SST with. Id-primary node SSTs carry
+    /// `scope = ""` and no declared columns (every property in overflow); legacy
+    /// single-label SSTs are still typed by their scope label.
+    fn label_def_for_node_sst(&self, desc: &SstDescriptor) -> LabelDef {
+        if desc.scope.is_empty() {
+            LabelDef {
+                name: String::new(),
+                properties: Vec::new(),
+            }
+        } else {
+            self.manifest
+                .manifest
+                .schema
+                .label(&desc.scope)
+                .cloned()
+                .unwrap_or_else(|| LabelDef {
+                    name: desc.scope.clone(),
+                    properties: Vec::new(),
+                })
+        }
+    }
+
+    /// Id-primary cold lookup: resolve the last-LSN-wins record for `id` across
+    /// the memtable and every node SST (decoding each row's label set), with no
+    /// label scoping. `lookup_node` filters the result by label.
+    async fn lookup_node_by_id(&self, id: NodeId) -> Result<Option<NodeView>> {
+        namidb_core::profile_scope!("Snapshot::lookup_node_by_id");
         let id_bytes = *id.as_bytes();
+        let dict = &self.manifest.manifest.label_dict;
         let mut winner: Option<(u64, Option<NodeView>)> = None;
 
         // 1. Memtable (highest LSN typically).
-        if let Some(entry) = self.memtable.get(&MemKey::Node {
-            label: label.to_string(),
-            id,
-        }) {
+        if let Some(entry) = self.memtable.get(&MemKey::Node { id }) {
             let view = match &entry.op {
                 MemOp::Tombstone => None,
-                MemOp::Upsert(payload) => Some(node_view_from_payload(
-                    id,
-                    label.to_string(),
-                    entry.lsn,
-                    payload,
-                )?),
+                MemOp::Upsert(payload) => {
+                    Some(node_view_from_payload(id, entry.lsn, payload, dict, "")?)
+                }
             };
             winner = Some((entry.lsn, view));
         }
 
-        // 2. SST candidates — pruned via the manifest's sorted-by-min-key
-        // index. The index returns descriptor positions whose
-        // `(min_key, max_key)` already straddles `id_bytes` for
-        // `(Nodes, label)`; we still bloom-probe + body-fetch.
-        let label_def = self
+        // 2. Node SST candidates across every scope (id-primary), pruned by the
+        // per-bucket min/max-key index; still bloom-probed + body-fetched.
+        let candidates = self
             .manifest
-            .manifest
-            .schema
-            .label(label)
-            .cloned()
-            .unwrap_or_else(|| LabelDef {
-                name: label.to_string(),
-                properties: vec![],
-            });
-        let candidates = self.manifest.index.lookup_candidates(
-            &self.manifest.manifest.ssts,
-            SstKind::Nodes,
-            label,
-            &id_bytes,
-        );
+            .index
+            .node_candidates(&self.manifest.manifest.ssts, &id_bytes);
         for idx in candidates {
             let desc = &self.manifest.manifest.ssts[idx];
             if !self.bloom_admits(desc, &id_bytes).await? {
                 continue;
             }
+            let label_def = self.label_def_for_node_sst(desc);
             // Cold-path routing (RFC-003):
             // - Ranged disabled (forced off, or `Auto` below the size
             // threshold): full-body GET via `get_sst_body` —
@@ -1216,12 +1227,12 @@ impl<'mt> Snapshot<'mt> {
             let candidate = if !use_ranged {
                 let body = self.get_sst_body(desc).await?;
                 let reader = NodeSstReader::open(label_def.clone(), body)?;
-                find_node_row(&reader, &label_def, id, label)?
+                find_node_row(&reader, &label_def, id, dict, &desc.scope)?
             } else {
                 let absolute = format!("{}/{}", self.paths.namespace_prefix().as_ref(), desc.path);
                 if let Some(body) = self.cache_get(&absolute) {
                     let reader = NodeSstReader::open(label_def.clone(), body)?;
-                    find_node_row(&reader, &label_def, id, label)?
+                    find_node_row(&reader, &label_def, id, dict, &desc.scope)?
                 } else {
                     // Look up cached parquet metadata first; on hit we
                     // skip the footer + page-index round-trip entirely
@@ -1242,7 +1253,7 @@ impl<'mt> Snapshot<'mt> {
                     if let Some(cache) = &self.cache {
                         cache.insert_metadata(absolute, meta);
                     }
-                    find_node_row_in_batches(&batches, &label_def, id, label)?
+                    find_node_row_in_batches(&batches, &label_def, id, dict, &desc.scope)?
                 }
             };
             if let Some((lsn, view)) = candidate {
@@ -1327,36 +1338,25 @@ impl<'mt> Snapshot<'mt> {
         predicates: &[ScanPredicate],
         projection: Option<&[String]>,
     ) -> Result<Vec<NodeView>> {
-        let label_def = self
-            .manifest
-            .manifest
-            .schema
-            .label(label)
-            .cloned()
-            .unwrap_or_else(|| LabelDef {
-                name: label.to_string(),
-                properties: vec![],
-            });
+        let dict = &self.manifest.manifest.label_dict;
 
         // (node_id) → (winning lsn, materialised view or tombstone marker).
+        // Nodes are id-primary: materialise every node across the label-agnostic
+        // memtable + node SSTs and keep only those whose decoded label set
+        // contains `label` (filtered at the end).
         let mut latest: BTreeMap<NodeId, (u64, Option<NodeView>)> = BTreeMap::new();
 
-        // 1. Memtable rows for this label. Apply predicates after
-        // materialising the view; if any predicate evaluates to
-        // false / NULL, drop the view (kept as tombstone-like None
-        // so subsequent SST upserts for the same id are not
-        // spuriously surfaced).
+        // 1. Memtable rows. Apply predicates after materialising the view; a
+        // failing predicate yields a tombstone-like None so a lower-LSN SST row
+        // for the same id is not spuriously surfaced.
         for (mk, entry) in self.memtable.iter() {
-            let MemKey::Node { label: ml, id } = mk else {
+            let MemKey::Node { id } = mk else {
                 continue;
             };
-            if ml != label {
-                continue;
-            }
             let view = match &entry.op {
                 MemOp::Tombstone => None,
                 MemOp::Upsert(payload) => {
-                    let mut v = node_view_from_payload(*id, label.to_string(), entry.lsn, payload)?;
+                    let mut v = node_view_from_payload(*id, entry.lsn, payload, dict, "")?;
                     if !node_view_matches_predicates(&v, predicates) {
                         None
                     } else {
@@ -1374,12 +1374,14 @@ impl<'mt> Snapshot<'mt> {
             update_node_winner(&mut latest, *id, entry.lsn, view);
         }
 
-        // 2. SSTs that scope to `label`, taken straight from the
-        // manifest index so we don't re-scan every descriptor.
-        for &idx in self.manifest.index.scope_descriptors(SstKind::Nodes, label) {
+        // 2. Every node SST: the id-primary partition plus any legacy per-label
+        // SSTs. Each row's label set is decoded from `__labels` (or the scope
+        // for legacy SSTs); the label filter is applied at the end.
+        for idx in self.manifest.index.node_descriptors() {
             let desc = &self.manifest.manifest.ssts[idx];
+            let sst_label_def = self.label_def_for_node_sst(desc);
             let body = self.get_sst_body(desc).await?;
-            let reader = NodeSstReader::open(label_def.clone(), body)?;
+            let reader = NodeSstReader::open(sst_label_def.clone(), body)?;
             // Build the projection set once per SST (declared properties
             // ∩ requested). When `projection.is_none()` we iterate every
             // declared property.
@@ -1419,7 +1421,7 @@ impl<'mt> Snapshot<'mt> {
                         continue;
                     }
                     let mut properties: BTreeMap<String, Value> = BTreeMap::new();
-                    for p in &label_def.properties {
+                    for p in &sst_label_def.properties {
                         // Skip properties not in the projection (when one
                         // is set). Engine columns are still required and
                         // were included by the ProjectionMask.
@@ -1454,7 +1456,7 @@ impl<'mt> Snapshot<'mt> {
                     }
                     let view = NodeView {
                         id: row_id,
-                        labels: BTreeSet::from([label.to_string()]),
+                        labels: decode_node_labels(&batch, row, dict, &desc.scope),
                         properties,
                         lsn,
                         schema_version: sv_col.value(row),
@@ -1474,8 +1476,13 @@ impl<'mt> Snapshot<'mt> {
             }
         }
 
-        // 3. Drop tombstones and return in ascending-id order (BTreeMap iter).
-        Ok(latest.into_values().filter_map(|(_, v)| v).collect())
+        // 3. Drop tombstones and rows that don't carry `label`; return in
+        // ascending-id order (BTreeMap iter).
+        Ok(latest
+            .into_values()
+            .filter_map(|(_, v)| v)
+            .filter(|v| v.labels.contains(label))
+            .collect())
     }
 
     /// Materialise every edge row of `edge_type` visible at this snapshot.
@@ -2337,18 +2344,71 @@ fn update_edge_count_winner(
 
 fn node_view_from_payload(
     id: NodeId,
-    label: String,
     lsn: u64,
     payload: &Bytes,
+    dict: &LabelDictionary,
+    scope_fallback: &str,
 ) -> Result<NodeView> {
     let rec = NodeWriteRecord::decode(payload)?;
+    let labels = labels_from_ids(&rec.labels, dict, scope_fallback);
     Ok(NodeView {
         id,
-        labels: BTreeSet::from([label]),
+        labels,
         properties: rec.properties,
         lsn,
         schema_version: rec.schema_version,
     })
+}
+
+/// Whether a decoded record carries `label`, resolving the name via `dict`.
+/// Used to label-filter memtable rows now that the label left the key.
+fn record_carries_label(rec: &NodeWriteRecord, label: &str, dict: &LabelDictionary) -> bool {
+    dict.id(label)
+        .map(|lid| rec.labels.contains(&lid.get()))
+        .unwrap_or(false)
+}
+
+/// Resolve interned `LabelId`s to label names via `dict`. Falls back to a
+/// singleton `{scope_fallback}` when there are no ids (a legacy single-label
+/// record/SST), or to an empty set when the fallback is empty.
+fn labels_from_ids(ids: &[u32], dict: &LabelDictionary, scope_fallback: &str) -> BTreeSet<String> {
+    let mut set: BTreeSet<String> = ids
+        .iter()
+        .filter_map(|&lid| dict.name(LabelId::new(lid)).map(String::from))
+        .collect();
+    if set.is_empty() && !scope_fallback.is_empty() {
+        set.insert(scope_fallback.to_string());
+    }
+    set
+}
+
+/// Decode a node SST row's label set from the `__labels` column, resolving
+/// `LabelId`s via `dict`. Legacy SSTs lack the column; their single label is
+/// the SST scope, supplied as `scope_fallback`.
+fn decode_node_labels(
+    batch: &RecordBatch,
+    row: usize,
+    dict: &LabelDictionary,
+    scope_fallback: &str,
+) -> BTreeSet<String> {
+    let Some(list) = batch
+        .column_by_name(COL_LABELS)
+        .and_then(|c| c.as_any().downcast_ref::<ListArray>())
+    else {
+        return labels_from_ids(&[], dict, scope_fallback);
+    };
+    if list.is_null(row) {
+        return labels_from_ids(&[], dict, scope_fallback);
+    }
+    let values = list.value(row);
+    let ids: Vec<u32> = match values.as_any().downcast_ref::<UInt32Array>() {
+        Some(a) => (0..a.len())
+            .filter(|&i| !a.is_null(i))
+            .map(|i| a.value(i))
+            .collect(),
+        None => Vec::new(),
+    };
+    labels_from_ids(&ids, dict, scope_fallback)
 }
 
 /// 3VL evaluation of a conjunctive predicate list against a single
@@ -2371,11 +2431,12 @@ fn find_node_row(
     reader: &NodeSstReader,
     label_def: &LabelDef,
     target: NodeId,
-    label: &str,
+    dict: &LabelDictionary,
+    scope_fallback: &str,
 ) -> Result<Option<(u64, Option<NodeView>)>> {
     let target_bytes = *target.as_bytes();
     let batches = reader.targeted_scan(&target_bytes)?;
-    find_node_row_in_batches(&batches, label_def, target, label)
+    find_node_row_in_batches(&batches, label_def, target, dict, scope_fallback)
 }
 
 /// Backend-agnostic row search over already-decoded record batches.
@@ -2386,7 +2447,8 @@ fn find_node_row_in_batches(
     batches: &[RecordBatch],
     label_def: &LabelDef,
     target: NodeId,
-    label: &str,
+    dict: &LabelDictionary,
+    scope_fallback: &str,
 ) -> Result<Option<(u64, Option<NodeView>)>> {
     let target_bytes = *target.as_bytes();
     for batch in batches {
@@ -2446,7 +2508,7 @@ fn find_node_row_in_batches(
                 lsn,
                 Some(NodeView {
                     id: target,
-                    labels: BTreeSet::from([label.to_string()]),
+                    labels: decode_node_labels(batch, row, dict, scope_fallback),
                     properties,
                     lsn,
                     schema_version,
@@ -2465,7 +2527,8 @@ fn find_node_row_in_batches(
 fn batch_harvest_node_rows(
     batches: &[RecordBatch],
     label_def: &LabelDef,
-    label: &str,
+    dict: &LabelDictionary,
+    scope_fallback: &str,
     pending: &std::collections::HashSet<[u8; 16]>,
     winners: &mut HashMap<[u8; 16], (u64, Option<NodeView>)>,
 ) -> Result<()> {
@@ -2529,7 +2592,7 @@ fn batch_harvest_node_rows(
                 let id = NodeId::from_uuid(Uuid::from_bytes(row_id));
                 Some(NodeView {
                     id,
-                    labels: BTreeSet::from([label.to_string()]),
+                    labels: decode_node_labels(batch, row, dict, scope_fallback),
                     properties,
                     lsn,
                     schema_version,
@@ -2830,6 +2893,7 @@ mod tests {
         NodeWriteRecord {
             properties: props,
             schema_version: 1,
+            ..Default::default()
         }
         .encode()
         .unwrap()
@@ -2856,10 +2920,7 @@ mod tests {
         let alice = sorted_node_id(1);
         let mut mt = Memtable::new();
         mt.apply(
-            MemKey::Node {
-                label: "Person".into(),
-                id: alice,
-            },
+            MemKey::Node { id: alice },
             10,
             MemOp::Upsert(node_payload("Alice", Some(30))),
         );
@@ -2910,6 +2971,7 @@ mod tests {
         NodeWriteRecord {
             properties: props,
             schema_version: 1,
+            ..Default::default()
         }
         .encode()
         .unwrap()
@@ -2924,14 +2986,7 @@ mod tests {
     ) -> LoadedManifest {
         let mut mt = Memtable::new();
         for (id, lsn, op) in rows {
-            mt.apply(
-                MemKey::Node {
-                    label: "Person".into(),
-                    id,
-                },
-                lsn,
-                op,
-            );
+            mt.apply(MemKey::Node { id }, lsn, op);
         }
         let frozen = mt.freeze();
         flush(ms, fence, base, &frozen, schema.clone())
@@ -3054,7 +3109,6 @@ mod tests {
         let mut mt = Memtable::new();
         mt.apply(
             MemKey::Node {
-                label: "Person".into(),
                 id: sorted_node_id(1),
             },
             20,
@@ -3105,7 +3159,6 @@ mod tests {
         let mut mt = Memtable::new();
         mt.apply(
             MemKey::Node {
-                label: "Person".into(),
                 id: sorted_node_id(1),
             },
             20,
@@ -3192,10 +3245,7 @@ mod tests {
         let alice = sorted_node_id(2);
         let mut mt = Memtable::new();
         mt.apply(
-            MemKey::Node {
-                label: "Person".into(),
-                id: alice,
-            },
+            MemKey::Node { id: alice },
             7,
             MemOp::Upsert(node_payload("Alice", Some(28))),
         );
@@ -3240,10 +3290,7 @@ mod tests {
         // Flush an upsert into an SST.
         let mut mt_flush = Memtable::new();
         mt_flush.apply(
-            MemKey::Node {
-                label: "Person".into(),
-                id: alice,
-            },
+            MemKey::Node { id: alice },
             10,
             MemOp::Upsert(node_payload("Alice", Some(30))),
         );
@@ -3254,14 +3301,7 @@ mod tests {
 
         // Live memtable now carries a tombstone at LSN 15 (> SST's LSN 10).
         let mut live_mt = Memtable::new();
-        live_mt.apply(
-            MemKey::Node {
-                label: "Person".into(),
-                id: alice,
-            },
-            15,
-            MemOp::Tombstone,
-        );
+        live_mt.apply(MemKey::Node { id: alice }, 15, MemOp::Tombstone);
 
         let live_mt_view = live_mt.snapshot_view();
         let snap = Snapshot::new(outcome.committed.clone(), &live_mt_view, store, paths);
@@ -3733,10 +3773,7 @@ mod tests {
 
         let mut mt1 = Memtable::new();
         mt1.apply(
-            MemKey::Node {
-                label: "Person".into(),
-                id: id_low,
-            },
+            MemKey::Node { id: id_low },
             1,
             MemOp::Upsert(node_payload("Low", None)),
         );
@@ -3747,10 +3784,7 @@ mod tests {
 
         let mut mt2 = Memtable::new();
         mt2.apply(
-            MemKey::Node {
-                label: "Person".into(),
-                id: id_high,
-            },
+            MemKey::Node { id: id_high },
             2,
             MemOp::Upsert(node_payload("High", None)),
         );
@@ -3787,10 +3821,7 @@ mod tests {
         let alice = sorted_node_id(1);
         let mut mt = Memtable::new();
         mt.apply(
-            MemKey::Node {
-                label: "Person".into(),
-                id: alice,
-            },
+            MemKey::Node { id: alice },
             5,
             MemOp::Upsert(node_payload("Alice", Some(30))),
         );
@@ -4041,10 +4072,7 @@ mod tests {
         let mut mt_flush = Memtable::new();
         for (i, id) in [(1u64, alice), (2, bob), (3, carol)] {
             mt_flush.apply(
-                MemKey::Node {
-                    label: "Person".into(),
-                    id,
-                },
+                MemKey::Node { id },
                 i,
                 MemOp::Upsert(node_payload("X", None)),
             );
@@ -4059,26 +4087,13 @@ mod tests {
         let dave = sorted_node_id(4);
         let mut live = Memtable::new();
         live.apply(
-            MemKey::Node {
-                label: "Person".into(),
-                id: alice,
-            },
+            MemKey::Node { id: alice },
             10,
             MemOp::Upsert(node_payload("Alice-updated", Some(99))),
         );
+        live.apply(MemKey::Node { id: bob }, 11, MemOp::Tombstone);
         live.apply(
-            MemKey::Node {
-                label: "Person".into(),
-                id: bob,
-            },
-            11,
-            MemOp::Tombstone,
-        );
-        live.apply(
-            MemKey::Node {
-                label: "Person".into(),
-                id: dave,
-            },
+            MemKey::Node { id: dave },
             12,
             MemOp::Upsert(node_payload("Dave", None)),
         );
@@ -4281,10 +4296,7 @@ mod tests {
 
         // Append a WAL segment containing an upsert for Alice.
         let entry = WalEntry {
-            key: MemKey::Node {
-                label: "Person".into(),
-                id: alice,
-            },
+            key: MemKey::Node { id: alice },
             op: WalOp::Upsert(node_payload("Alice", Some(40)).to_vec()),
             lsn: 30,
         };
@@ -4361,18 +4373,12 @@ mod tests {
         let company = sorted_node_id(2);
         let mut mt = Memtable::new();
         mt.apply(
-            MemKey::Node {
-                label: "Person".into(),
-                id: person,
-            },
+            MemKey::Node { id: person },
             1,
             MemOp::Upsert(node_payload("Alice", None)),
         );
         mt.apply(
-            MemKey::Node {
-                label: "Company".into(),
-                id: company,
-            },
+            MemKey::Node { id: company },
             2,
             MemOp::Upsert(node_payload("Acme", None)),
         );
@@ -4427,18 +4433,12 @@ mod tests {
         let company = sorted_node_id(2);
         let mut mt = Memtable::new();
         mt.apply(
-            MemKey::Node {
-                label: "Person".into(),
-                id: person,
-            },
+            MemKey::Node { id: person },
             1,
             MemOp::Upsert(node_payload("Alice", None)),
         );
         mt.apply(
-            MemKey::Node {
-                label: "Company".into(),
-                id: company,
-            },
+            MemKey::Node { id: company },
             2,
             MemOp::Upsert(node_payload("Acme", None)),
         );
@@ -4607,10 +4607,7 @@ mod tests {
         let alice = sorted_node_id(1);
         let mut mt = Memtable::new();
         mt.apply(
-            MemKey::Node {
-                label: "Person".into(),
-                id: alice,
-            },
+            MemKey::Node { id: alice },
             1,
             MemOp::Upsert(node_payload("Alice", Some(30))),
         );

--- a/crates/namidb-storage/src/read.rs
+++ b/crates/namidb-storage/src/read.rs
@@ -2893,7 +2893,25 @@ mod tests {
         NodeWriteRecord {
             properties: props,
             schema_version: 1,
-            ..Default::default()
+            // These tests use the single label "Person", which interns to
+            // LabelId(0) on a fresh dict. Carry it on-row so the id-primary
+            // read path resolves the node to "Person".
+            labels: vec![0],
+        }
+        .encode()
+        .unwrap()
+    }
+
+    /// Like `node_payload` but carries an explicit interned `LabelId` on-row.
+    /// Used by the multi-label endpoint-inference tests where the two endpoint
+    /// nodes need distinct labels (e.g. "Person" -> 0, "Company" -> 1).
+    fn labeled_node_payload(name: &str, label_id: u32) -> Bytes {
+        let mut props: BTreeMap<String, Value> = BTreeMap::new();
+        props.insert("name".into(), Value::Str(name.into()));
+        NodeWriteRecord {
+            properties: props,
+            schema_version: 1,
+            labels: vec![label_id],
         }
         .encode()
         .unwrap()
@@ -2913,7 +2931,9 @@ mod tests {
         let store = make_store();
         let paths = make_paths("read-flush");
         let ms = ManifestStore::new(store.clone(), paths.clone());
-        let base = ms.bootstrap(Uuid::now_v7()).await.unwrap();
+        let mut base = ms.bootstrap(Uuid::now_v7()).await.unwrap();
+        // Seed the dict so the on-row LabelId(0) resolves to "Person".
+        base.manifest.label_dict.intern("Person");
         let fence = WriterFence::new(base.manifest.epoch);
         let schema = SchemaBuilder::new().label(person_label()).unwrap().build();
 
@@ -2971,7 +2991,8 @@ mod tests {
         NodeWriteRecord {
             properties: props,
             schema_version: 1,
-            ..Default::default()
+            // Single label "Person" -> LabelId(0) on a fresh dict.
+            labels: vec![0],
         }
         .encode()
         .unwrap()
@@ -3025,7 +3046,9 @@ mod tests {
         let store = make_store();
         let paths = make_paths("eqidx-all");
         let ms = ManifestStore::new(store.clone(), paths.clone());
-        let base = ms.bootstrap(Uuid::now_v7()).await.unwrap();
+        let mut base = ms.bootstrap(Uuid::now_v7()).await.unwrap();
+        // Seed the dict so the on-row LabelId(0) resolves to "Person".
+        base.manifest.label_dict.intern("Person");
         let fence = WriterFence::new(base.manifest.epoch);
         let schema = SchemaBuilder::new()
             .label(indexed_city_label())
@@ -3075,7 +3098,9 @@ mod tests {
         let store = make_store();
         let paths = make_paths("eqidx-tomb");
         let ms = ManifestStore::new(store.clone(), paths.clone());
-        let base = ms.bootstrap(Uuid::now_v7()).await.unwrap();
+        let mut base = ms.bootstrap(Uuid::now_v7()).await.unwrap();
+        // Seed the dict so the on-row LabelId(0) resolves to "Person".
+        base.manifest.label_dict.intern("Person");
         let fence = WriterFence::new(base.manifest.epoch);
         let schema = SchemaBuilder::new()
             .label(indexed_city_label())
@@ -3134,7 +3159,9 @@ mod tests {
         let store = make_store();
         let paths = make_paths("eqidx-changed");
         let ms = ManifestStore::new(store.clone(), paths.clone());
-        let base = ms.bootstrap(Uuid::now_v7()).await.unwrap();
+        let mut base = ms.bootstrap(Uuid::now_v7()).await.unwrap();
+        // Seed the dict so the on-row LabelId(0) resolves to "Person".
+        base.manifest.label_dict.intern("Person");
         let fence = WriterFence::new(base.manifest.epoch);
         let schema = SchemaBuilder::new()
             .label(indexed_city_label())
@@ -3187,7 +3214,9 @@ mod tests {
         let store = make_store();
         let paths = make_paths("eqidx-compact");
         let ms = ManifestStore::new(store.clone(), paths.clone());
-        let base = ms.bootstrap(Uuid::now_v7()).await.unwrap();
+        let mut base = ms.bootstrap(Uuid::now_v7()).await.unwrap();
+        // Seed the dict so the on-row LabelId(0) resolves to "Person".
+        base.manifest.label_dict.intern("Person");
         let fence = WriterFence::new(base.manifest.epoch);
         let schema = SchemaBuilder::new()
             .label(indexed_city_label())
@@ -3240,7 +3269,10 @@ mod tests {
         let store = make_store();
         let paths = make_paths("read-mt");
         let ms = ManifestStore::new(store.clone(), paths.clone());
-        let base = ms.bootstrap(Uuid::now_v7()).await.unwrap();
+        let mut base = ms.bootstrap(Uuid::now_v7()).await.unwrap();
+        // No flush here: the snapshot reads the live memtable. Seed the dict so
+        // the record's on-row LabelId(0) resolves to "Person".
+        base.manifest.label_dict.intern("Person");
 
         let alice = sorted_node_id(2);
         let mut mt = Memtable::new();
@@ -3764,7 +3796,9 @@ mod tests {
         let store = make_store();
         let paths = make_paths("read-prune");
         let ms = ManifestStore::new(store.clone(), paths.clone());
-        let base = ms.bootstrap(Uuid::now_v7()).await.unwrap();
+        let mut base = ms.bootstrap(Uuid::now_v7()).await.unwrap();
+        // Seed the dict so the on-row LabelId(0) resolves to "Person".
+        base.manifest.label_dict.intern("Person");
         let fence = WriterFence::new(base.manifest.epoch);
         let schema = SchemaBuilder::new().label(person_label()).unwrap().build();
 
@@ -3814,7 +3848,9 @@ mod tests {
         let store = make_store();
         let paths = make_paths("read-cache");
         let ms = ManifestStore::new(store.clone(), paths.clone());
-        let base = ms.bootstrap(Uuid::now_v7()).await.unwrap();
+        let mut base = ms.bootstrap(Uuid::now_v7()).await.unwrap();
+        // Seed the dict so the on-row LabelId(0) resolves to "Person".
+        base.manifest.label_dict.intern("Person");
         let fence = WriterFence::new(base.manifest.epoch);
         let schema = SchemaBuilder::new().label(person_label()).unwrap().build();
 
@@ -4061,7 +4097,10 @@ mod tests {
         let store = make_store();
         let paths = make_paths("scan-nodes");
         let ms = ManifestStore::new(store.clone(), paths.clone());
-        let base = ms.bootstrap(Uuid::now_v7()).await.unwrap();
+        let mut base = ms.bootstrap(Uuid::now_v7()).await.unwrap();
+        // Seed the dict so the on-row LabelId(0) resolves to "Person" for both
+        // the flushed SST rows and the live-memtable rows.
+        base.manifest.label_dict.intern("Person");
         let fence = WriterFence::new(base.manifest.epoch);
         let schema = SchemaBuilder::new().label(person_label()).unwrap().build();
 
@@ -4289,7 +4328,10 @@ mod tests {
         let paths = make_paths("read-recovery");
         let ms = ManifestStore::new(store.clone(), paths.clone());
         let wal_store = WalStore::new(store.clone(), paths.clone());
-        let base = ms.bootstrap(Uuid::now_v7()).await.unwrap();
+        let mut base = ms.bootstrap(Uuid::now_v7()).await.unwrap();
+        // Seed the dict so the recovered record's on-row LabelId(0) resolves to
+        // "Person". `next_version` clones the dict forward into `with_wal`.
+        base.manifest.label_dict.intern("Person");
         let fence = WriterFence::new(base.manifest.epoch);
 
         let alice = sorted_node_id(5);
@@ -4365,7 +4407,11 @@ mod tests {
         let store = make_store();
         let paths = make_paths("schema-endpoints-inferred");
         let ms = ManifestStore::new(store.clone(), paths.clone());
-        let base = ms.bootstrap(Uuid::now_v7()).await.unwrap();
+        let mut base = ms.bootstrap(Uuid::now_v7()).await.unwrap();
+        // Two distinct labels: "Person" -> LabelId(0), "Company" -> LabelId(1).
+        // Seed the dict so each record's on-row id resolves to its name.
+        base.manifest.label_dict.intern("Person");
+        base.manifest.label_dict.intern("Company");
 
         // Two nodes with distinct labels, one edge that ties them
         // together, no `SchemaBuilder` ever ran.
@@ -4380,7 +4426,7 @@ mod tests {
         mt.apply(
             MemKey::Node { id: company },
             2,
-            MemOp::Upsert(node_payload("Acme", None)),
+            MemOp::Upsert(labeled_node_payload("Acme", 1)),
         );
         mt.apply(
             MemKey::Edge {
@@ -4413,7 +4459,13 @@ mod tests {
         let store = make_store();
         let paths = make_paths("schema-endpoints-sst");
         let ms = ManifestStore::new(store.clone(), paths.clone());
-        let base = ms.bootstrap(Uuid::now_v7()).await.unwrap();
+        let mut base = ms.bootstrap(Uuid::now_v7()).await.unwrap();
+        // Two distinct labels: "Person" -> LabelId(0), "Company" -> LabelId(1).
+        // Seed the dict so each flushed SST row's on-row id resolves to its
+        // name (`next_version` clones the dict forward into the committed
+        // manifest).
+        base.manifest.label_dict.intern("Person");
+        base.manifest.label_dict.intern("Company");
         let fence = WriterFence::new(base.manifest.epoch);
 
         // Declare the node labels so the flush writes node SSTs, but leave
@@ -4440,7 +4492,7 @@ mod tests {
         mt.apply(
             MemKey::Node { id: company },
             2,
-            MemOp::Upsert(node_payload("Acme", None)),
+            MemOp::Upsert(labeled_node_payload("Acme", 1)),
         );
         mt.apply(
             MemKey::Edge {

--- a/crates/namidb-storage/src/recovery.rs
+++ b/crates/namidb-storage/src/recovery.rs
@@ -365,10 +365,7 @@ mod tests {
     #[test]
     fn wal_entry_round_trip_upsert() {
         let entry = WalEntry {
-            key: MemKey::Node {
-                label: "Person".into(),
-                id: nid(1),
-            },
+            key: MemKey::Node { id: nid(1) },
             op: WalOp::Upsert(b"payload-bytes".to_vec()),
             lsn: 7,
         };
@@ -395,10 +392,7 @@ mod tests {
 
     #[test]
     fn from_apply_converts_memop() {
-        let key = MemKey::Node {
-            label: "Person".into(),
-            id: nid(3),
-        };
+        let key = MemKey::Node { id: nid(3) };
         let upsert = MemOp::Upsert(Bytes::from_static(b"x"));
         let entry = WalEntry::from_apply(key.clone(), 5, &upsert);
         match entry.op {
@@ -436,26 +430,17 @@ mod tests {
         let bob_id = nid(2);
 
         let e1 = WalEntry {
-            key: MemKey::Node {
-                label: "Person".into(),
-                id: alice_id,
-            },
+            key: MemKey::Node { id: alice_id },
             op: WalOp::Upsert(b"alice-v1".to_vec()),
             lsn: 10,
         };
         let e2 = WalEntry {
-            key: MemKey::Node {
-                label: "Person".into(),
-                id: bob_id,
-            },
+            key: MemKey::Node { id: bob_id },
             op: WalOp::Upsert(b"bob-v1".to_vec()),
             lsn: 11,
         };
         let e3 = WalEntry {
-            key: MemKey::Node {
-                label: "Person".into(),
-                id: alice_id,
-            },
+            key: MemKey::Node { id: alice_id },
             op: WalOp::Tombstone,
             lsn: 12,
         };
@@ -481,19 +466,13 @@ mod tests {
         assert_eq!(out.memtable.len(), 2);
 
         // Alice's last op was the tombstone.
-        let alice_key = MemKey::Node {
-            label: "Person".into(),
-            id: alice_id,
-        };
+        let alice_key = MemKey::Node { id: alice_id };
         let alice = out.memtable.get(&alice_key).unwrap();
         assert_eq!(alice.lsn, 12);
         assert_eq!(alice.op, MemOp::Tombstone);
 
         // Bob is still an upsert.
-        let bob_key = MemKey::Node {
-            label: "Person".into(),
-            id: bob_id,
-        };
+        let bob_key = MemKey::Node { id: bob_id };
         let bob = out.memtable.get(&bob_key).unwrap();
         assert_eq!(bob.lsn, 11);
         match &bob.op {
@@ -515,10 +494,7 @@ mod tests {
         // not strictly increasing with seq to prove we trust seq order
         // and the Memtable's "last write wins" semantics, not a sort
         // by LSN.)
-        let key = MemKey::Node {
-            label: "Person".into(),
-            id: nid(7),
-        };
+        let key = MemKey::Node { id: nid(7) };
 
         let mut seg_first = WalSegment::new(1);
         seg_first.push(WalRecord {
@@ -579,10 +555,7 @@ mod tests {
         seg.push(WalRecord {
             lsn: 1,
             payload: WalEntry {
-                key: MemKey::Node {
-                    label: "Person".into(),
-                    id: nid(9),
-                },
+                key: MemKey::Node { id: nid(9) },
                 op: WalOp::Upsert(b"x".to_vec()),
                 lsn: 999,
             }
@@ -621,10 +594,7 @@ mod tests {
         seg.push(WalRecord {
             lsn: 10,
             payload: WalEntry {
-                key: MemKey::Node {
-                    label: "Person".into(),
-                    id: nid(1),
-                },
+                key: MemKey::Node { id: nid(1) },
                 op: WalOp::Upsert(b"x".to_vec()),
                 lsn: 10,
             }
@@ -660,10 +630,7 @@ mod tests {
         seg.push(WalRecord {
             lsn: 100,
             payload: WalEntry {
-                key: MemKey::Node {
-                    label: "Person".into(),
-                    id: nid(1),
-                },
+                key: MemKey::Node { id: nid(1) },
                 op: WalOp::Tombstone,
                 lsn: 100,
             }
@@ -706,10 +673,7 @@ mod tests {
         let snap = MemtableSnapshotFile::from_iter(
             10,
             vec![(
-                MemKey::Node {
-                    label: "Person".into(),
-                    id: nid(1),
-                },
+                MemKey::Node { id: nid(1) },
                 1,
                 MemOp::Upsert(Bytes::from_static(b"ada-v1")),
             )],
@@ -719,10 +683,7 @@ mod tests {
             .unwrap();
 
         let new_record = WalEntry {
-            key: MemKey::Node {
-                label: "Person".into(),
-                id: nid(2),
-            },
+            key: MemKey::Node { id: nid(2) },
             op: WalOp::Upsert(b"bob-v1".to_vec()),
             lsn: 11,
         }
@@ -732,10 +693,7 @@ mod tests {
         seg0.push(WalRecord {
             lsn: 1,
             payload: WalEntry {
-                key: MemKey::Node {
-                    label: "Person".into(),
-                    id: nid(1),
-                },
+                key: MemKey::Node { id: nid(1) },
                 op: WalOp::Upsert(b"ada-v1".to_vec()),
                 lsn: 1,
             }
@@ -786,10 +744,7 @@ mod tests {
         seg.push(WalRecord {
             lsn: 1,
             payload: WalEntry {
-                key: MemKey::Node {
-                    label: "Person".into(),
-                    id: nid(1),
-                },
+                key: MemKey::Node { id: nid(1) },
                 op: WalOp::Upsert(b"ada-v1".to_vec()),
                 lsn: 1,
             }

--- a/crates/namidb-storage/src/sst/nodes.rs
+++ b/crates/namidb-storage/src/sst/nodes.rs
@@ -526,18 +526,28 @@ impl NodeSstReader {
         // caller requested. When `projection.is_none()` we skip the mask
         // and Parquet reads every leaf.
         let projection_mask = projection.map(|cols| {
-            let mut leaves: Vec<usize> = Vec::with_capacity(cols.len() + 5);
+            let mut leaves: Vec<usize> = Vec::with_capacity(cols.len() + 6);
+            // Match on the leaf column's top-level path component, not its leaf
+            // name: `__labels` is a `List<UInt32>` whose Parquet leaf is named
+            // `element` (path `__labels.list.element`), so a `c.name()` match
+            // would silently miss it — and eliding `__labels` makes
+            // `decode_node_labels` fall back to the (now empty) scope and drop
+            // every row at the label filter under the id-primary layout.
+            let root_of = |c: &parquet::schema::types::ColumnDescriptor| -> Option<String> {
+                c.path().parts().first().cloned()
+            };
             for engine in [
                 COL_NODE_ID,
                 COL_TOMBSTONE,
                 COL_LSN,
                 SCHEMA_VERSION,
                 OVERFLOW_JSON,
+                COL_LABELS,
             ] {
                 if let Some(idx) = schema_descr
                     .columns()
                     .iter()
-                    .position(|c| c.name() == engine)
+                    .position(|c| root_of(c).as_deref() == Some(engine))
                 {
                     leaves.push(idx);
                 }
@@ -1901,6 +1911,13 @@ mod tests {
         assert!(batch.column_by_name(COL_LSN).is_some());
         assert!(batch.column_by_name(SCHEMA_VERSION).is_some());
         assert!(batch.column_by_name(OVERFLOW_JSON).is_some());
+        // `__labels` must survive projection: it is the id-primary source of
+        // truth for a row's label set, and dropping it makes label scans return
+        // nothing (its Parquet leaf is nested, so the mask matches on path root).
+        assert!(
+            batch.column_by_name(COL_LABELS).is_some(),
+            "__labels must always be kept in a projected scan"
+        );
         assert!(batch.column_by_name("prop_age").is_some());
         assert!(
             batch.column_by_name("prop_name").is_none(),

--- a/crates/namidb-storage/src/sst/nodes.rs
+++ b/crates/namidb-storage/src/sst/nodes.rs
@@ -67,6 +67,11 @@ pub const COL_LSN: &str = "lsn";
 pub const OVERFLOW_JSON: &str = "__overflow_json";
 /// Always-present column carrying the schema version this row was written under.
 pub const SCHEMA_VERSION: &str = "__schema_version";
+/// Always-present column carrying the node's label set as a `List<UInt32>` of
+/// [`LabelId`](namidb_core::LabelId) values (multi-label nodes). Legacy
+/// single-label SSTs predate this column; [`NodeSstReader::open`] tolerates its
+/// absence and the read path then derives the label set from the SST scope.
+pub const COL_LABELS: &str = "__labels";
 
 /// Tuning knobs for `NodeSstWriter`.
 #[derive(Debug, Clone)]
@@ -95,8 +100,13 @@ impl Default for NodeSstWriterOptions {
 }
 
 /// Build the canonical Arrow schema for a node label.
+///
+/// Column order: `node_id, tombstone, lsn, __labels, prop_*, __overflow_json,
+/// __schema_version`. Production node SSTs are built with an empty `LabelDef`
+/// (no `prop_*` columns; every property rides in `__overflow_json`), but the
+/// schema stays parameterised so the writer/reader remain general.
 pub fn node_arrow_schema(label: &LabelDef) -> SchemaRef {
-    let mut fields = Vec::with_capacity(label.properties.len() + 5);
+    let mut fields = Vec::with_capacity(label.properties.len() + 6);
     fields.push(Field::new(
         COL_NODE_ID,
         ArrowDataType::FixedSizeBinary(16),
@@ -104,6 +114,13 @@ pub fn node_arrow_schema(label: &LabelDef) -> SchemaRef {
     ));
     fields.push(Field::new(COL_TOMBSTONE, ArrowDataType::Boolean, false));
     fields.push(Field::new(COL_LSN, ArrowDataType::UInt64, false));
+    fields.push(Field::new(
+        COL_LABELS,
+        // `item` nullable matches what `ListBuilder<UInt32Builder>` emits, so
+        // the built RecordBatch's column type equals this field exactly.
+        ArrowDataType::List(Arc::new(Field::new("item", ArrowDataType::UInt32, true))),
+        false,
+    ));
     for p in &label.properties {
         fields.push(prop_field(p));
     }

--- a/crates/namidb-storage/src/sst/nodes.rs
+++ b/crates/namidb-storage/src/sst/nodes.rs
@@ -1329,6 +1329,8 @@ mod tests {
         let mut nid = FixedSizeBinaryBuilder::with_capacity(rows.len(), 16);
         let mut tomb = BooleanBuilder::with_capacity(rows.len());
         let mut lsn = UInt64Builder::with_capacity(rows.len());
+        let mut labels =
+            arrow_array::builder::ListBuilder::new(arrow_array::builder::UInt32Builder::new());
         let mut prop_name = StringBuilder::with_capacity(rows.len(), 32);
         let mut prop_age = arrow_array::builder::Int32Builder::with_capacity(rows.len());
         let mut overflow = StringBuilder::with_capacity(rows.len(), 32);
@@ -1340,6 +1342,7 @@ mod tests {
             nid.append_value(id).unwrap();
             tomb.append_value(*t);
             lsn.append_value(*l);
+            labels.append(true); // empty __labels list for these property tests
             match name_opt {
                 Some(n) => prop_name.append_value(n),
                 None => prop_name.append_null(),
@@ -1359,6 +1362,7 @@ mod tests {
             Arc::new(nid.finish()),
             Arc::new(tomb.finish()),
             Arc::new(lsn.finish()),
+            Arc::new(labels.finish()),
             Arc::new(prop_name.finish()),
             Arc::new(prop_age.finish()),
             Arc::new(overflow.finish()),

--- a/crates/namidb-storage/src/sst/nodes.rs
+++ b/crates/namidb-storage/src/sst/nodes.rs
@@ -1684,6 +1684,12 @@ mod tests {
         tomb.append_value(false);
         let mut lsn = UInt64Builder::with_capacity(1);
         lsn.append_value(1);
+        // `node_arrow_schema` now carries a `__labels` `List<UInt32>` column at
+        // slot index 3 (between `lsn` and the overflow JSON); emit an empty
+        // label list so the batch matches the schema's field count.
+        let mut labels =
+            arrow_array::builder::ListBuilder::new(arrow_array::builder::UInt32Builder::new());
+        labels.append(true);
         let mut overflow = StringBuilder::with_capacity(1, 0);
         overflow.append_null();
         let mut sv = UInt64Builder::with_capacity(1);
@@ -1692,6 +1698,7 @@ mod tests {
             Arc::new(nid.finish()),
             Arc::new(tomb.finish()),
             Arc::new(lsn.finish()),
+            Arc::new(labels.finish()),
             Arc::new(overflow.finish()),
             Arc::new(sv.finish()),
         ];

--- a/crates/namidb-storage/src/wal.rs
+++ b/crates/namidb-storage/src/wal.rs
@@ -13,7 +13,7 @@
 //! Acknowledgement to the client happens **after** the segment PUT returns
 //! success — at that point the records are durable.
 //!
-//! ## Binary format (v0)
+//! ## Binary format
 //!
 //! ```text
 //! Segment ::= Header Records+ Footer
@@ -23,8 +23,18 @@
 //! ```
 //!
 //! All integers are little-endian. CRC32 uses the IEEE polynomial via
-//! [`crc32fast`]. `version = 0` for now; bumping it is a breaking change
-//! and requires a new manifest schema field.
+//! [`crc32fast`].
+//!
+//! ### Versioning
+//!
+//! `version = 1` marks the multi-label era: the *framing* above is unchanged
+//! from v0, but record payloads now carry a node label set
+//! ([`NodeWriteRecord::labels`](crate::flush::NodeWriteRecord)). The header is
+//! self-describing, so decode reads every version up to the one this build
+//! writes (v0 segments still recover unchanged) and rejects only a *newer*
+//! version it cannot understand. The point of the bump is the other
+//! direction: an older binary will now refuse a v1 segment outright instead of
+//! silently dropping the labels field its JSON decoder doesn't know about.
 
 use std::sync::Arc;
 
@@ -38,7 +48,10 @@ use crate::paths::NamespacePaths;
 
 const MAGIC_HEADER: &[u8; 4] = b"TGWL";
 const MAGIC_FOOTER: &[u8; 4] = b"TGEL";
-const FORMAT_VERSION: u16 = 0;
+/// Version stamped into every segment this build writes (see module docs).
+/// v1 = multi-label era. The framing is identical across versions, so decode
+/// accepts anything `<= FORMAT_VERSION`.
+const FORMAT_VERSION: u16 = 1;
 
 /// A single WAL record. `lsn` is assigned by the writer monotonically and
 /// becomes the durable order of operations within a namespace.
@@ -156,10 +169,15 @@ impl WalSegment {
             });
         }
         let version = cursor.get_u16_le();
-        if version != FORMAT_VERSION {
+        // The framing is identical across versions and payloads are
+        // self-describing, so any version up to ours is readable; only a
+        // future, newer version is not.
+        if version > FORMAT_VERSION {
             return Err(Error::Corrupted {
                 path: format!("wal#{seq}"),
-                detail: format!("unsupported WAL format version {version}"),
+                detail: format!(
+                    "WAL format version {version} is newer than supported {FORMAT_VERSION}"
+                ),
             });
         }
         let _reserved = cursor.get_u16_le();
@@ -366,6 +384,43 @@ mod tests {
         let back = WalSegment::decode(7, bytes).unwrap();
         assert_eq!(back.seq, 7);
         assert_eq!(back.records, seg.records);
+    }
+
+    /// Patch the `version` field (u16 LE at offset 4) of an encoded segment
+    /// to `v`, fixing up the footer CRC so only the version differs.
+    fn reversion(seg: &WalSegment, v: u16) -> Bytes {
+        let mut bytes = seg.encode().to_vec();
+        bytes[4..6].copy_from_slice(&v.to_le_bytes());
+        let body_len = bytes.len() - 8; // header + records (footer is magic + crc)
+        let crc = crc32fast::hash(&bytes[..body_len]);
+        let len = bytes.len();
+        bytes[len - 4..].copy_from_slice(&crc.to_le_bytes());
+        Bytes::from(bytes)
+    }
+
+    #[test]
+    fn decode_accepts_legacy_v0_segment() {
+        // A pre-multi-label (v0) WAL must still recover under the current build:
+        // bumping the write version may not break recovery of existing logs.
+        let mut seg = WalSegment::new(9);
+        seg.push(rec(1, "legacy"));
+        seg.push(rec(2, "single-label"));
+        let back = WalSegment::decode(9, reversion(&seg, 0)).unwrap();
+        assert_eq!(back.records, seg.records, "v0 WAL must still decode");
+    }
+
+    #[test]
+    fn decode_rejects_future_version() {
+        // A segment written by a newer build is not readable; fail loudly.
+        let mut seg = WalSegment::new(10);
+        seg.push(rec(1, "from the future"));
+        let err = WalSegment::decode(10, reversion(&seg, FORMAT_VERSION + 1)).unwrap_err();
+        match err {
+            Error::Corrupted { detail, .. } => {
+                assert!(detail.contains("newer"), "unexpected detail: {detail}")
+            }
+            other => panic!("expected Corrupted, got {other:?}"),
+        }
     }
 
     #[test]

--- a/crates/namidb-storage/tests/end_to_end.rs
+++ b/crates/namidb-storage/tests/end_to_end.rs
@@ -54,7 +54,6 @@ async fn bootstrap_then_first_write_cycle() {
         });
         memtable.apply(
             MemKey::Node {
-                label: "Person".into(),
                 id: namidb_core::NodeId::new(),
             },
             next_lsn,

--- a/crates/namidb-storage/tests/multi_label.rs
+++ b/crates/namidb-storage/tests/multi_label.rs
@@ -1,0 +1,165 @@
+//! Integration tests for multi-label nodes (id-primary storage).
+//!
+//! A node carries a *set* of labels on-row; it is keyed by id alone, so the
+//! same node surfaces under every one of its labels exactly once, and a
+//! tombstone (by id) removes it from all of them. These exercise the full
+//! write -> flush -> reopen -> scan path against an in-memory object store.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use object_store::memory::InMemory;
+use object_store::ObjectStore;
+use uuid::Uuid;
+
+use namidb_core::{NamespaceId, NodeId, Schema, Value};
+use namidb_storage::{NamespacePaths, NodeWriteRecord, WriterSession};
+
+fn store() -> Arc<dyn ObjectStore> {
+    Arc::new(InMemory::new())
+}
+
+fn paths(ns: &str) -> NamespacePaths {
+    NamespacePaths::new("tenants", NamespaceId::new(ns).unwrap())
+}
+
+fn nid(b: u8) -> NodeId {
+    let mut bytes = [0u8; 16];
+    bytes[15] = b;
+    NodeId::from_uuid(Uuid::from_bytes(bytes))
+}
+
+fn rec(name: &str) -> NodeWriteRecord {
+    let mut props = BTreeMap::new();
+    props.insert("name".to_string(), Value::Str(name.into()));
+    NodeWriteRecord {
+        properties: props,
+        schema_version: 0,
+        ..Default::default()
+    }
+}
+
+fn labels(set: &[&str]) -> Vec<String> {
+    set.iter().map(|s| s.to_string()).collect()
+}
+
+/// Write `(:A:B)`, flush, reopen: the node surfaces under BOTH labels exactly
+/// once, carries the full label set, and is invisible under a label it lacks.
+#[tokio::test]
+async fn two_labels_scan_each_once_after_flush() {
+    let mut s = WriterSession::open(store(), paths("ml-two")).await.unwrap();
+    let id = nid(1);
+    s.upsert_node_with_labels(labels(&["A", "B"]), id, &rec("x"))
+        .unwrap();
+    s.commit_batch().await.unwrap();
+    s.flush(Schema::empty()).await.unwrap();
+
+    let snap = s.snapshot();
+    let a = snap.scan_label("A").await.unwrap();
+    let b = snap.scan_label("B").await.unwrap();
+    assert_eq!(a.len(), 1, "exactly one node under A");
+    assert_eq!(b.len(), 1, "exactly one node under B (no per-label dup)");
+    assert_eq!(a[0].id, id);
+    assert_eq!(b[0].id, id);
+    // The on-row label set round-trips through the SST.
+    assert!(a[0].labels.contains("A") && a[0].labels.contains("B"));
+    assert_eq!(a[0].labels.len(), 2);
+
+    // Point lookups are label-scoped: present under A, absent under C.
+    assert!(snap.lookup_node("A", id).await.unwrap().is_some());
+    assert!(snap.lookup_node("B", id).await.unwrap().is_some());
+    assert!(snap.lookup_node("C", id).await.unwrap().is_none());
+}
+
+/// Same as above but BEFORE a flush: the memtable path must also surface a
+/// multi-label node under each label.
+#[tokio::test]
+async fn two_labels_scan_each_once_from_memtable() {
+    let mut s = WriterSession::open(store(), paths("ml-mem")).await.unwrap();
+    let id = nid(1);
+    s.upsert_node_with_labels(labels(&["A", "B"]), id, &rec("x"))
+        .unwrap();
+    s.commit_batch().await.unwrap();
+    // No flush: rows live in the memtable.
+
+    let snap = s.snapshot();
+    assert_eq!(snap.scan_label("A").await.unwrap().len(), 1);
+    assert_eq!(snap.scan_label("B").await.unwrap().len(), 1);
+    assert_eq!(snap.lookup_node("B", id).await.unwrap().unwrap().id, id);
+}
+
+/// A tombstone is keyed by id: it removes the node from EVERY label scan.
+#[tokio::test]
+async fn tombstone_clears_all_label_scans() {
+    let mut s = WriterSession::open(store(), paths("ml-tomb"))
+        .await
+        .unwrap();
+    let id = nid(1);
+    s.upsert_node_with_labels(labels(&["A", "B"]), id, &rec("x"))
+        .unwrap();
+    s.commit_batch().await.unwrap();
+    s.flush(Schema::empty()).await.unwrap();
+
+    s.tombstone_node("A", id).unwrap();
+    s.commit_batch().await.unwrap();
+    s.flush(Schema::empty()).await.unwrap();
+
+    let snap = s.snapshot();
+    assert!(snap.scan_label("A").await.unwrap().is_empty());
+    assert!(snap.scan_label("B").await.unwrap().is_empty());
+    assert!(snap.lookup_node("A", id).await.unwrap().is_none());
+}
+
+/// Re-upserting with a smaller label set (drop B) is last-LSN-wins: the node
+/// leaves B's scan and stays in A's, with the updated label set.
+#[tokio::test]
+async fn relabel_via_reupsert_is_last_write_wins() {
+    let mut s = WriterSession::open(store(), paths("ml-relabel"))
+        .await
+        .unwrap();
+    let id = nid(1);
+    s.upsert_node_with_labels(labels(&["A", "B"]), id, &rec("x"))
+        .unwrap();
+    s.commit_batch().await.unwrap();
+    s.flush(Schema::empty()).await.unwrap();
+
+    // Rewrite the node as :A only (B removed).
+    s.upsert_node_with_labels(labels(&["A"]), id, &rec("x"))
+        .unwrap();
+    s.commit_batch().await.unwrap();
+    s.flush(Schema::empty()).await.unwrap();
+
+    let snap = s.snapshot();
+    let a = snap.scan_label("A").await.unwrap();
+    assert_eq!(a.len(), 1);
+    assert_eq!(a[0].labels.len(), 1);
+    assert!(a[0].labels.contains("A"));
+    // The stale B membership from the older SST must NOT resurface.
+    assert!(
+        snap.scan_label("B").await.unwrap().is_empty(),
+        "removed label must not resurface from the older SST"
+    );
+}
+
+/// Reopen a fresh `WriterSession` on the same store after flush: the label set
+/// survives via the manifest's dictionary + the on-row `__labels` column, with
+/// no live memtable.
+#[tokio::test]
+async fn labels_survive_a_reopen() {
+    let store = store();
+    let p = paths("ml-reopen");
+    let id = nid(7);
+    {
+        let mut s = WriterSession::open(store.clone(), p.clone()).await.unwrap();
+        s.upsert_node_with_labels(labels(&["A", "B"]), id, &rec("x"))
+            .unwrap();
+        s.commit_batch().await.unwrap();
+        s.flush(Schema::empty()).await.unwrap();
+    }
+    // Fresh session, fresh in-process state — must read labels off disk.
+    let s = WriterSession::open(store, p).await.unwrap();
+    let snap = s.snapshot();
+    let a = snap.scan_label("A").await.unwrap();
+    assert_eq!(a.len(), 1);
+    assert!(a[0].labels.contains("A") && a[0].labels.contains("B"));
+}

--- a/crates/namidb-storage/tests/node_cache_parity.rs
+++ b/crates/namidb-storage/tests/node_cache_parity.rs
@@ -40,6 +40,7 @@ fn node_payload(name: &str) -> Bytes {
             .into_iter()
             .collect(),
         schema_version: 1,
+        ..Default::default()
     }
     .encode()
     .unwrap()
@@ -65,14 +66,7 @@ async fn parity_pure_sst_nodes() {
 
     let mut mt = Memtable::new();
     for (lsn, id, name) in [(10u64, alice, "Alice"), (11, bob, "Bob")] {
-        mt.apply(
-            MemKey::Node {
-                label: "Person".into(),
-                id,
-            },
-            lsn,
-            MemOp::Upsert(node_payload(name)),
-        );
+        mt.apply(MemKey::Node { id }, lsn, MemOp::Upsert(node_payload(name)));
     }
     let frozen = mt.freeze();
     let outcome = flush(&ms, &fence, &base, &frozen, schema.clone())
@@ -119,10 +113,7 @@ async fn parity_with_tombstone_caches_negative() {
     // Flush alice@LSN10.
     let mut mt = Memtable::new();
     mt.apply(
-        MemKey::Node {
-            label: "Person".into(),
-            id: alice,
-        },
+        MemKey::Node { id: alice },
         10,
         MemOp::Upsert(node_payload("Alice")),
     );
@@ -133,14 +124,7 @@ async fn parity_with_tombstone_caches_negative() {
 
     // Live memtable tombstone @ LSN 20 > SST 10.
     let mut live = Memtable::new();
-    live.apply(
-        MemKey::Node {
-            label: "Person".into(),
-            id: alice,
-        },
-        20,
-        MemOp::Tombstone,
-    );
+    live.apply(MemKey::Node { id: alice }, 20, MemOp::Tombstone);
 
     let cache = Arc::new(NodeViewCache::new(1024 * 1024));
     let live_view = live.snapshot_view();
@@ -180,10 +164,7 @@ async fn cache_reuses_across_snapshots_of_same_manifest_version() {
 
     let mut mt = Memtable::new();
     mt.apply(
-        MemKey::Node {
-            label: "Person".into(),
-            id: alice,
-        },
+        MemKey::Node { id: alice },
         10,
         MemOp::Upsert(node_payload("Alice")),
     );
@@ -243,10 +224,7 @@ async fn l1_hit_short_circuits_before_l2() {
 
     let mut mt = Memtable::new();
     mt.apply(
-        MemKey::Node {
-            label: "Person".into(),
-            id: alice,
-        },
+        MemKey::Node { id: alice },
         10,
         MemOp::Upsert(node_payload("Alice")),
     );


### PR DESCRIPTION
## Summary

Moves node storage to the id-primary layout so a node can carry a set of
labels instead of exactly one, and fixes the read, cost-model, compaction,
and GC paths that still assumed label-partitioned SSTs. Nodes are keyed by id
alone; the label set rides on-row (a `__labels` column) and a per-SST
label-index sidecar maps each `LabelId` to its node ids.

## Type

- [x] Bug fix (`fix:`)
- [x] New feature or capability (`feat:`)
- [ ] Refactor with no behaviour change (`refactor:`)
- [ ] Performance improvement (`perf:`)
- [ ] Documentation (`docs:`)
- [ ] Test only (`test:`)
- [x] Build / CI / chore (`chore:` / `ci:` / `build:`)
- [ ] Bench / benchmark (`bench:`)

## What changed

- id-primary node SSTs: one partition, empty scope, every property in a
  single `__overflow_json` column, label set in `__labels`. Offline builder
  and fixtures follow the same layout.
- Cost model: per-label `node_count` now comes from the label-index posting
  counts (resolved via the namespace label dictionary), with `total_nodes`
  from `row_count` so `node_count(L) <= total_nodes` holds even for
  multi-label nodes. Reading `sst.scope` (now empty) had collapsed every
  label to 0, which made the optimizer prune populated labels to 0 rows.
- Compaction rebuilds the label index on the merged L1 SST, so per-label
  counts survive an L0 to L1 merge instead of resetting to 0.
- Projected scans keep `__labels`. Its Parquet leaf is nested, so the old
  name-based projection mask missed it, label decode fell back to the empty
  scope, and the label filter dropped every row (a projected
  `MATCH (a:Person) RETURN a.firstName` returned nothing).
- Orphan sweep marks unique / equality / label-index sidecar paths
  referenced so it cannot delete live sidecars.
- WAL format version bumped to 1 to mark multi-label payloads. Framing is
  unchanged and decode still reads v0 logs; the bump makes an older binary
  refuse a v1 log instead of silently dropping the labels field.

## Deferred

Per-column property stats (min/max/ndv) are not available under id-primary
because properties live in `__overflow_json` rather than typed `prop_*`
columns. The optimizer uses its documented fallbacks (eq 0.1, range 0.33,
ndv none): results stay correct, estimates are looser. Precise per-label
column stats return with the typed-column layout.

## RFC reference

- RFC: (none) Extends the RFC-002 node SST layout; per-label column stats are
  deferred to a future typed-column layout.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --lib --tests --exclude namidb-py -- -D warnings -A clippy::doc_lazy_continuation` (the CI invocation; clean)
- [x] `cargo test --workspace --exclude namidb-py` (1081 passing)
- [ ] (Python bindings not touched by this branch)
- [ ] Storage tests run against the in-memory object store, not LocalStack
- [ ] (no perf-sensitive change)

New coverage: multi-label per-label counts, counts surviving compaction,
multi-label scan with projection pushdown, projected scan keeps `__labels`,
and WAL v0 read / future-version reject.

## Breaking changes

On-disk format only, and no released version ships the id-primary layout yet:

- WAL segments are now written as v1 (v0 still readable).
- Manifest gains `label_dict`, node SSTs gain a `label_index` sidecar with
  `per_label_counts`. All are `serde(default)`, so older manifests load
  unchanged.
- Node SSTs use the id-primary layout (empty scope, `__overflow_json`,
  `__labels`). Legacy single-label SSTs still read via the scope fallback.

## Checklist

- [ ] I have read `CONTRIBUTING.md`
- [x] I have added tests covering the change
- [x] I have updated relevant documentation (doc comments)
- [ ] I have signed my commits (`git commit -S`)
