### PR TITLE
feat(query): intersection-aware cardinality for multi-label MATCH

### DIFF
--- a/crates/namidb-query/src/cost/cardinality.rs
+++ b/crates/namidb-query/src/cost/cardinality.rs
@@ -801,7 +801,7 @@ fn make_binding_stats<'a>(
     catalog: &'a StatsCatalog,
     bindings: &BTreeMap<String, BindingMeta>,
 ) -> BindingStats<'a> {
-    let mut bs = BindingStats::empty();
+    let mut bs = BindingStats::empty().with_catalog(catalog);
     for (alias, meta) in bindings {
         if let Some(label) = &meta.label {
             if let Some(ls) = catalog.label(label) {

--- a/crates/namidb-query/src/cost/selectivity.rs
+++ b/crates/namidb-query/src/cost/selectivity.rs
@@ -21,7 +21,7 @@ use std::collections::BTreeMap;
 
 use namidb_storage::sst::stats::StatScalar;
 
-use super::stats::{LabelStats, PropStats};
+use super::stats::{LabelStats, PropStats, StatsCatalog};
 use crate::parser::ast::{BinaryOp, Expression, ExpressionKind, Literal, StringOp, UnaryOp};
 
 /// Bindings visible to the predicate, mapping alias → label stats. The
@@ -29,6 +29,10 @@ use crate::parser::ast::{BinaryOp, Expression, ExpressionKind, Literal, StringOp
 #[derive(Debug, Default, Clone)]
 pub struct BindingStats<'a> {
     pub by_alias: BTreeMap<String, &'a LabelStats>,
+    /// Optional catalog for rules that need namespace-wide counts not tied to
+    /// a bound alias — currently the secondary-label fraction for `__label_eq`
+    /// (`MATCH (n:A:B)`). `None` falls back to the old defensive behaviour.
+    pub catalog: Option<&'a StatsCatalog>,
 }
 
 impl<'a> BindingStats<'a> {
@@ -38,6 +42,11 @@ impl<'a> BindingStats<'a> {
 
     pub fn with(mut self, alias: impl Into<String>, stats: &'a LabelStats) -> Self {
         self.by_alias.insert(alias.into(), stats);
+        self
+    }
+
+    pub fn with_catalog(mut self, catalog: &'a StatsCatalog) -> Self {
+        self.catalog = Some(catalog);
         self
     }
 
@@ -128,21 +137,46 @@ fn sel_inner(expr: &Expression, bindings: &BindingStats<'_>) -> f64 {
         ExpressionKind::Exists(_) => FALLBACK_UNKNOWN,
 
         // ─── synthetic engine functions ────────────────────────────────
-        ExpressionKind::FunctionCall { name, .. }
+        ExpressionKind::FunctionCall { name, args, .. }
             if name
                 .segments
                 .first()
                 .map(|s| s.name.eq_ignore_ascii_case("__label_eq"))
                 .unwrap_or(false) =>
         {
-            // The lowering already attached a label-aware operator; the
-            // predicate Filter is purely defensive. Treat as 1.0 so it
-            // doesn't multiply downstream estimates by 0.5.
-            1.0
+            sel_label_eq(args, bindings)
         }
 
         // Anything else (function calls, CASE, list/map literals, etc.).
         _ => FALLBACK_UNKNOWN,
+    }
+}
+
+/// Selectivity of a synthetic `__label_eq(alias, "L")` filter: the fraction of
+/// nodes carrying label `L`, approximated as `node_count(L) / total_nodes`
+/// (independence). `MATCH (n:A:B)` scans `A` and applies this for `B`, so the
+/// estimate becomes `node_count(A) * node_count(B)/total_nodes` — an
+/// intersection guess rather than the old `node_count(A)` (which ignored `B`).
+/// Falls back to 1.0 (no shrink) when the catalog or label is unknown.
+fn sel_label_eq(args: &[Expression], bindings: &BindingStats<'_>) -> f64 {
+    let (Some(catalog), Some(label)) = (bindings.catalog, label_literal(args)) else {
+        return 1.0;
+    };
+    let total = catalog.total_nodes();
+    if total == 0 {
+        return 1.0;
+    }
+    match catalog.label(label) {
+        Some(ls) => ls.node_count as f64 / total as f64,
+        None => 1.0,
+    }
+}
+
+/// Pull the label string out of `__label_eq(target, "Label")`'s second arg.
+fn label_literal(args: &[Expression]) -> Option<&str> {
+    match args.get(1).map(|e| &e.kind) {
+        Some(ExpressionKind::Literal(Literal::String(s))) => Some(s.as_str()),
+        _ => None,
     }
 }
 

--- a/crates/namidb-query/tests/cost_smoke.rs
+++ b/crates/namidb-query/tests/cost_smoke.rs
@@ -319,6 +319,57 @@ async fn catalog_counts_multi_label_nodes_under_each_label() {
 }
 
 #[tokio::test]
+async fn multi_label_match_estimate_reflects_intersection() {
+    // 3 plain Person, 2 Person+Admin, 1 plain Admin -> Person=5, Admin=3, total=6.
+    let mut writer = WriterSession::open(store(), paths("ml-est")).await.unwrap();
+    for i in 0..3 {
+        writer
+            .upsert_node_with_labels(
+                ["Person".to_string()],
+                NodeId::new(),
+                &person(&format!("p{i}"), "x", 30),
+            )
+            .unwrap();
+    }
+    for i in 0..2 {
+        writer
+            .upsert_node_with_labels(
+                ["Person".to_string(), "Admin".to_string()],
+                NodeId::new(),
+                &person(&format!("pa{i}"), "x", 30),
+            )
+            .unwrap();
+    }
+    writer
+        .upsert_node_with_labels(["Admin".to_string()], NodeId::new(), &person("a0", "x", 30))
+        .unwrap();
+    writer.flush(schema()).await.expect("flush");
+    let snap = writer.snapshot();
+    let cat = StatsCatalog::from_manifest(&snap.manifest().manifest);
+
+    // Optimized plan: NodeScan(Person) + Filter(__label_eq(n, "Admin")).
+    let opt = optimize(
+        lower(&parse("MATCH (n:Person:Admin) RETURN n").unwrap()).unwrap(),
+        &cat,
+    );
+    let card = estimate(&opt, &cat);
+    let rows = execute(&opt, &snap, &Params::new()).await.unwrap();
+
+    assert_eq!(rows.len(), 2, "exactly the 2 Person+Admin nodes match");
+    // node_count(Person) * node_count(Admin)/total = 5 * 3/6 = 2.5, vs the old
+    // estimate of 5.0 that ignored the :Admin constraint entirely.
+    assert!(
+        (card.rows - 2.5).abs() < 0.6,
+        "estimate {} should reflect the Person-and-Admin intersection (~2.5)",
+        card.rows
+    );
+    assert!(
+        card.rows < 5.0,
+        "the :Admin constraint must shrink the estimate below node_count(Person)=5"
+    );
+}
+
+#[tokio::test]
 async fn per_label_counts_survive_compaction() {
     // Compaction rebuilds the label-index sidecar (with per-label counts) on the
     // merged L1 SST. Without that, post-compaction `from_manifest` would read an


### PR DESCRIPTION
## Summary

Refines the cardinality estimate for multi-label `MATCH (n:A:B)`. Results were
always correct; this only tightens the optimizer's row estimate.

## Type

- [x] Performance improvement (`perf:` / cost-model accuracy)
- [x] New feature or capability (`feat:`)

## What changed

`MATCH (n:A:B)` lowers to `NodeScan(A) + Filter(__label_eq(n, "B"))`. The
`__label_eq` selectivity was a flat `1.0` (the old defensive-filter
convention), so the estimate was `node_count(A)` and ignored `:B`. It is now
`node_count(B) / total_nodes`, making the estimate
`node_count(A) * node_count(B)/total_nodes` (independence). `BindingStats`
gained an optional catalog ref; the rule falls back to `1.0` when the label or
catalog is unknown, so single-label plans (which emit no `__label_eq`) are
unchanged.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --lib --tests --exclude namidb-py -- -D warnings -A clippy::doc_lazy_continuation`
- [x] `cargo test --workspace --exclude namidb-py` (1087 passing)

New `cost_smoke::multi_label_match_estimate_reflects_intersection`: Person=5,
Admin=3, total=6 -> estimate ~2.5 (was 5.0), actual 2.

## Breaking changes

None. Estimate-only change; query results are unaffected.

## Checklist

- [ ] I have read `CONTRIBUTING.md`
- [x] I have added tests covering the change
- [x] I have updated relevant doc comments
- [ ] I have signed my commits
