### PR TITLE
fix(bolt): reject RESET before authentication (pre-auth bypass)

### DIFF
--- a/crates/namidb-bolt/src/session.rs
+++ b/crates/namidb-bolt/src/session.rs
@@ -196,6 +196,13 @@ pub struct Session<S: AsyncReadExt + AsyncWriteExt + Unpin> {
     /// transaction back (releasing the writer) and fails it. `None` (the
     /// default) keeps the legacy unbounded behaviour for test backends.
     tx_idle_timeout: Option<std::time::Duration>,
+    /// Whether this session has completed authentication (the v5 HELLO +
+    /// LOGON handshake, or the v4 HELLO that carries auth). RESET only
+    /// recovers a session to READY once this is set: before auth a RESET
+    /// must not grant READY, or a client could skip HELLO/LOGON entirely
+    /// (handshake -> RESET -> RUN). LOGOFF clears it, forcing a fresh LOGON
+    /// before any further work.
+    authenticated: bool,
 }
 
 impl<S: AsyncReadExt + AsyncWriteExt + Unpin> Session<S> {
@@ -210,6 +217,7 @@ impl<S: AsyncReadExt + AsyncWriteExt + Unpin> Session<S> {
             pending_statement_type: None,
             pending_counters: BTreeMap::new(),
             tx_idle_timeout: None,
+            authenticated: false,
         }
     }
 
@@ -309,10 +317,14 @@ impl<S: AsyncReadExt + AsyncWriteExt + Unpin> Session<S> {
     }
 
     async fn handle(&mut self, req: Request, element_mode: ElementIdMode) -> Result<()> {
-        // RESET always recovers; GOODBYE always ends. Either one while a
-        // transaction is open must roll it back so its staged writes are
-        // discarded (and the writer it holds is released).
-        if matches!(req, Request::Reset) {
+        // RESET recovers a session to READY, but only once it has
+        // authenticated. Before auth (CONNECTED/AUTHENTICATION) a RESET must
+        // not grant READY, or a client could skip HELLO/LOGON entirely
+        // (handshake -> RESET -> RUN). When unauthenticated it falls through
+        // to the per-state handlers below, which reject it. GOODBYE always
+        // ends. Either one while a transaction is open rolls it back so its
+        // staged writes are discarded (and the writer it holds is released).
+        if matches!(req, Request::Reset) && self.authenticated {
             if matches!(self.state, State::TxReady | State::TxStreaming) {
                 let _ = self.backend.rollback_tx().await;
             }
@@ -375,6 +387,7 @@ impl<S: AsyncReadExt + AsyncWriteExt + Unpin> Session<S> {
                     .write_failure("Neo.ClientError.Security.Unauthorized", e)
                     .await;
             }
+            self.authenticated = true;
             self.state = State::Ready;
             self.write_response(Response::Success(meta)).await?;
         }
@@ -391,6 +404,7 @@ impl<S: AsyncReadExt + AsyncWriteExt + Unpin> Session<S> {
                 .write_failure("Neo.ClientError.Security.Unauthorized", e)
                 .await;
         }
+        self.authenticated = true;
         self.state = State::Ready;
         self.write_response(Response::success_empty()).await
     }
@@ -414,6 +428,7 @@ impl<S: AsyncReadExt + AsyncWriteExt + Unpin> Session<S> {
             },
             Request::Route { .. } => self.respond_route().await,
             Request::Logoff => {
+                self.authenticated = false;
                 self.state = State::Authentication;
                 self.write_response(Response::success_empty()).await
             }
@@ -940,6 +955,127 @@ mod tests {
             }),
         )
         .await;
