### PR TITLE
feat(storage,query): RFC 025 Phase 1 - per-label property statistics sidecar

### DIFF
--- a/crates/namidb-query/src/cost/stats.rs
+++ b/crates/namidb-query/src/cost/stats.rs
@@ -359,12 +359,37 @@ fn merge_node_sst(
         }
     }
 
-    // Per-column property stats stay keyed by `scope`. Under id-primary every
-    // property rides in one `__overflow_json` column, so `property_stats` is
-    // empty and this is a no-op (min/max/ndv stay `None`, and the optimizer
-    // uses its documented fallbacks); per-label column stats return with the
-    // typed-column layout. Legacy typed-column SSTs still populate their one
-    // label's stats here via `scope`.
+    // Per-(label, property) stats for id-primary node SSTs (RFC 025). The SST
+    // spans many labels with properties in one `__overflow_json` column, so the
+    // typed-column `property_stats` below is empty; these come from a per-label
+    // sidecar computed at flush/compaction. Resolve each label id via the
+    // dictionary and fold min/max/null + the HLL sketch into that label's
+    // PropStats. `non_null_count` backfills from `node_count - null_count`.
+    for s in &sst.per_label_property_stats {
+        let Some(name) = label_dict.name(LabelId(s.label_id)) else {
+            continue;
+        };
+        let entry = labels
+            .entry(name.to_string())
+            .or_insert_with(|| LabelStats {
+                name: name.to_string(),
+                ..Default::default()
+            });
+        let prop = entry.properties.entry(s.property.clone()).or_default();
+        prop.null_count = prop.null_count.saturating_add(s.null_count);
+        prop.min = merge_min(prop.min.take(), s.min.clone());
+        prop.max = merge_max(prop.max.take(), s.max.clone());
+        absorb_hll_sketch(
+            hll_merge,
+            name.to_string(),
+            s.property.clone(),
+            s.ndv_estimate.as_ref(),
+        );
+    }
+
+    // Legacy typed-column SSTs keep their per-column `property_stats` keyed by
+    // `scope` (a single label). Under id-primary `property_stats` is empty and
+    // this loop is a no-op (the RFC-025 sidecar above carries the stats).
     if !sst.property_stats.is_empty() {
         let label = &sst.scope;
         let entry = labels.entry(label.clone()).or_insert_with(|| LabelStats {
@@ -637,6 +662,7 @@ mod tests {
             unique_property_indices: Vec::new(),
             equality_property_indices: Vec::new(),
             label_index: None,
+            per_label_property_stats: Vec::new(),
         }
     }
 
@@ -673,6 +699,7 @@ mod tests {
             unique_property_indices: Vec::new(),
             equality_property_indices: Vec::new(),
             label_index: None,
+            per_label_property_stats: Vec::new(),
         }
     }
 

--- a/crates/namidb-query/tests/cost_smoke.rs
+++ b/crates/namidb-query/tests/cost_smoke.rs
@@ -105,6 +105,20 @@ fn person(first: &str, last: &str, age: i32) -> NodeWriteRecord {
     }
 }
 
+/// A `Person` that sets `firstName`/`lastName` but leaves the declared `age`
+/// property unset — used to exercise null accounting for a declared-but-absent
+/// property.
+fn person_no_age(first: &str, last: &str) -> NodeWriteRecord {
+    let mut p: BTreeMap<String, CoreValue> = BTreeMap::new();
+    p.insert("firstName".into(), CoreValue::Str(first.into()));
+    p.insert("lastName".into(), CoreValue::Str(last.into()));
+    NodeWriteRecord {
+        properties: p,
+        schema_version: 1,
+        ..Default::default()
+    }
+}
+
 fn message(content: &str, creation_date: i64) -> NodeWriteRecord {
     let mut p = BTreeMap::new();
     p.insert("content".into(), CoreValue::Str(content.into()));
@@ -426,6 +440,54 @@ async fn per_label_property_stats_attribute_per_label_and_survive_compaction() {
     ));
 
     // ...and unchanged after L0->L1 compaction rebuilds the sidecar.
