### PR TITLE
feat(py): multi-label node support in the storage API

### DIFF
--- a/.github/workflows/python-wheels.yml
+++ b/.github/workflows/python-wheels.yml
@@ -142,7 +142,13 @@ jobs:
         shell: bash
         run: |
           python -m pip install --upgrade pip
-          python -m pip install --find-links dist namidb
+          # Install the LOCAL wheel by path, not by name. A bare
+          # `pip install namidb` (even with --find-links) can resolve to the
+          # PUBLISHED PyPI wheel of the same version (0.11.0) and silently test
+          # that instead of this build — masking any new API in the PR.
+          # Installing the file directly forces the local artifact; deps (e.g.
+          # pyarrow) still resolve from PyPI since the index stays enabled.
+          python -m pip install dist/*.whl
       - name: Smoke (import + Client roundtrip)
         shell: bash
         run: |

--- a/crates/namidb-py/python/namidb/__init__.pyi
+++ b/crates/namidb-py/python/namidb/__init__.pyi
@@ -85,6 +85,17 @@ class Client:
     ) -> None:
         """Stage a single node upsert. `id` must be a UUID string."""
 
+    def upsert_node_with_labels(
+        self,
+        labels: list[str],
+        id: str,
+        properties: dict[str, Any],
+    ) -> None:
+        """Stage a multi-label node upsert. `labels` is the full label
+        set; the node is keyed by `id` alone, so a later upsert with a
+        different set replaces it (last-write-wins). `id` must be a UUID
+        string."""
+
     def tombstone_node(self, label: str, id: str) -> None:
         """Stage a node tombstone."""
 
@@ -140,8 +151,9 @@ class Client:
         label: str,
         id: str,
     ) -> Optional[dict[str, Any]]:
-        """Snapshot-isolated lookup. Returns `{"id", "label",
-        "lsn", "schema_version", "properties"}` or `None`."""
+        """Snapshot-isolated lookup. Returns `{"id", "label", "labels",
+        "lsn", "schema_version", "properties"}` or `None`. `label` is the
+        representative (first) label; `labels` is the full set."""
 
     def out_edges(
         self,
@@ -168,8 +180,9 @@ class Client:
 
     def scan_label_arrow(self, label: str) -> _Table:
         """Like [`Client.scan_label`] but returns a `pyarrow.Table`
-        directly. Columns: `id`, `label`, `lsn`, `schema_version`,
-        then the union of property keys (missing keys → null)."""
+        directly. Columns: `id`, `label` (representative), `labels`
+        (full set, list<string>), `lsn`, `schema_version`, then the
+        union of property keys (missing keys -> null)."""
 
     # ── Cypher ─────────────────────────────────────────────────────
 

--- a/crates/namidb-py/src/lib.rs
+++ b/crates/namidb-py/src/lib.rs
@@ -102,6 +102,31 @@ impl Client {
         Ok(())
     }
 
+    /// Stage a multi-label node upsert into the current batch. `labels` is the
+    /// full label set the node carries; the node is keyed by `id` alone, so a
+    /// later upsert with a different set replaces it (last-write-wins).
+    fn upsert_node_with_labels(
+        &self,
+        labels: Vec<String>,
+        id: &str,
+        properties: &Bound<'_, PyDict>,
+    ) -> PyResult<()> {
+        let id = parse_node_id(id)?;
+        let props = py_dict_to_value_map(properties)?;
+        let record = NodeWriteRecord {
+            properties: props,
+            schema_version: 0,
+            ..Default::default()
+        };
+        self.runtime.block_on(async {
+            let mut session = self.session.lock().await;
+            session
+                .upsert_node_with_labels(labels, id, &record)
+                .map_err(map_storage_err)
+        })?;
+        Ok(())
+    }
+
     /// Stage a node tombstone into the current batch.
     fn tombstone_node(&self, label: &str, id: &str) -> PyResult<()> {
         let id = parse_node_id(id)?;
@@ -1065,6 +1090,7 @@ fn build_node_views_table(
     let mut all_names: Vec<String> = vec![
         "id".to_string(),
         "label".to_string(),
+        "labels".to_string(),
         "lsn".to_string(),
         "schema_version".to_string(),
     ];
@@ -1076,11 +1102,23 @@ fn build_node_views_table(
     }
     arrays.append(pyarrow.call_method1("array", (ids,))?)?;
 
+    // `label` (representative, back-compat) and `labels` (full set as a
+    // list<string> column) sit side by side.
     let labels = PyList::empty_bound(py);
     for v in views {
         labels.append(v.labels.iter().next().map(String::as_str).unwrap_or(""))?;
     }
     arrays.append(pyarrow.call_method1("array", (labels,))?)?;
+
+    let label_lists = PyList::empty_bound(py);
+    for v in views {
+        let inner = PyList::empty_bound(py);
+        for l in &v.labels {
+            inner.append(l.as_str())?;
+        }
+        label_lists.append(inner)?;
+    }
+    arrays.append(pyarrow.call_method1("array", (label_lists,))?)?;
 
     let lsns = PyList::empty_bound(py);
     for v in views {

--- a/crates/namidb-py/tests/test_bulk_arrow.py
+++ b/crates/namidb-py/tests/test_bulk_arrow.py
@@ -196,8 +196,9 @@ def test_scan_label_arrow_basic(client: tg.Client) -> None:
     assert isinstance(table, pa.Table)
     assert table.num_rows == 3
     # Metadata columns first, then properties in alpha order from BTreeSet.
-    assert table.column_names[:4] == ["id", "label", "lsn", "schema_version"]
-    assert set(table.column_names[4:]) == {"age", "city", "name"}
+    # `labels` (full set) sits next to the representative `label`.
+    assert table.column_names[:5] == ["id", "label", "labels", "lsn", "schema_version"]
+    assert set(table.column_names[5:]) == {"age", "city", "name"}
     # Bob is missing age + city — should land as null.
     rows_by_name = {r["name"]: r for r in table.to_pylist()}
     assert rows_by_name["Bob"]["age"] is None
@@ -210,4 +211,4 @@ def test_scan_label_arrow_empty(client: tg.Client) -> None:
     assert isinstance(table, pa.Table)
     assert table.num_rows == 0
     # Metadata columns are always present even for empty scans.
-    assert table.column_names == ["id", "label", "lsn", "schema_version"]
+    assert table.column_names == ["id", "label", "labels", "lsn", "schema_version"]

--- a/crates/namidb-py/tests/test_storage.py
+++ b/crates/namidb-py/tests/test_storage.py
@@ -55,6 +55,37 @@ def test_upsert_uses_last_write_wins(client: tg.Client) -> None:
     assert view["properties"]["age"] == 31
 
 
+# ── multi-label nodes ──────────────────────────────────────────────────
+
+
+def test_upsert_node_with_labels_roundtrip(client: tg.Client) -> None:
+    node_id = _new_uuid()
+    client.upsert_node_with_labels(["Person", "Admin"], node_id, {"name": "Ada"})
+    client.commit()
+    # lookup_node returns the representative `label` plus the full `labels` set.
+    view = client.lookup_node("Person", node_id)
+    assert view is not None
+    assert view["id"] == node_id
+    assert set(view["labels"]) == {"Person", "Admin"}
+    assert view["label"] in {"Person", "Admin"}
+    # The node surfaces under each of its labels individually.
+    assert client.lookup_node("Admin", node_id) is not None
+    assert {n["id"] for n in client.scan_label("Person")} == {node_id}
+    assert {n["id"] for n in client.scan_label("Admin")} == {node_id}
+
+
+def test_scan_label_arrow_carries_labels_column(client: tg.Client) -> None:
+    node_id = _new_uuid()
+    client.upsert_node_with_labels(["Person", "Admin"], node_id, {"name": "Ada"})
+    client.commit()
+    table = client.scan_label_arrow("Person")
+    assert "labels" in table.column_names  # full set
+    assert "label" in table.column_names  # representative, back-compat
+    labels_col = table.column("labels").to_pylist()
+    assert len(labels_col) == 1
+    assert set(labels_col[0]) == {"Person", "Admin"}
+
+
 # ── tombstone_node ─────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## Summary

The Cypher layer creates and matches multi-label nodes (#66), but the Python
storage API was still single-label. This adds the missing surface.

## Type

- [x] New feature or capability (`feat:`)
- [ ] Bug fix / refactor / perf / docs / test / chore / bench

## What changed

- `Client.upsert_node_with_labels(labels: list[str], id, properties)` wraps
  `WriterSession::upsert_node_with_labels`. The existing single-label
  `upsert_node` is unchanged.
- `scan_label_arrow` gains a `labels` (`list<string>`) column carrying the
  full set, alongside the back-compat `label` (representative) column.
- `lookup_node` already returns both `label` and `labels`; type stub updated
  to document it.

## Test plan

- [x] `cargo check -p namidb-py` (the pyo3 cdylib links only under maturin)
- [ ] `cargo fmt --all -- --check` (clean)
- [ ] CI builds the wheels and runs `pytest`, including the new
      `test_upsert_node_with_labels_roundtrip` and
      `test_scan_label_arrow_carries_labels_column` in `test_storage.py`.

## Breaking changes

None. `scan_label_arrow` gains a `labels` column (additive); the singular
`label` column and all existing keys are retained.

## Checklist

- [ ] I have read `CONTRIBUTING.md`
- [x] I have added tests covering the change
- [x] I have updated relevant doc comments / type stubs
- [ ] I have signed my commits