+        drop(client);
+        let _ = task.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn reset_before_auth_does_not_bypass_authentication() {
+        // A client that completes the handshake but never sends HELLO/LOGON
+        // must not reach READY (and run queries) by sending RESET. Before the
+        // fix, RESET was handled ahead of the per-state dispatch and jumped
+        // unconditionally to READY (handshake -> RESET -> RUN bypass).
+        let (mut client, server) = duplex(16 * 1024);
+        let session = fixture_session(
+            server,
+            RunOutcome::default(),
+            AuthPolicy::Token(Arc::from("correct-token")),
+        );
+        let task = tokio::spawn(async move { session.run().await });
+
+        send_handshake(&mut client).await;
+        let _ = read_handshake_reply(&mut client).await;
+
+        // RESET straight after the handshake, with no HELLO/LOGON.
+        write_msg(
+            &mut client,
+            &pack_request(&Value::Struct {
+                tag: crate::value::struct_tag::RESET,
+                fields: vec![],
+            }),
+        )
+        .await;
+        // Must be rejected, not answered with SUCCESS (a SUCCESS would mean
+        // the session reached READY unauthenticated).
+        match decode_response(&read_msg(&mut client).await) {
+            Response::Failure(meta) => assert_eq!(
+                meta.get("code"),
+                Some(&Value::String("Neo.ClientError.Request.Invalid".into())),
+                "pre-auth RESET must fail as an invalid request"
+            ),
+            other => panic!("expected FAILURE for pre-auth RESET, got {:?}", other),
+        }
+
+        // And a RUN must still be refused (IGNORED after the failure),
+        // proving no query executes on an unauthenticated connection.
+        write_msg(
+            &mut client,
+            &pack_request(&Value::Struct {
+                tag: crate::value::struct_tag::RUN,
+                fields: vec![
+                    Value::String("RETURN 1".into()),
+                    Value::Map(BTreeMap::new()),
+                    Value::Map(BTreeMap::new()),
+                ],
+            }),
+        )
+        .await;
+        assert!(matches!(
+            decode_response(&read_msg(&mut client).await),
+            Response::Ignored
+        ));
+
+        drop(client);
+        let _ = task.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn reset_after_auth_recovers_to_ready() {
+        // RESET on an authenticated session still recovers to READY: the fix
+        // gates pre-auth RESET only, it must not break the normal recovery.
+        let (mut client, server) = duplex(16 * 1024);
+        let session = fixture_session(
+            server,
+            RunOutcome::default(),
+            AuthPolicy::Token(Arc::from("correct-token")),
+        );
+        let task = tokio::spawn(async move { session.run().await });
+
+        send_handshake(&mut client).await;
+        let _ = read_handshake_reply(&mut client).await;
+
+        write_msg(
+            &mut client,
+            &pack_request(&Value::Struct {
+                tag: crate::value::struct_tag::HELLO,
+                fields: vec![Value::Map(BTreeMap::new())],
+            }),
+        )
+        .await;
+        let _ = read_msg(&mut client).await;
+
+        write_msg(
+            &mut client,
+            &pack_request(&Value::Struct {
+                tag: crate::value::struct_tag::LOGON,
+                fields: vec![Value::Map({
+                    let mut m = BTreeMap::new();
+                    m.insert("scheme".into(), Value::String("basic".into()));
+                    m.insert("credentials".into(), Value::String("correct-token".into()));
+                    m
+                })],
+            }),
+        )
+        .await;
+        assert!(matches!(
+            decode_response(&read_msg(&mut client).await),
+            Response::Success(_)
+        ));
+
+        // RESET on the authenticated session returns SUCCESS.
+        write_msg(
+            &mut client,
+            &pack_request(&Value::Struct {
+                tag: crate::value::struct_tag::RESET,
+                fields: vec![],
+            }),
+        )
+        .await;
+        assert!(matches!(
+            decode_response(&read_msg(&mut client).await),
+            Response::Success(_)
+        ));
+
         drop(client);
         let _ = task.await.unwrap();
     }


### PR DESCRIPTION
## The bug

`Session::handle` matched `RESET` **before** the per-state dispatch and set `state = State::Ready` unconditionally:

```rust
if matches!(req, Request::Reset) {
    ...
    self.state = State::Ready;
    return self.write_response(Response::success_empty()).await;
}
```

A client in `CONNECTED` or `AUTHENTICATION` (i.e. before sending HELLO/LOGON) could therefore reach `READY` with a single RESET and then run queries:

```
handshake -> RESET -> RUN <arbitrary Cypher>
```

This bypassed `AuthPolicy::Token`. Combined with the lack of TLS on the Bolt listener, an exposed port with a token configured was still openly readable and writable by an unauthenticated client.

## The fix

Track an `authenticated` flag on the session:

- set when a v4 HELLO (which carries auth) or a v5 LOGON authenticates successfully,
- cleared on LOGOFF (which returns the session to `AUTHENTICATION`).

RESET only short-circuits to `READY` when `authenticated` is set. An unauthenticated RESET falls through to the `CONNECTED` / `AUTHENTICATION` handlers, which reject it with `Neo.ClientError.Request.Invalid`. Legitimate post-auth RESET (the recovery path drivers rely on) is unchanged.

## Tests

- `reset_before_auth_does_not_bypass_authentication`: handshake then RESET is rejected with a FAILURE, and a following RUN is IGNORED (no query executes).
- `reset_after_auth_recovers_to_ready`: HELLO + LOGON with a valid token, then RESET returns SUCCESS.

## Verification

- `cargo test -p namidb-bolt`: pass (incl. the two new tests)
- `cargo test -p namidb-server`: pass, including `bolt_integration` (commit/rollback/multi-statement/introspection/idle-timeout/bad-token)
- `cargo clippy -p namidb-bolt -p namidb-server --lib --tests -- -D warnings -A clippy::doc_lazy_continuation`: clean
- `cargo fmt --all -- --check`: clean

Independent of #72; both touch `session.rs` but in different regions and merge cleanly.
