### PR TITLE
chore: reconcile release line into main and cut 0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,57 @@ below and in the release notes.
 
 ---
 
+## [0.12.0] - 2026-06-04: multi-label nodes, secondary indexes, per-label stats, pluggable Bolt auth
+
+This release reconciles two lines that forked at 0.11.0 and advanced in
+parallel: the published 0.11.x tags (pluggable Bolt auth, the logoff hook,
+variable-length path bindings) and main (multi-label nodes, the secondary
+equality index, per-label statistics). They are unified here, and releases
+are cut from `main` from now on. The intervening 0.11.0, 0.11.1 and 0.11.2
+tags shipped without changelog entries; their changes are folded below.
+
+### Added
+
+- **Multi-label nodes, end-to-end.** A node carries a set of labels rather
+  than one. New `LabelId`/`LabelDictionary` in the core, an id-primary
+  storage core that keeps the label set per node, Cypher that matches on any
+  subset of labels, intersection-aware cardinality for multi-label `MATCH`,
+  and Python bindings that read and write the label set.
+- **Secondary equality index for non-unique properties.** Indexed properties
+  that are not declared unique now get a value to node-set index (storage
+  half), and the planner uses it for equality predicates instead of scanning.
+- **Per-label property statistics (RFC-025, Phase 1).** Statistics are kept
+  per `(label, property)` so selectivity estimation no longer blends
+  unrelated labels.
+- **Pluggable Bolt authenticator.** Embedders can supply a custom
+  `Authenticator` instead of the built-in open/token schemes, plus a
+  `Backend::logoff` hook so they can drop per-connection identity on `LOGOFF`.
+- **Variable-length path bindings.** `MATCH p = (a)-[*1..2]->(b) RETURN p`
+  now binds the whole path to `p`.
+- **Real Bolt transactions.** `BEGIN`/`COMMIT`/`ROLLBACK` run as genuine
+  multi-statement transactions over the single-writer session.
+- **Background compaction scheduler.** A server task runs L0->L1 compaction
+  and orphan sweep on a tick.
+- **GUI client support.** G.V()/gdotv support (Neo4j connection type, write
+  counters, elementId point lookup) and Memgraph schema-introspection
+  procedures for GUI clients.
+- **Query surface.** `timestamp()` (epoch milliseconds), standard string,
+  math and list scalar builtins, `SKIP`/`LIMIT $parameter` resolution at
+  execution time, and synthesised bindings for anonymous elements in a
+  bound path.
+
+### Fixed
+
+- **Read-after-write through the property index.** `commit_batch` now resets
+  the cross-snapshot property index, the same way `flush` and `attach_ssts`
+  already did. Before this, a node committed without a flush could be
+  invisible to `lookup_node_by_property` once that `(label, property)` pair
+  had been warmed, returning stale or missing rows. Covered by a regression
+  test.
+- Python bindings adapted to the `NodeView` label set.
+
+---
+
 ## [0.10.0] - 2026-05-31: Live incremental sync (--watch, frontmatter links and aliases, nested tags)
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2072,7 +2072,7 @@ dependencies = [
 
 [[package]]
 name = "namidb"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "namidb-core",
  "namidb-graph",
@@ -2082,7 +2082,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-bench"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2101,7 +2101,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-bolt"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2121,7 +2121,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-cli"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2141,7 +2141,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-core"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "arrow-array",
  "arrow-schema",
@@ -2157,7 +2157,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-graph"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -2178,7 +2178,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-markdown"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -2196,7 +2196,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-mcp"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -2214,7 +2214,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-py"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "bytes",
  "chrono",
@@ -2232,7 +2232,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-query"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2256,7 +2256,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-server"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2286,7 +2286,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-storage"
-version = "0.11.2"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "arrow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2072,7 +2072,7 @@ dependencies = [
 
 [[package]]
 name = "namidb"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "namidb-core",
  "namidb-graph",
@@ -2082,7 +2082,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-bench"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -2101,7 +2101,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-bolt"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2121,7 +2121,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-cli"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -2141,7 +2141,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-core"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "arrow-array",
  "arrow-schema",
@@ -2157,7 +2157,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-graph"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -2178,7 +2178,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-markdown"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "blake3",
@@ -2196,7 +2196,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-mcp"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "clap",
@@ -2214,7 +2214,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-py"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "bytes",
  "chrono",
@@ -2232,7 +2232,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-query"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2256,7 +2256,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-server"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2286,7 +2286,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-storage"
-version = "0.11.1"
+version = "0.11.2"
 dependencies = [
  "anyhow",
  "arrow",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2072,7 +2072,7 @@ dependencies = [
 
 [[package]]
 name = "namidb"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "namidb-core",
  "namidb-graph",
@@ -2082,7 +2082,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-bench"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -2101,7 +2101,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-bolt"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2121,7 +2121,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-cli"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -2141,7 +2141,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-core"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "arrow-array",
  "arrow-schema",
@@ -2157,7 +2157,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-graph"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -2178,7 +2178,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-markdown"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "blake3",
@@ -2196,7 +2196,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-mcp"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -2214,7 +2214,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-py"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "bytes",
  "chrono",
@@ -2232,7 +2232,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-query"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2256,7 +2256,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-server"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2286,7 +2286,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-storage"
-version = "0.11.0"
+version = "0.11.1"
 dependencies = [
  "anyhow",
  "arrow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.11.2"
+version = "0.12.0"
 edition = "2021"
 rust-version = "1.85"
 license = "BUSL-1.1"
@@ -109,12 +109,12 @@ tower = "0.5"
 tower-http = { version = "0.6", features = ["trace", "cors"] }
 
 # Local workspace crates
-namidb-core = { path = "crates/namidb-core", version = "0.11.2" }
-namidb-storage = { path = "crates/namidb-storage", version = "0.11.2" }
-namidb-markdown = { path = "crates/namidb-markdown", version = "0.11.2" }
-namidb-graph = { path = "crates/namidb-graph", version = "0.11.2" }
-namidb-query = { path = "crates/namidb-query", version = "0.11.2" }
-namidb-bolt = { path = "crates/namidb-bolt", version = "0.11.2" }
+namidb-core = { path = "crates/namidb-core", version = "0.12.0" }
+namidb-storage = { path = "crates/namidb-storage", version = "0.12.0" }
+namidb-markdown = { path = "crates/namidb-markdown", version = "0.12.0" }
+namidb-graph = { path = "crates/namidb-graph", version = "0.12.0" }
+namidb-query = { path = "crates/namidb-query", version = "0.12.0" }
+namidb-bolt = { path = "crates/namidb-bolt", version = "0.12.0" }
 
 [profile.release]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.11.1"
+version = "0.11.2"
 edition = "2021"
 rust-version = "1.85"
 license = "BUSL-1.1"
@@ -109,12 +109,12 @@ tower = "0.5"
 tower-http = { version = "0.6", features = ["trace", "cors"] }
 
 # Local workspace crates
-namidb-core = { path = "crates/namidb-core", version = "0.11.1" }
-namidb-storage = { path = "crates/namidb-storage", version = "0.11.1" }
-namidb-markdown = { path = "crates/namidb-markdown", version = "0.11.1" }
-namidb-graph = { path = "crates/namidb-graph", version = "0.11.1" }
-namidb-query = { path = "crates/namidb-query", version = "0.11.1" }
-namidb-bolt = { path = "crates/namidb-bolt", version = "0.11.1" }
+namidb-core = { path = "crates/namidb-core", version = "0.11.2" }
+namidb-storage = { path = "crates/namidb-storage", version = "0.11.2" }
+namidb-markdown = { path = "crates/namidb-markdown", version = "0.11.2" }
+namidb-graph = { path = "crates/namidb-graph", version = "0.11.2" }
+namidb-query = { path = "crates/namidb-query", version = "0.11.2" }
+namidb-bolt = { path = "crates/namidb-bolt", version = "0.11.2" }
 
 [profile.release]
 opt-level = 3

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.11.0"
+version = "0.11.1"
 edition = "2021"
 rust-version = "1.85"
 license = "BUSL-1.1"
@@ -109,12 +109,12 @@ tower = "0.5"
 tower-http = { version = "0.6", features = ["trace", "cors"] }
 
 # Local workspace crates
-namidb-core = { path = "crates/namidb-core", version = "0.11.0" }
-namidb-storage = { path = "crates/namidb-storage", version = "0.11.0" }
-namidb-markdown = { path = "crates/namidb-markdown", version = "0.11.0" }
-namidb-graph = { path = "crates/namidb-graph", version = "0.11.0" }
-namidb-query = { path = "crates/namidb-query", version = "0.11.0" }
-namidb-bolt = { path = "crates/namidb-bolt", version = "0.11.0" }
+namidb-core = { path = "crates/namidb-core", version = "0.11.1" }
+namidb-storage = { path = "crates/namidb-storage", version = "0.11.1" }
+namidb-markdown = { path = "crates/namidb-markdown", version = "0.11.1" }
+namidb-graph = { path = "crates/namidb-graph", version = "0.11.1" }
+namidb-query = { path = "crates/namidb-query", version = "0.11.1" }
+namidb-bolt = { path = "crates/namidb-bolt", version = "0.11.1" }
 
 [profile.release]
 opt-level = 3

--- a/crates/namidb-bolt/src/lib.rs
+++ b/crates/namidb-bolt/src/lib.rs
@@ -30,7 +30,8 @@ pub use handshake::{Version, SUPPORTED_VERSIONS};
 pub use mapping::{bolt_to_runtime, params_from_bolt_map, runtime_to_bolt, ElementIdMode};
 pub use message::{Request, Response};
 pub use session::{
-    AuthPolicy, Backend, BackendError, RunOutcome, ServerInfo, Session, StatementType,
+    AuthPolicy, Authenticator, Backend, BackendError, RunOutcome, ServerInfo, Session,
+    StatementType,
 };
 pub use state::State;
 pub use value::{struct_tag, Node, Relationship, Value};

--- a/crates/namidb-bolt/src/session.rs
+++ b/crates/namidb-bolt/src/session.rs
@@ -210,6 +210,15 @@ pub trait Backend: Send + Sync {
     async fn current_bookmark(&self) -> Option<String> {
         None
     }
+
+    /// Called when the client issues LOGOFF, returning the connection to the
+    /// unauthenticated state. The default is a no-op. An embedder that binds
+    /// per-connection identity to its [`Backend`] out of band — e.g. a cloud
+    /// edge that resolved an API key to a tenant at LOGON via a custom
+    /// [`Authenticator`] — overrides this to drop that identity, so a
+    /// subsequent RESET (which returns the connection to `Ready`) cannot
+    /// resume executing as the logged-off principal.
+    async fn logoff(&self) {}
 }
 
 /// One Bolt connection. Created once per `accept()` and driven to
@@ -452,6 +461,11 @@ impl<S: AsyncReadExt + AsyncWriteExt + Unpin> Session<S> {
             },
             Request::Route { .. } => self.respond_route().await,
             Request::Logoff => {
+                // Drop any per-connection identity the embedder bound out of
+                // band, then return to the unauthenticated state. Without the
+                // first step, a later RESET (any-state → Ready) would let the
+                // connection keep executing as the logged-off principal.
+                self.backend.logoff().await;
                 self.state = State::Authentication;
                 self.write_response(Response::success_empty()).await
             }
@@ -750,6 +764,102 @@ mod tests {
             auth,
             backend,
         )
+    }
+
+    /// LOGOFF must invoke `Backend::logoff()` so an embedder can drop the
+    /// per-connection identity it bound out of band — otherwise a later RESET
+    /// (any-state → Ready) would let the connection keep executing as the
+    /// logged-off principal. Regression test for that auth-state bypass.
+    #[tokio::test]
+    async fn logoff_invokes_backend_logoff_hook() {
+        use std::sync::atomic::{AtomicBool, Ordering};
+
+        struct LogoffBackend {
+            logged_off: Arc<AtomicBool>,
+        }
+        #[async_trait]
+        impl Backend for LogoffBackend {
+            async fn run(
+                &self,
+                _cypher: &str,
+                _params: Params,
+            ) -> std::result::Result<RunOutcome, BackendError> {
+                Ok(RunOutcome::default())
+            }
+            async fn logoff(&self) {
+                self.logged_off.store(true, Ordering::SeqCst);
+            }
+        }
+
+        let flag = Arc::new(AtomicBool::new(false));
+        let (mut client, server) = duplex(64 * 1024);
+        let session = Session::new(
+            server,
+            ServerInfo {
+                agent: "NamiDB/test".into(),
+                connection_id: "test-conn".into(),
+            },
+            AuthPolicy::Open,
+            Arc::new(LogoffBackend {
+                logged_off: flag.clone(),
+            }),
+        );
+        let task = tokio::spawn(async move { session.run().await });
+
+        send_handshake(&mut client).await;
+        let _ = read_handshake_reply(&mut client).await;
+
+        // HELLO + LOGON (open auth).
+        write_msg(
+            &mut client,
+            &pack_request(&Value::Struct {
+                tag: crate::value::struct_tag::HELLO,
+                fields: vec![Value::Map(BTreeMap::new())],
+            }),
+        )
+        .await;
+        let _ = read_msg(&mut client).await;
+        write_msg(
+            &mut client,
+            &pack_request(&Value::Struct {
+                tag: crate::value::struct_tag::LOGON,
+                fields: vec![Value::Map({
+                    let mut m = BTreeMap::new();
+                    m.insert("scheme".into(), Value::String("none".into()));
+                    m
+                })],
+            }),
+        )
+        .await;
+        let _ = read_msg(&mut client).await;
+        assert!(!flag.load(Ordering::SeqCst), "logoff not called before LOGOFF");
+
+        // LOGOFF must ack AND invoke the hook.
+        write_msg(
+            &mut client,
+            &pack_request(&Value::Struct {
+                tag: crate::value::struct_tag::LOGOFF,
+                fields: vec![],
+            }),
+        )
+        .await;
+        let resp = read_msg(&mut client).await;
+        assert!(matches!(decode_response(&resp), Response::Success(_)), "LOGOFF acked");
+        assert!(
+            flag.load(Ordering::SeqCst),
+            "LOGOFF must invoke Backend::logoff()"
+        );
+
+        write_msg(
+            &mut client,
+            &pack_request(&Value::Struct {
+                tag: crate::value::struct_tag::GOODBYE,
+                fields: vec![],
+            }),
+        )
+        .await;
+        drop(client);
+        let _ = task.await.unwrap();
     }
 
     async fn send_handshake<W: AsyncWriteExt + Unpin>(w: &mut W) {

--- a/crates/namidb-bolt/src/session.rs
+++ b/crates/namidb-bolt/src/session.rs
@@ -50,10 +50,8 @@ pub struct ServerInfo {
 #[async_trait]
 pub trait Authenticator: Send + Sync {
     /// Authenticate a connection from its HELLO/LOGON auth map.
-    async fn authenticate(
-        &self,
-        auth: &BTreeMap<String, Value>,
-    ) -> std::result::Result<(), String>;
+    async fn authenticate(&self, auth: &BTreeMap<String, Value>)
+        -> std::result::Result<(), String>;
 }
 
 /// Auth policy applied to LOGON.
@@ -832,7 +830,10 @@ mod tests {
         )
         .await;
         let _ = read_msg(&mut client).await;
-        assert!(!flag.load(Ordering::SeqCst), "logoff not called before LOGOFF");
+        assert!(
+            !flag.load(Ordering::SeqCst),
+            "logoff not called before LOGOFF"
+        );
 
         // LOGOFF must ack AND invoke the hook.
         write_msg(
@@ -844,7 +845,10 @@ mod tests {
         )
         .await;
         let resp = read_msg(&mut client).await;
-        assert!(matches!(decode_response(&resp), Response::Success(_)), "LOGOFF acked");
+        assert!(
+            matches!(decode_response(&resp), Response::Success(_)),
+            "LOGOFF acked"
+        );
         assert!(
             flag.load(Ordering::SeqCst),
             "LOGOFF must invoke Backend::logoff()"

--- a/crates/namidb-bolt/src/session.rs
+++ b/crates/namidb-bolt/src/session.rs
@@ -32,14 +32,52 @@ pub struct ServerInfo {
     pub connection_id: String,
 }
 
+/// Pluggable LOGON / HELLO authenticator.
+///
+/// Lets an embedder (e.g. the NamiDB cloud gateway) verify Bolt credentials
+/// against an external source instead of the built-in [`AuthPolicy::Open`] /
+/// [`AuthPolicy::Token`] schemes. The session calls [`authenticate`] with the
+/// auth map carried by HELLO (Bolt 4.x) or LOGON (Bolt 5.x) — `scheme`,
+/// `principal`, `credentials`. Returning `Err(message)` fails the connection
+/// with `Neo.ClientError.Security.Unauthorized` (the message reaches the
+/// client); `Ok(())` authenticates it.
+///
+/// Any per-connection context the authenticator establishes (the resolved
+/// principal, the target namespace, …) is shared with the paired [`Backend`]
+/// out of band — the embedder constructs both per connection.
+///
+/// [`authenticate`]: Authenticator::authenticate
+#[async_trait]
+pub trait Authenticator: Send + Sync {
+    /// Authenticate a connection from its HELLO/LOGON auth map.
+    async fn authenticate(
+        &self,
+        auth: &BTreeMap<String, Value>,
+    ) -> std::result::Result<(), String>;
+}
+
 /// Auth policy applied to LOGON.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub enum AuthPolicy {
     /// Accept any LOGON. Mirrors the REST server's "no auth" mode.
     Open,
     /// Accept `basic` or `bearer` schemes whose credentials match
     /// this token (constant-time compare). Anything else fails.
     Token(Arc<str>),
+    /// Delegate authentication to a custom [`Authenticator`] — e.g. the
+    /// cloud gateway verifying an API key against the control plane.
+    Custom(Arc<dyn Authenticator>),
+}
+
+impl std::fmt::Debug for AuthPolicy {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            AuthPolicy::Open => f.write_str("AuthPolicy::Open"),
+            // Never print the token material.
+            AuthPolicy::Token(_) => f.write_str("AuthPolicy::Token(***)"),
+            AuthPolicy::Custom(_) => f.write_str("AuthPolicy::Custom(..)"),
+        }
+    }
 }
 
 /// What [`Backend::run`] returns. Streamed result production lives
@@ -369,7 +407,7 @@ impl<S: AsyncReadExt + AsyncWriteExt + Unpin> Session<S> {
             self.write_response(Response::Success(meta)).await?;
         } else {
             // v4 HELLO carries scheme/principal/credentials.
-            if let Err(e) = self.authenticate(&extra) {
+            if let Err(e) = self.authenticate(&extra).await {
                 self.state = State::Failed;
                 return self
                     .write_failure("Neo.ClientError.Security.Unauthorized", e)
@@ -385,7 +423,7 @@ impl<S: AsyncReadExt + AsyncWriteExt + Unpin> Session<S> {
         let Request::Logon(extra) = req else {
             return self.invalid_state("LOGON required").await;
         };
-        if let Err(e) = self.authenticate(&extra) {
+        if let Err(e) = self.authenticate(&extra).await {
             self.state = State::Failed;
             return self
                 .write_failure("Neo.ClientError.Security.Unauthorized", e)
@@ -602,7 +640,15 @@ impl<S: AsyncReadExt + AsyncWriteExt + Unpin> Session<S> {
         self.write_response(Response::Success(meta)).await
     }
 
-    fn authenticate(&self, extra: &BTreeMap<String, Value>) -> std::result::Result<(), String> {
+    async fn authenticate(
+        &self,
+        extra: &BTreeMap<String, Value>,
+    ) -> std::result::Result<(), String> {
+        // A custom authenticator owns the whole decision and receives the
+        // full auth map (scheme / principal / credentials).
+        if let AuthPolicy::Custom(authenticator) = &self.auth {
+            return authenticator.authenticate(extra).await;
+        }
         let scheme = extra
             .get("scheme")
             .and_then(|v| match v {
@@ -973,5 +1019,94 @@ mod tests {
             label: "X".into(),
             properties: BTreeMap::new(),
         };
+    }
+
+    /// Test authenticator: accept only when `credentials` matches.
+    struct ApiKeyAuth(&'static str);
+
+    #[async_trait]
+    impl Authenticator for ApiKeyAuth {
+        async fn authenticate(
+            &self,
+            auth: &BTreeMap<String, Value>,
+        ) -> std::result::Result<(), String> {
+            match auth.get("credentials") {
+                Some(Value::String(s)) if s == self.0 => Ok(()),
+                _ => Err("invalid api key".into()),
+            }
+        }
+    }
+
+    /// Drive handshake → HELLO (v5) → LOGON with `creds` under `policy`,
+    /// returning the LOGON reply.
+    async fn drive_logon(creds: &str, policy: AuthPolicy) -> Response {
+        let (mut client, server) = duplex(16 * 1024);
+        let session = fixture_session(server, RunOutcome::default(), policy);
+        let task = tokio::spawn(async move { session.run().await });
+
+        send_handshake(&mut client).await;
+        let _ = read_handshake_reply(&mut client).await;
+
+        // v5 HELLO carries no auth; it just moves to Authentication.
+        write_msg(
+            &mut client,
+            &pack_request(&Value::Struct {
+                tag: crate::value::struct_tag::HELLO,
+                fields: vec![Value::Map(BTreeMap::new())],
+            }),
+        )
+        .await;
+        let _ = read_msg(&mut client).await;
+
+        // LOGON carries the credentials the custom authenticator checks.
+        write_msg(
+            &mut client,
+            &pack_request(&Value::Struct {
+                tag: crate::value::struct_tag::LOGON,
+                fields: vec![Value::Map({
+                    let mut m = BTreeMap::new();
+                    m.insert("scheme".into(), Value::String("basic".into()));
+                    m.insert("credentials".into(), Value::String(creds.into()));
+                    m
+                })],
+            }),
+        )
+        .await;
+        let reply = decode_response(&read_msg(&mut client).await);
+
+        write_msg(
+            &mut client,
+            &pack_request(&Value::Struct {
+                tag: crate::value::struct_tag::GOODBYE,
+                fields: vec![],
+            }),
+        )
+        .await;
+        drop(client);
+        let _ = task.await.unwrap();
+        reply
+    }
+
+    #[tokio::test]
+    async fn custom_authenticator_accepts_valid_credentials() {
+        let policy = AuthPolicy::Custom(Arc::new(ApiKeyAuth("good-key")));
+        assert!(matches!(
+            drive_logon("good-key", policy).await,
+            Response::Success(_)
+        ));
+    }
+
+    #[tokio::test]
+    async fn custom_authenticator_rejects_bad_credentials() {
+        let policy = AuthPolicy::Custom(Arc::new(ApiKeyAuth("good-key")));
+        match drive_logon("wrong", policy).await {
+            Response::Failure(meta) => assert_eq!(
+                meta.get("code"),
+                Some(&Value::String(
+                    "Neo.ClientError.Security.Unauthorized".into()
+                )),
+            ),
+            other => panic!("expected FAILURE, got {other:?}"),
+        }
     }
 }

--- a/crates/namidb-py/pyproject.toml
+++ b/crates/namidb-py/pyproject.toml
@@ -7,7 +7,7 @@ name = "namidb"
 # Keep in sync with the workspace `version` in /Cargo.toml.
 # `python-wheels.yml` publishes a wheel whose filename uses THIS
 # version; the release tag `py-vX.Y.Z` must match X.Y.Z exactly.
-version = "0.11.0"
+version = "0.11.1"
 description = "Cloud-native graph database on object storage — Python bindings"
 readme = "README.md"
 license = { text = "BUSL-1.1" }

--- a/crates/namidb-py/pyproject.toml
+++ b/crates/namidb-py/pyproject.toml
@@ -7,7 +7,7 @@ name = "namidb"
 # Keep in sync with the workspace `version` in /Cargo.toml.
 # `python-wheels.yml` publishes a wheel whose filename uses THIS
 # version; the release tag `py-vX.Y.Z` must match X.Y.Z exactly.
-version = "0.11.2"
+version = "0.12.0"
 description = "Cloud-native graph database on object storage — Python bindings"
 readme = "README.md"
 license = { text = "BUSL-1.1" }

--- a/crates/namidb-py/pyproject.toml
+++ b/crates/namidb-py/pyproject.toml
@@ -7,7 +7,7 @@ name = "namidb"
 # Keep in sync with the workspace `version` in /Cargo.toml.
 # `python-wheels.yml` publishes a wheel whose filename uses THIS
 # version; the release tag `py-vX.Y.Z` must match X.Y.Z exactly.
-version = "0.11.1"
+version = "0.11.2"
 description = "Cloud-native graph database on object storage — Python bindings"
 readme = "README.md"
 license = { text = "BUSL-1.1" }

--- a/crates/namidb-query/src/plan/lower.rs
+++ b/crates/namidb-query/src/plan/lower.rs
@@ -690,7 +690,6 @@ fn validate_shortest_path_pattern_v0(
     Ok(())
 }
 
-
 fn build_path_constructor(elem: &PatternElement, span: SourceSpan) -> Expression {
     let mut args: Vec<Expression> = Vec::with_capacity(1 + 2 * elem.chain.len());
     let head_name = elem.head.binding.as_ref().expect("validated").name.clone();

--- a/crates/namidb-query/src/plan/lower.rs
+++ b/crates/namidb-query/src/plan/lower.rs
@@ -569,9 +569,17 @@ fn lower_pattern_part(
         // fresh internal bindings so the path can be assembled; without
         // this the lower rejects them. See `fill_anonymous_path_bindings`.
         let element = ctx.fill_anonymous_path_bindings(&part.element);
-        validate_path_pattern_v0(&element)?;
         let plan = lower_pattern_element(&element, input, optional, shortest, ctx)?;
         ctx.introduce(&path_bind.name, path_bind.span)?;
+        // A variable-length path binding (`p = (a)-[*1..3]->(b)`) can't be
+        // assembled statically — the hop count varies per match. Thread the
+        // name to the Expand so the walker materialises the trail directly,
+        // exactly like shortestPath above: the executor builds the trail
+        // whenever `path_binding` is set (see `materialise_trail` in the
+        // walker), not only in shortestPath mode.
+        if element.chain.iter().any(|(rel, _)| rel.length.is_some()) {
+            return Ok(attach_path_binding(plan, &path_bind.name));
+        }
         let path_expr = build_path_constructor(&element, path_bind.span);
         return Ok(LogicalPlan::Project {
             input: Box::new(plan),
@@ -682,21 +690,6 @@ fn validate_shortest_path_pattern_v0(
     Ok(())
 }
 
-fn validate_path_pattern_v0(elem: &PatternElement) -> Result<(), LowerError> {
-    // Anonymous elements are filled with internal bindings before this
-    // runs (see `fill_anonymous_path_bindings`), so the only path-binding
-    // shape still unsupported in v0 is variable-length.
-    for (rel, _target) in &elem.chain {
-        if rel.length.is_some() {
-            return Err(LowerError::new(
-                LowerErrorKind::UnsupportedFeature,
-                "variable-length path bindings (e.g. `p = (a)-[*1..3]->(b)`) are not yet supported",
-                rel.span,
-            ));
-        }
-    }
-    Ok(())
-}
 
 fn build_path_constructor(elem: &PatternElement, span: SourceSpan) -> Expression {
     let mut args: Vec<Expression> = Vec::with_capacity(1 + 2 * elem.chain.len());

--- a/crates/namidb-query/tests/exec_match_expand.rs
+++ b/crates/namidb-query/tests/exec_match_expand.rs
@@ -548,6 +548,58 @@ async fn path_binding_two_hop_chain() {
 }
 
 #[tokio::test]
+async fn var_length_path_binding_materialises_variable_trails() {
+    // gdotv-style "show paths up to N hops": a path binding over a
+    // variable-length relationship. The lower routes this through the walker's
+    // trail materialisation (the same path the executor uses for shortestPath),
+    // so each match returns a real Path whose length tracks the hop count —
+    // rather than the old "variable-length path bindings are not yet supported"
+    // rejection.
+    let mut writer = WriterSession::open(store(), paths("exec-varlen-path"))
+        .await
+        .unwrap();
+    build_friend_graph(&mut writer).await;
+    let snapshot = writer.snapshot();
+
+    let q = parse(
+        "MATCH p = (a:Person)-[:KNOWS*1..2]->(b:Person) \
+         WHERE a.name = 'Alice' \
+         RETURN p",
+    )
+    .unwrap();
+    let plan = lower(&q).unwrap();
+    let rows = execute(&plan, &snapshot, &Params::new()).await.unwrap();
+    assert!(!rows.is_empty(), "expected variable-length paths from Alice");
+    let mut lengths = std::collections::BTreeSet::new();
+    for row in &rows {
+        match row.get("p") {
+            // The trail alternates Node, Rel, Node, ... so a valid path has an
+            // odd item count >= 3 (one hop).
+            Some(RuntimeValue::Path(items)) => {
+                assert!(
+                    items.len() >= 3 && items.len() % 2 == 1,
+                    "unexpected trail shape: {} items",
+                    items.len()
+                );
+                lengths.insert(items.len());
+            }
+            other => panic!("expected Path, got {:?}", other),
+        }
+    }
+    // `*1..2` from Alice yields both 1-hop (3-item) and 2-hop (5-item) trails.
+    assert!(
+        lengths.contains(&3),
+        "expected a 1-hop path (3 items), got {:?}",
+        lengths
+    );
+    assert!(
+        lengths.contains(&5),
+        "expected a 2-hop path (5 items), got {:?}",
+        lengths
+    );
+}
+
+#[tokio::test]
 async fn path_binding_supports_anonymous_elements() {
     // Clients like gdotv bind paths with anonymous elements:
     // `p = ()-[]->()` for the default graph view, or an anonymous

--- a/crates/namidb-query/tests/exec_match_expand.rs
+++ b/crates/namidb-query/tests/exec_match_expand.rs
@@ -593,7 +593,10 @@ async fn var_length_path_binding_materialises_variable_trails() {
     .unwrap();
     let plan = lower(&q).unwrap();
     let rows = execute(&plan, &snapshot, &Params::new()).await.unwrap();
-    assert!(!rows.is_empty(), "expected variable-length paths from Alice");
+    assert!(
+        !rows.is_empty(),
+        "expected variable-length paths from Alice"
+    );
     let mut lengths = std::collections::BTreeSet::new();
     for row in &rows {
         match row.get("p") {

--- a/crates/namidb-storage/src/ingest.rs
+++ b/crates/namidb-storage/src/ingest.rs
@@ -664,6 +664,13 @@ impl WriterSession {
         // Bolt, embedded) pick up the just-committed records without
         // taking the writer lock. See RFC-021.
         self.refresh_published();
+        // Invalidate the cross-snapshot property index. A commit adds new
+        // nodes to the live memtable, but a previously warmed value→NodeId
+        // map was frozen against an older snapshot and would otherwise hide
+        // the just-committed records from `lookup_node_by_property`
+        // (read-after-write bug). Subsequent snapshots rebuild on their
+        // first miss. Mirrors the reset in `flush`/`attach_ssts`.
+        self.property_index_cache.reset();
 
         // Auto-snapshot tick. Best effort: a snapshot is a cache, the
         // WAL is the source of truth. Log the failure and keep going
@@ -1123,6 +1130,61 @@ mod tests {
         let out = session.commit_batch().await.unwrap();
         assert_eq!(out, CommitOutcome::Empty);
         assert_eq!(session.manifest_version(), 0);
+    }
+
+    // Regression: a node committed via `commit_batch` (no flush) must be
+    // visible to `lookup_node_by_property` even after the cross-snapshot
+    // property index has been warmed for that (label, property) pair.
+    // Before the fix `commit_batch` did not reset the cache, so a warmed
+    // value→NodeId map (frozen on an older snapshot) hid the just-committed
+    // record and the lookup returned `None` (read-after-write bug).
+    #[tokio::test]
+    async fn commit_batch_resets_property_index_for_read_after_write() {
+        let store = make_store();
+        let paths = make_paths("ingest-ryow-prop-index");
+        let mut session = WriterSession::open(store, paths).await.unwrap();
+
+        // Commit Alice.
+        let alice = sorted_node_id(1);
+        session
+            .upsert_node("Person", alice, &node_record("Alice", Some(30)))
+            .unwrap();
+        let _ = session.commit_batch().await.unwrap();
+
+        // Warm the property-index cache with a miss on a not-yet-existing
+        // value, freezing the (Person, name) -> {Alice} map.
+        {
+            let snap = session.snapshot();
+            let miss = snap
+                .lookup_node_by_property("Person", "name", "Bob")
+                .await
+                .unwrap();
+            assert!(miss.is_none(), "Bob does not exist yet");
+        }
+
+        // Commit Bob via the normal write path (no flush).
+        let bob = sorted_node_id(2);
+        session
+            .upsert_node("Person", bob, &node_record("Bob", Some(40)))
+            .unwrap();
+        let _ = session.commit_batch().await.unwrap();
+
+        // Bob must now be visible BOTH to scan and to property lookup.
+        let snap = session.snapshot();
+        let scanned = snap.scan_label("Person").await.unwrap();
+        assert!(
+            scanned.iter().any(|v| v.id == bob),
+            "Bob must be visible to scan_label after commit"
+        );
+        let found = snap
+            .lookup_node_by_property("Person", "name", "Bob")
+            .await
+            .unwrap();
+        assert!(
+            found.is_some(),
+            "Bob committed via commit_batch must be visible to \
+             lookup_node_by_property (property index cache reset on commit)"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What

Reconciles two lines that forked at `v0.11.0` and advanced in parallel, and cuts a unified `0.12.0`.

- The published `0.11.x` tags were cut from a `release/0.11.1` branch that forked at `v0.11.0`. They carry the Bolt work (pluggable authenticator, `LOGOFF` hook, variable-length path bindings) but **not** the data-model work on `main`.
- `main` advanced independently with multi-label nodes (#56–#68), the secondary equality index (#51, #55) and per-label statistics (#69 / RFC-025), but never released and lacked the Bolt work.

Neither side was a superset. This branch merges `release/0.11.1` into `main` (clean, no conflicts) so both feature sets live in one tree, and bumps the workspace and Python bindings to `0.12.0`.

## Also fixed

`commit_batch` did not reset the cross-snapshot property index (only `flush` / `attach_ssts` did), so a node committed without a flush could be invisible to `lookup_node_by_property` once that `(label, property)` pair had been warmed: the frozen value→NodeId map short-circuited and returned `None`. Reset the cache after publishing the new memtable snapshot, the same way `flush` does. Added a regression test.

## Changelog

`0.11.0`–`0.11.2` shipped without changelog entries. The `0.12.0` entry folds them in and documents the unified feature set.

## Verification

- `cargo fmt --all -- --check`: clean
- `cargo clippy --workspace --lib --tests --exclude namidb-py -- -D warnings -A clippy::doc_lazy_continuation`: clean
- `cargo test --workspace --exclude namidb-py`: 1094 passed, 0 failed
- `cargo check --workspace --exclude namidb-py`: clean

## Follow-up

Releases should be cut from `main` only from now on; the separate `release/0.11.1` branch is what caused the divergence. After this merges, tag `v0.12.0` + `py-v0.12.0` from `main`.