+    writer.compact_l0(&schema()).await.expect("compact");
+    check(&StatsCatalog::from_manifest(
+        &writer.snapshot().manifest().manifest,
+    ));
+}
+
+#[tokio::test]
+async fn declared_property_absent_in_an_sst_counts_as_null_not_present() {
+    // RFC 025 null accounting: a property DECLARED on a label but absent from
+    // every row of a given SST emits no observed accumulator, so without the
+    // schema-seeded null entry the cross-SST merge would leave `null_count = 0`
+    // and the backfill (`non_null = node_count - null_count`) would report the
+    // property as fully present. Here `age` is set in flush 1 and absent in
+    // flush 2; the catalog must report 3 non-null + 2 null, not 5 non-null.
+    let mut writer = WriterSession::open(store(), paths("rfc025-null-absent"))
+        .await
+        .unwrap();
+    // Flush 1: 3 Persons WITH age.
+    for (f, l, age) in [("a", "x", 10), ("b", "x", 20), ("c", "x", 30)] {
+        writer
+            .upsert_node("Person", NodeId::new(), &person(f, l, age))
+            .unwrap();
+    }
+    writer.flush(schema()).await.expect("flush 1");
+    // Flush 2: 2 Persons WITHOUT age (declared, but unset on every row here).
+    for (f, l) in [("d", "x"), ("e", "x")] {
+        writer
+            .upsert_node("Person", NodeId::new(), &person_no_age(f, l))
+            .unwrap();
+    }
+    writer.flush(schema()).await.expect("flush 2");
+
+    let check = |cat: &StatsCatalog| {
+        let person = cat.label("Person").unwrap();
+        assert_eq!(person.node_count, 5, "5 Persons total");
+        let age = &person.properties["age"];
+        assert_eq!(age.non_null_count, 3, "only flush-1 Persons set age");
+        assert_eq!(age.null_count, 2, "flush-2 Persons leave age null");
+        use namidb_storage::sst::stats::StatScalar::Int64;
+        assert_eq!(age.min, Some(Int64(10)));
+        assert_eq!(age.max, Some(Int64(30)));
+    };
+
+    // Cross-SST merge across the two L0 SSTs...
+    check(&StatsCatalog::from_manifest(
+        &writer.snapshot().manifest().manifest,
+    ));
+    // ...and unchanged after compaction rebuilds the merged sidecar.
     writer.compact_l0(&schema()).await.expect("compact");
     check(&StatsCatalog::from_manifest(
         &writer.snapshot().manifest().manifest,

--- a/crates/namidb-query/tests/cost_smoke.rs
+++ b/crates/namidb-query/tests/cost_smoke.rs
@@ -370,6 +370,69 @@ async fn multi_label_match_estimate_reflects_intersection() {
 }
 
 #[tokio::test]
+async fn per_label_property_stats_attribute_per_label_and_survive_compaction() {
+    // RFC 025: a property on a multi-label node contributes to EVERY one of its
+    // labels' stats. Two flushes (two L0 SSTs) exercise the cross-SST merge,
+    // then compaction must preserve the merged stats.
+    let mut writer = WriterSession::open(store(), paths("rfc025-stats"))
+        .await
+        .unwrap();
+    // Flush 1: 2 plain Person (age 10, 20) + 1 Person+Admin (age 100).
+    writer
+        .upsert_node_with_labels(["Person".to_string()], NodeId::new(), &person("a", "x", 10))
+        .unwrap();
+    writer
+        .upsert_node_with_labels(["Person".to_string()], NodeId::new(), &person("b", "x", 20))
+        .unwrap();
+    writer
+        .upsert_node_with_labels(
+            ["Person".to_string(), "Admin".to_string()],
+            NodeId::new(),
+            &person("c", "x", 100),
+        )
+        .unwrap();
+    writer.flush(schema()).await.expect("flush 1");
+    // Flush 2: 1 plain Person (age 30) + 1 Person+Admin (age 200).
+    writer
+        .upsert_node_with_labels(["Person".to_string()], NodeId::new(), &person("d", "x", 30))
+        .unwrap();
+    writer
+        .upsert_node_with_labels(
+            ["Person".to_string(), "Admin".to_string()],
+            NodeId::new(),
+            &person("e", "x", 200),
+        )
+        .unwrap();
+    writer.flush(schema()).await.expect("flush 2");
+
+    let check = |cat: &StatsCatalog| {
+        // Person.age spans all 5 (10,20,100,30,200); Admin.age only the 2
+        // Person+Admin nodes (100, 200) — the multi-label nodes' age is folded
+        // into BOTH labels.
+        let person_age = &cat.label("Person").unwrap().properties["age"];
+        let admin_age = &cat.label("Admin").unwrap().properties["age"];
+        use namidb_storage::sst::stats::StatScalar::Int64;
+        assert_eq!(person_age.min, Some(Int64(10)), "Person.age min over all 5");
+        assert_eq!(person_age.max, Some(Int64(200)));
+        assert_eq!(person_age.non_null_count, 5);
+        assert_eq!(admin_age.min, Some(Int64(100)), "Admin.age min over the 2");
+        assert_eq!(admin_age.max, Some(Int64(200)));
+        assert_eq!(admin_age.non_null_count, 2);
+    };
+
+    // Across the two L0 SSTs (cross-SST merge).
+    check(&StatsCatalog::from_manifest(
+        &writer.snapshot().manifest().manifest,
+    ));
+
+    // ...and unchanged after L0->L1 compaction rebuilds the sidecar.
+    writer.compact_l0(&schema()).await.expect("compact");
+    check(&StatsCatalog::from_manifest(
+        &writer.snapshot().manifest().manifest,
+    ));
+}
+
+#[tokio::test]
 async fn per_label_counts_survive_compaction() {
     // Compaction rebuilds the label-index sidecar (with per-label counts) on the
     // merged L1 SST. Without that, post-compaction `from_manifest` would read an
@@ -503,48 +566,46 @@ async fn property_stats_are_present_after_flush() {
     let cat = StatsCatalog::from_manifest(&snap.manifest().manifest);
 
     let p = cat.label("Person").unwrap();
-    // Each declared property is still present as a catalog entry (seeded from
-    // the schema), so the optimizer knows the column exists. Under the
-    // id-primary layout every property rides in a single `__overflow_json`
-    // column rather than a typed `prop_*` column, so the writer emits no
-    // per-column Parquet statistics: min/max/ndv come back `None` and the
-    // optimizer uses its documented fallbacks. Precise per-label column stats
-    // (min/max=25/40, firstName=Alice..Frank, real ndv) return with the
-    // typed-column layout (RFC-pending); this test guards the current contract.
+    // RFC 025: the per-(label, property) sidecar restores real min/max/null
+    // under id-primary. Properties live in `__overflow_json`, but flush walks
+    // the rows grouped by label and records the stats. Ages range 25..=40
+    // (Bob=25, Eve=40); firstName covers Alice..Frank lexicographically.
     assert!(p.properties.contains_key("age"), "age stats present");
     assert!(p.properties.contains_key("firstName"));
     assert!(p.properties.contains_key("lastName"));
     let age = &p.properties["age"];
-    assert!(
-        age.min.is_none() && age.max.is_none(),
-        "id-primary: no per-column min/max until the typed-column layout, got {:?}/{:?}",
-        age.min,
-        age.max
-    );
-    assert!(age.ndv.is_none(), "id-primary: no per-column ndv yet");
-    // No per-column null statistics either: null_count stays 0 and
-    // non_null_count backfills to the label's node_count (6 Persons).
-    assert_eq!(
-        age.null_count, 0,
-        "no per-column null stats under id-primary"
-    );
-    assert_eq!(age.non_null_count, 6, "non_null backfills to node_count");
+    match (&age.min, &age.max) {
+        (
+            Some(namidb_storage::sst::stats::StatScalar::Int64(mn)),
+            Some(namidb_storage::sst::stats::StatScalar::Int64(mx)),
+        ) => {
+            assert_eq!(*mn, 25, "Bob (25) is the youngest");
+            assert_eq!(*mx, 40, "Eve (40) is the oldest");
+        }
+        other => panic!("unexpected age stats: {:?}", other),
+    }
+    assert_eq!(age.null_count, 0, "no NULL ages in the fixture");
+    assert_eq!(age.non_null_count, 6, "6 Persons, all with an age");
 
     let first = &p.properties["firstName"];
-    assert!(
-        first.min.is_none() && first.max.is_none(),
-        "id-primary: no per-column min/max for firstName yet"
-    );
+    match (&first.min, &first.max) {
+        (
+            Some(namidb_storage::sst::stats::StatScalar::Utf8(mn)),
+            Some(namidb_storage::sst::stats::StatScalar::Utf8(mx)),
+        ) => {
+            assert_eq!(mn, "Alice");
+            assert_eq!(mx, "Frank");
+        }
+        other => panic!("unexpected firstName stats: {:?}", other),
+    }
 }
 
 #[tokio::test]
 async fn filter_estimate_uses_real_min_max_after_writer_fix() {
-    // Range selectivity with real min/max would use the precise formula
-    // (lit-min)/(max-min): ages min=25,max=40,lit=30 → 6 * 0.667 = 4.0.
-    // Under id-primary there are no per-column min/max (properties live in
-    // `__overflow_json`), so range selectivity falls back to the documented
-    // 0.33 constant → 6 * 0.33 ≈ 1.98. The precise estimate returns with the
-    // typed-column layout; results are unaffected either way.
+    // RFC 025 restores real min/max under id-primary, so range selectivity
+    // uses the precise formula (lit-min)/(max-min): ages min=25, max=40,
+    // lit=30 -> below=(30-25)/(40-25)=0.333; Gt -> 1-below=0.667 -> 6 * 0.667
+    // = 4.0 (vs the 6 * 0.33 = 1.98 fallback when min/max are unknown).
     let mut writer = WriterSession::open(store(), paths("stats06b"))
         .await
         .unwrap();
@@ -558,16 +619,11 @@ async fn filter_estimate_uses_real_min_max_after_writer_fix() {
     let rows = execute(&plan, &snap, &Params::new()).await.unwrap();
 
     assert_eq!(rows.len(), 3, "Carol(35), Eve(40), Frank(33)");
-    // Fallback: 6 * 0.33 ≈ 1.98. The filter still drops the estimate below the
-    // 6-row scan cardinality, which is the property the optimizer relies on.
+    // Precise estimate ~4.0 (close to the actual 3); the fallback would be 1.98.
     assert!(
-        (card.rows - 2.0).abs() < 0.6,
-        "fallback range selectivity should give ~2 (6 * 0.33), got {}",
+        (card.rows - 4.0).abs() < 0.5,
+        "with real min/max the estimate {} should be ~4 (close to actual 3)",
         card.rows
-    );
-    assert!(
-        card.rows < 6.0,
-        "filter must still drop below scan cardinality"
     );
 }
 
@@ -1022,25 +1078,29 @@ async fn catalog_materializes_real_ndv_after_flush() {
     let cat = StatsCatalog::from_manifest(&snap.manifest().manifest);
 
     let person = cat.label("Person").expect("Person label");
-    // The HLL pipeline only runs over typed `prop_*` columns. Under id-primary
-    // every property rides in `__overflow_json`, so no sketch is emitted and
-    // `ndv` is `None` for every property; equality/IN selectivity falls back to
-    // the documented constants. Real per-column ndv (≈6 distinct firstNames in
-    // the Alice..Frank fixture) returns with the typed-column layout.
+    // RFC 025: the per-(label, property) sidecar feeds an HLL per (label, prop)
+    // at flush, so `ndv` is populated under id-primary. 6 distinct firstNames
+    // and 6 distinct ages in the fixture; HLL at the default precision rounds
+    // into [5, 8].
     let first = person
         .properties
         .get("firstName")
         .expect("firstName stats present");
+    let ndv = first
+        .ndv
+        .expect("ndv populated by the per-label HLL sidecar");
     assert!(
-        first.ndv.is_none(),
-        "id-primary: no per-column ndv until the typed-column layout, got {:?}",
-        first.ndv
+        (5..=8).contains(&ndv),
+        "firstName ndv {} not close to 6",
+        ndv
     );
 
     let age = person.properties.get("age").expect("age stats present");
+    let age_ndv = age.ndv.expect("age ndv populated");
     assert!(
-        age.ndv.is_none(),
-        "id-primary: no per-column ndv for age yet"
+        (5..=8).contains(&age_ndv),
+        "age ndv {} not close to 6",
+        age_ndv
     );
 }
 
@@ -1136,13 +1196,9 @@ async fn hash_join_executes_correctly() {
 async fn hash_join_estimate_matches_actual_within_micro_graph() {
     // HashJoin uses Selinger '79:
     //   rows = (|build| * |probe|) / max(ndv(build_key), ndv(probe_key))
-    // The join key here is the property `firstName`. With a real ndv ≈ 6 the
-    // divisor would tighten the estimate to ≈ 6 (the actual). Under id-primary
-    // `firstName` has no per-column ndv (it lives in `__overflow_json`), so the
-    // divisor falls back to 1 and the estimate is the cartesian upper bound
-    // |build| * |probe| = 36 — loose but still a valid over-estimate. The tight
-    // estimate returns with the typed-column layout. Either way execution is
-    // correct (each Person matches only itself; distinct names → 6 rows).
+    // The join key is the property `firstName`. RFC 025 restores its real ndv
+    // (~6) under id-primary, so the divisor tightens the estimate to ~6 (the
+    // actual), instead of the cartesian 36 it would be with no per-column ndv.
     let mut writer = WriterSession::open(store(), paths("s123-hj03"))
         .await
         .unwrap();
@@ -1157,14 +1213,13 @@ async fn hash_join_estimate_matches_actual_within_micro_graph() {
     let rows = execute(&optimized, &snap, &Params::new()).await.unwrap();
     let actual = rows.len() as f64;
     assert_eq!(actual, 6.0, "6 Persons, each joins only to itself");
-    // Cartesian fallback: 6 * 6 = 36, and it must remain a valid upper bound.
+    let err = (opt_est - actual).abs() / actual.max(1.0);
     assert!(
-        opt_est >= actual,
-        "estimate {opt_est} must not under-count actual {actual}"
-    );
-    assert!(
-        (opt_est - 36.0).abs() < 1.0,
-        "without per-column ndv the estimate is the cartesian bound 36, got {opt_est}"
+        err < 0.30,
+        "HashJoin estimate {} far from actual {} (rel err {})",
+        opt_est,
+        actual,
+        err
     );
 }
 

--- a/crates/namidb-storage/src/compact.rs
+++ b/crates/namidb-storage/src/compact.rs
@@ -551,6 +551,9 @@ async fn put_node_sst_l1(
         unique_property_indices,
         equality_property_indices,
         label_index,
+        // Recompute per-(label, property) stats from the merged rows so they
+        // survive L0->L1 the same way the label index does (RFC 025).
+        per_label_property_stats: crate::flush::compute_per_label_property_stats(merged_rows)?,
     };
     Ok((descriptor, wrote_bloom))
 }
@@ -618,6 +621,7 @@ async fn put_edge_sst_l1(
         unique_property_indices: Vec::new(),
         equality_property_indices: Vec::new(),
         label_index: None,
+        per_label_property_stats: Vec::new(),
     };
     Ok((descriptor, wrote_bloom))
 }

--- a/crates/namidb-storage/src/compact.rs
+++ b/crates/namidb-storage/src/compact.rs
@@ -45,7 +45,7 @@ use object_store::{ObjectStore, ObjectStoreExt, PutMode, PutOptions, PutPayload}
 use tracing::{debug, instrument};
 use uuid::Uuid;
 
-use namidb_core::{LabelDef, Schema, Value};
+use namidb_core::{LabelDef, LabelDictionary, Schema, Value};
 
 use crate::error::{Error, Result};
 use crate::fence::WriterFence;
@@ -151,6 +151,8 @@ pub async fn compact_l0_to_l1(
             &label_def,
             &merged_rows,
             finish,
+            schema,
+            &base.manifest.label_dict,
         )
         .await?;
         if wrote_bloom {
@@ -450,6 +452,10 @@ fn compact_edge_ssts(
 
 // ── PUT helpers (L1 variants) ───────────────────────────────────────────
 
+// `schema` + `label_dict` join the existing five to seed per-label property
+// stats for declared-but-absent properties during the L0->L1 rebuild; the
+// params are all distinct and bundling them would not aid readability.
+#[allow(clippy::too_many_arguments)]
 async fn put_node_sst_l1(
     store: &dyn ObjectStore,
     paths: &NamespacePaths,
@@ -457,6 +463,8 @@ async fn put_node_sst_l1(
     label_def: &LabelDef,
     merged_rows: &[NodeRow],
     finish: NodeSstFinish,
+    schema: &Schema,
+    label_dict: &LabelDictionary,
 ) -> Result<(SstDescriptor, bool)> {
     let id = Uuid::now_v7();
     let level = SstLevel(1);
@@ -553,7 +561,11 @@ async fn put_node_sst_l1(
         label_index,
         // Recompute per-(label, property) stats from the merged rows so they
         // survive L0->L1 the same way the label index does (RFC 025).
-        per_label_property_stats: crate::flush::compute_per_label_property_stats(merged_rows)?,
+        per_label_property_stats: crate::flush::compute_per_label_property_stats(
+            merged_rows,
+            schema,
+            label_dict,
+        )?,
     };
     Ok((descriptor, wrote_bloom))
 }

--- a/crates/namidb-storage/src/flush.rs
+++ b/crates/namidb-storage/src/flush.rs
@@ -60,7 +60,9 @@ use tokio::io::AsyncWriteExt;
 use tracing::{debug, instrument};
 use uuid::Uuid;
 
-use namidb_core::{DataType, EdgeTypeDef, LabelDef, PropertyDef, Schema, Value};
+use namidb_core::{
+    DataType, EdgeTypeDef, LabelDef, LabelDictionary, LabelId, PropertyDef, Schema, Value,
+};
 
 use crate::error::{Error, Result};
 use crate::fence::WriterFence;
@@ -203,6 +205,8 @@ pub async fn flush(
             &index_props,
             &node_rows,
             finish,
+            &schema,
+            &base.manifest.label_dict,
         )?);
     }
     for (edge_type, rows) in edge_buckets {
@@ -596,6 +600,8 @@ fn prepare_node_pending(
     label_def: &LabelDef,
     rows: &[NodeRow],
     finish: NodeSstFinish,
+    schema: &Schema,
+    label_dict: &LabelDictionary,
 ) -> Result<PendingSst> {
     let id = Uuid::now_v7();
     let level = SstLevel::L0;
@@ -658,7 +664,7 @@ fn prepare_node_pending(
         unique_property_indices,
         equality_property_indices,
         label_index,
-        per_label_property_stats: compute_per_label_property_stats(rows)?,
+        per_label_property_stats: compute_per_label_property_stats(rows, schema, label_dict)?,
     };
 
     Ok(PendingSst {
@@ -744,6 +750,8 @@ pub(crate) fn prepare_label_index_sidecar(
 /// contribute nothing (only `MemOp::Upsert` rows are folded).
 pub(crate) fn compute_per_label_property_stats(
     rows: &[NodeRow],
+    schema: &Schema,
+    label_dict: &LabelDictionary,
 ) -> Result<Vec<PerLabelPropertyStat>> {
     struct Acc {
         min: Option<StatScalar>,
@@ -782,6 +790,34 @@ pub(crate) fn compute_per_label_property_stats(
                     None => scalar,
                 });
             }
+        }
+    }
+
+    // Seed declared-but-absent properties. A property declared on a label but
+    // null on every row of this SST yields no accumulator above, so it would
+    // emit no entry; the cost model's backfill (`non_null = node_count -
+    // null_count`) then leaves `null_count = 0` and the property reads as fully
+    // non-null. Seeding an empty accumulator for every declared property of a
+    // label present here makes its `null_count` resolve to `live` (all rows
+    // null), which is correct and additive across SSTs. Only labels present in
+    // this SST are seeded; their declared set comes from the schema, resolved
+    // through the label dictionary (an un-resolvable or undeclared label simply
+    // falls back to the observed-only behavior).
+    for &label_id in live_per_label.keys() {
+        let Some(name) = label_dict.name(LabelId(label_id)) else {
+            continue;
+        };
+        let Some(def) = schema.label(name) else {
+            continue;
+        };
+        for prop in &def.properties {
+            accs.entry((label_id, prop.name.clone()))
+                .or_insert_with(|| Acc {
+                    min: None,
+                    max: None,
+                    hll: Hll::new(DEFAULT_PRECISION),
+                    non_null: 0,
+                });
         }
     }
 
@@ -1551,7 +1587,8 @@ pub mod builder {
         };
         let index_props = union_indexed_props(schema);
         let finish = super::build_node_sst(&column_label, &node_rows)?;
-        let pending = prepare_node_pending(paths, &index_props, &node_rows, finish)?;
+        let pending =
+            prepare_node_pending(paths, &index_props, &node_rows, finish, schema, &node_dict)?;
         Ok(Some(BuiltSst {
             inner: pending,
             label_dict: node_dict,

--- a/crates/namidb-storage/src/flush.rs
+++ b/crates/namidb-storage/src/flush.rs
@@ -65,7 +65,8 @@ use namidb_core::{DataType, EdgeTypeDef, LabelDef, PropertyDef, Schema, Value};
 use crate::error::{Error, Result};
 use crate::fence::WriterFence;
 use crate::manifest::{
-    KindSpecificStats, LoadedManifest, ManifestStore, SstDescriptor, SstKind, SstLevel,
+    KindSpecificStats, LoadedManifest, ManifestStore, PerLabelPropertyStat, SstDescriptor, SstKind,
+    SstLevel,
 };
 use crate::memtable::{FrozenMemtable, MemKey, MemOp};
 use crate::paths::NamespacePaths;
@@ -75,7 +76,11 @@ use crate::sst::edges::writer::{
     EdgeRecord as EdgeStreamRow, EdgeSstFinish, EdgeSstWriter, EdgeSstWriterOptions,
 };
 use crate::sst::edges::EdgeDirection;
-use crate::sst::nodes::{node_arrow_schema, NodeSstFinish, NodeSstWriter, NodeSstWriterOptions};
+use crate::sst::hll::{Hll, DEFAULT_PRECISION};
+use crate::sst::nodes::{
+    max_scalar, min_scalar, node_arrow_schema, NodeSstFinish, NodeSstWriter, NodeSstWriterOptions,
+};
+use crate::sst::stats::StatScalar;
 
 // ── Wire-level records ─────────────────────────────────────────────────
 
@@ -653,6 +658,7 @@ fn prepare_node_pending(
         unique_property_indices,
         equality_property_indices,
         label_index,
+        per_label_property_stats: compute_per_label_property_stats(rows)?,
     };
 
     Ok(PendingSst {
@@ -727,6 +733,94 @@ pub(crate) fn prepare_label_index_sidecar(
         per_label_counts,
     };
     Ok((Some(descriptor), Some((object_path, body))))
+}
+
+/// Compute per-(label, property) statistics for an id-primary node SST
+/// (RFC 025). Walks the reconciled rows, and for every label a row carries,
+/// folds each scalar property value into a `(LabelId, property)` accumulator:
+/// min/max, an HLL for ndv, and a non-null count. `null_count` is then the
+/// label's live-row count minus the non-null count (a property absent / null /
+/// non-scalar on a row carrying the label counts as null). Tombstones
+/// contribute nothing (only `MemOp::Upsert` rows are folded).
+pub(crate) fn compute_per_label_property_stats(
+    rows: &[NodeRow],
+) -> Result<Vec<PerLabelPropertyStat>> {
+    struct Acc {
+        min: Option<StatScalar>,
+        max: Option<StatScalar>,
+        hll: Hll,
+        non_null: u64,
+    }
+    let mut accs: BTreeMap<(u32, String), Acc> = BTreeMap::new();
+    let mut live_per_label: BTreeMap<u32, u64> = BTreeMap::new();
+
+    for row in rows {
+        let MemOp::Upsert(payload) = &row.op else {
+            continue;
+        };
+        let rec = NodeWriteRecord::decode(payload)?;
+        for &lid in &rec.labels {
+            *live_per_label.entry(lid).or_default() += 1;
+            for (name, value) in &rec.properties {
+                let Some(scalar) = value_to_stat_scalar(value) else {
+                    continue;
+                };
+                let acc = accs.entry((lid, name.clone())).or_insert_with(|| Acc {
+                    min: None,
+                    max: None,
+                    hll: Hll::new(DEFAULT_PRECISION),
+                    non_null: 0,
+                });
+                acc.non_null += 1;
+                acc.hll.add_scalar(&scalar);
+                acc.min = Some(match acc.min.take() {
+                    Some(prev) => min_scalar(prev, scalar.clone()),
+                    None => scalar.clone(),
+                });
+                acc.max = Some(match acc.max.take() {
+                    Some(prev) => max_scalar(prev, scalar),
+                    None => scalar,
+                });
+            }
+        }
+    }
+
+    let mut out = Vec::with_capacity(accs.len());
+    for ((label_id, property), acc) in accs {
+        let live = live_per_label
+            .get(&label_id)
+            .copied()
+            .unwrap_or(acc.non_null);
+        out.push(PerLabelPropertyStat {
+            label_id,
+            property,
+            null_count: live.saturating_sub(acc.non_null),
+            min: acc.min,
+            max: acc.max,
+            ndv_estimate: if acc.hll.is_empty() {
+                None
+            } else {
+                Some(acc.hll.to_sketch_bytes())
+            },
+        });
+    }
+    Ok(out)
+}
+
+/// Map a core [`Value`] to the [`StatScalar`] the optimizer's min/max/ndv
+/// machinery understands. Returns `None` for non-scalar values (null, vector,
+/// list, map) which carry no useful per-column statistic.
+fn value_to_stat_scalar(v: &Value) -> Option<StatScalar> {
+    match v {
+        Value::Bool(b) => Some(StatScalar::Bool(*b)),
+        Value::I64(i) => Some(StatScalar::Int64(*i)),
+        Value::F64(f) => Some(StatScalar::Float64(*f)),
+        Value::Str(s) => Some(StatScalar::Utf8(s.clone())),
+        Value::Bytes(b) => Some(StatScalar::Binary(b.clone())),
+        Value::Date(d) => Some(StatScalar::Date32(*d)),
+        Value::DateTime(m) => Some(StatScalar::TimestampMicrosUtc(*m)),
+        Value::Null | Value::Vec(_) | Value::List(_) | Value::Map(_) => None,
+    }
 }
 
 /// Parallel outputs of [`prepare_unique_property_sidecars`]: the
@@ -935,6 +1029,7 @@ fn prepare_edge_pending(
         unique_property_indices: Vec::new(),
         equality_property_indices: Vec::new(),
         label_index: None,
+        per_label_property_stats: Vec::new(),
     };
 
     PendingSst {

--- a/crates/namidb-storage/src/manifest.rs
+++ b/crates/namidb-storage/src/manifest.rs
@@ -34,7 +34,7 @@ use crate::error::{Error, Result};
 use crate::fence::{Epoch, WriterFence};
 use crate::paths::NamespacePaths;
 use crate::sst::bloom::BloomDescriptor;
-use crate::sst::stats::{DegreeHistogram, PropertyColumnStats};
+use crate::sst::stats::{DegreeHistogram, HllSketchBytes, PropertyColumnStats, StatScalar};
 
 /// Top-level versioned manifest. Self-contained snapshot of every artefact
 /// that belongs to the namespace at this version.
@@ -233,6 +233,38 @@ pub struct SstDescriptor {
     // older manifests loading unchanged.
     #[serde(default)]
     pub label_index: Option<LabelIndexDescriptor>,
+
+    // Per-(label, property) statistics for id-primary node SSTs (RFC 025).
+    // Because one node SST spans many labels and every property rides in a
+    // single `__overflow_json` column, the per-column Parquet footer stats that
+    // `property_stats` used to carry no longer exist. These are computed at
+    // flush/compaction by grouping the SST's rows by their label set, and the
+    // cost model folds them into `(label, property)` PropStats. Empty for edge
+    // SSTs, for legacy typed-column SSTs (which still use `property_stats`), and
+    // for manifests written before this field existed (`serde(default)`).
+    #[serde(default)]
+    pub per_label_property_stats: Vec<PerLabelPropertyStat>,
+}
+
+/// One `(label, property)` statistics entry for an id-primary node SST
+/// (RFC 025). `label_id` resolves to a name via the manifest's `label_dict`,
+/// the same dictionary the label-index posting counts use.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct PerLabelPropertyStat {
+    pub label_id: u32,
+    /// Logical property name (no `prop_` prefix).
+    pub property: String,
+    /// Rows carrying this label for which the property is absent / null /
+    /// non-scalar. The cost model derives `non_null_count` as
+    /// `node_count - null_count` after the merge.
+    pub null_count: u64,
+    pub min: Option<StatScalar>,
+    pub max: Option<StatScalar>,
+    /// Serialised HLL sketch of the non-null scalar values; merged across node
+    /// SSTs at read time into `PropStats::ndv`. `None` when no sketchable value
+    /// was observed.
+    #[serde(default)]
+    pub ndv_estimate: Option<HllSketchBytes>,
 }
 
 /// Side-car pointer for a single `(SST, unique property)` pair. The
@@ -1033,6 +1065,7 @@ mod tests {
             unique_property_indices: Vec::new(),
             equality_property_indices: Vec::new(),
             label_index: None,
+            per_label_property_stats: Vec::new(),
         }
     }
 
@@ -1066,6 +1099,7 @@ mod tests {
             unique_property_indices: Vec::new(),
             equality_property_indices: Vec::new(),
             label_index: None,
+            per_label_property_stats: Vec::new(),
         }
     }
 

--- a/crates/namidb-storage/src/read.rs
+++ b/crates/namidb-storage/src/read.rs
@@ -4281,6 +4281,7 @@ mod tests {
             unique_property_indices: Vec::new(),
             equality_property_indices: Vec::new(),
             label_index: None,
+            per_label_property_stats: Vec::new(),
         };
 
         let empty = Memtable::new();
@@ -4306,6 +4307,7 @@ mod tests {
             unique_property_indices: Vec::new(),
             equality_property_indices: Vec::new(),
             label_index: None,
+            per_label_property_stats: Vec::new(),
             ..descriptor.clone()
         };
         assert!(snap
@@ -4633,6 +4635,7 @@ mod tests {
             unique_property_indices: Vec::new(),
             equality_property_indices: Vec::new(),
             label_index: None,
+            per_label_property_stats: Vec::new(),
         });
         let mt = Memtable::new();
         let view = mt.snapshot_view();

--- a/crates/namidb-storage/src/sst/nodes.rs
+++ b/crates/namidb-storage/src/sst/nodes.rs
@@ -1252,7 +1252,7 @@ fn extract_byte_array(
     }
 }
 
-fn min_scalar(a: StatScalar, b: StatScalar) -> StatScalar {
+pub(crate) fn min_scalar(a: StatScalar, b: StatScalar) -> StatScalar {
     if scalar_lt(&a, &b) {
         a
     } else {
@@ -1260,7 +1260,7 @@ fn min_scalar(a: StatScalar, b: StatScalar) -> StatScalar {
     }
 }
 
-fn max_scalar(a: StatScalar, b: StatScalar) -> StatScalar {
+pub(crate) fn max_scalar(a: StatScalar, b: StatScalar) -> StatScalar {
     if scalar_lt(&a, &b) {
         b
     } else {


### PR DESCRIPTION
## Summary

Implements **RFC 025 Phase 1** (#69): restores per-(label, property) statistics
(min/max/null/ndv) under the id-primary layout, lost when properties moved into
a single `__overflow_json` column (#65/#66). No physical layout change.

## Type

- [x] New feature / capability (`feat:`)
- [x] Implements an RFC (RFC 025)

## What changed

- **manifest:** `SstDescriptor` gains `per_label_property_stats:
  Vec<PerLabelPropertyStat>` (`serde(default)`, backward compatible).
- **flush:** `compute_per_label_property_stats` walks the reconciled rows; for
  every label a row carries, it folds each scalar property value into a
  `(LabelId, prop)` accumulator (min/max, an HLL for ndv, null_count). A
  property on a multi-label node contributes to every one of its labels.
- **compaction:** re-emits the sidecar from the merged rows so stats survive
  `L0->L1` (mirrors the label-index rebuild from #65).
- **cost/stats.rs `merge_node_sst`:** folds the sidecar into `PropStats` keyed
  by `(label, prop)`, resolving label ids via `label_dict` and reusing the
  existing min/max merge + HLL finalisation. No selectivity/cardinality code
  changes — they already consume `PropStats`.
- The cost-model assertions relaxed in #65/#66 (min/max/ndv None, fallback
  selectivity) are **tightened back** to the real values.

## RFC reference

- RFC: 025 (accepted, #69). Phase 2 (typed union columns for Parquet
  predicate/projection pushdown) is a separate future RFC.

## Test plan

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy --workspace --lib --tests --exclude namidb-py -- -D warnings -A clippy::doc_lazy_continuation`
- [x] `cargo test --workspace --exclude namidb-py` (1088 passing)

New: `per_label_property_stats_attribute_per_label_and_survive_compaction`
(multi-label attribution + cross-SST merge + compaction). Restored:
`property_stats_are_present_after_flush`, `catalog_materializes_real_ndv_after_flush`,
`filter_estimate_uses_real_min_max_after_writer_fix`,
`hash_join_estimate_matches_actual_within_micro_graph`.

## Breaking changes

On-disk only and additive: a new `serde(default)` manifest field. Older
manifests load unchanged; node SSTs written before this carry no sidecar and
fall back to today's behaviour until recompacted/reflushed.

## Checklist

- [ ] I have read `CONTRIBUTING.md`
- [x] I have added tests covering the change
- [x] I have updated relevant doc comments + the RFC
- [ ] I have signed my commits
