### PR TITLE
fix(storage): fsync local backend writes for crash durability

### DIFF
--- a/crates/namidb-storage/src/local.rs
+++ b/crates/namidb-storage/src/local.rs
@@ -39,7 +39,7 @@ use object_store::path::Path;
 use object_store::{
     CopyOptions, GetOptions, GetResult, ListResult, MultipartUpload, ObjectMeta, ObjectStore,
     ObjectStoreExt, PutMode, PutMultipartOptions, PutOptions, PutPayload, PutResult,
-    Result as OsResult, UpdateVersion,
+    Result as OsResult, UpdateVersion, UploadPart,
 };
 
 /// Filesystem-backed `ObjectStore` with the conditional-write semantics
@@ -100,6 +100,14 @@ impl LocalFileObjectStore {
     /// Root directory on disk. Useful for tests and operational tooling.
     pub fn root(&self) -> &std::path::Path {
         &self.root
+    }
+
+    /// Map an object-store key to its on-disk path under `root`. Relies on
+    /// the 1:1 key->path layout `LocalFileSystem` uses for the safe ASCII
+    /// keys NamiDB writes (digits, `-`, `_`, `.`, `/`); it does not attempt
+    /// the percent-encoding `LocalFileSystem` applies to exotic keys.
+    fn fs_path(&self, location: &Path) -> PathBuf {
+        self.root.join(location.as_ref())
     }
 
     /// Acquire the namespace-wide CAS lock for the duration of the
@@ -204,6 +212,70 @@ fn is_internal_path(p: &Path) -> bool {
     p.as_ref().starts_with(INTERNAL_DIR)
 }
 
+/// The [`object_store::Error::Generic`] this store uses for IO and task
+/// join failures.
+fn generic_err(e: impl std::error::Error + Send + Sync + 'static) -> object_store::Error {
+    object_store::Error::Generic {
+        store: "LocalFileObjectStore",
+        source: Box::new(e),
+    }
+}
+
+/// fsync `fs_path` and its parent directory so a published write survives
+/// an OS crash or power loss. `LocalFileSystem` publishes via tmp+rename
+/// but never fsyncs. A file that is gone (a delete or a racing overwrite
+/// moved it) is treated as already durable.
+async fn fsync_published(fs_path: PathBuf) -> OsResult<()> {
+    tokio::task::spawn_blocking(move || -> std::io::Result<()> {
+        match std::fs::File::open(&fs_path) {
+            Ok(f) => f.sync_all()?,
+            Err(ref e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(()),
+            Err(e) => return Err(e),
+        }
+        // fsync the parent directory so the rename (the new directory
+        // entry) is durable. POSIX-only: std offers no portable directory
+        // fsync on Windows, where the file `sync_all` above is the knob.
+        #[cfg(unix)]
+        if let Some(parent) = fs_path.parent() {
+            match std::fs::File::open(parent) {
+                Ok(dir) => dir.sync_all()?,
+                Err(ref e) if e.kind() == std::io::ErrorKind::NotFound => {}
+                Err(e) => return Err(e),
+            }
+        }
+        Ok(())
+    })
+    .await
+    .map_err(generic_err)?
+    .map_err(generic_err)
+}
+
+/// Wraps a [`MultipartUpload`] so `complete()` fsyncs the published file
+/// (and its parent directory) before returning, giving local multipart
+/// writes the same crash-durability as the single-PUT path in `put_opts`.
+#[derive(Debug)]
+struct FsyncMultipartUpload {
+    inner: Box<dyn MultipartUpload>,
+    fs_path: PathBuf,
+}
+
+#[async_trait]
+impl MultipartUpload for FsyncMultipartUpload {
+    fn put_part(&mut self, data: PutPayload) -> UploadPart {
+        self.inner.put_part(data)
+    }
+
+    async fn complete(&mut self) -> OsResult<PutResult> {
+        let result = self.inner.complete().await?;
+        fsync_published(self.fs_path.clone()).await?;
+        Ok(result)
+    }
+
+    async fn abort(&mut self) -> OsResult<()> {
+        self.inner.abort().await
+    }
+}
+
 #[async_trait]
 impl ObjectStore for LocalFileObjectStore {
     async fn put_opts(
@@ -212,12 +284,20 @@ impl ObjectStore for LocalFileObjectStore {
         payload: PutPayload,
         opts: PutOptions,
     ) -> OsResult<PutResult> {
-        match opts.mode.clone() {
-            PutMode::Update(uv) => self.put_with_cas(location, payload, uv, opts).await,
+        let result = match opts.mode.clone() {
+            PutMode::Update(uv) => self.put_with_cas(location, payload, uv, opts).await?,
             // Create + Overwrite both supported by LocalFileSystem; CAS
             // is not involved so we forward.
-            _ => self.inner.put_opts(location, payload, opts).await,
-        }
+            _ => self.inner.put_opts(location, payload, opts).await?,
+        };
+        // LocalFileSystem publishes via tmp+rename but never fsyncs, so a
+        // PUT this method just reported as durable could still be lost on an
+        // OS crash or power loss. Flush the file and its parent directory
+        // before returning: the local-backend equivalent of S3
+        // durability-on-ack. This covers the whole commit path — WAL
+        // segment, manifest body, and the pointer CAS all go through here.
+        fsync_published(self.fs_path(location)).await?;
+        Ok(result)
     }
 
     async fn put_multipart_opts(
@@ -225,7 +305,13 @@ impl ObjectStore for LocalFileObjectStore {
         location: &Path,
         opts: PutMultipartOptions,
     ) -> OsResult<Box<dyn MultipartUpload>> {
-        self.inner.put_multipart_opts(location, opts).await
+        // Large SST bodies upload multipart, bypassing put_opts; wrap the
+        // upload so its `complete()` fsyncs the published file too.
+        let inner = self.inner.put_multipart_opts(location, opts).await?;
+        Ok(Box::new(FsyncMultipartUpload {
+            inner,
+            fs_path: self.fs_path(location),
+        }))
     }
 
     async fn get_opts(&self, location: &Path, options: GetOptions) -> OsResult<GetResult> {
@@ -290,6 +376,25 @@ mod tests {
         let s: Arc<dyn ObjectStore> = Arc::new(LocalFileObjectStore::new(dir).unwrap());
         let paths = NamespacePaths::new("", NamespaceId::new("acme").unwrap());
         (s, paths)
+    }
+
+    #[tokio::test]
+    async fn put_maps_to_on_disk_path_and_round_trips() {
+        // Guards the key->path mapping that `fsync_published` relies on: a
+        // PUT lands at root.join(key), reads back, and the fsync in
+        // `put_opts` does not error on the commit-path key shape.
+        let dir = tempdir().unwrap();
+        let s = LocalFileObjectStore::new(dir.path()).unwrap();
+        let p = Path::from("wal/0000000001.wal");
+        s.put_opts(
+            &p,
+            PutPayload::from(Bytes::from_static(b"durable")),
+            PutOptions::from(PutMode::Create),
+        )
+        .await
+        .unwrap();
+        let on_disk = dir.path().join("wal").join("0000000001.wal");
+        assert_eq!(std::fs::read(&on_disk).unwrap(), b"durable");
     }
 
     #[tokio::test]


### PR DESCRIPTION
## The bug

The local-filesystem backend (`LocalFileObjectStore`) delegates writes to `object_store`'s `LocalFileSystem`, which publishes via a temp file + atomic rename but **never fsyncs** the file or its parent directory. There is no `sync_all` / `sync_data` anywhere in the storage crate.

So a write the commit path treated as durable, the WAL segment, the manifest body, and the pointer CAS, could still sit only in the page cache. An OS crash or power loss after `commit_batch` returned success could lose acknowledged data. Any non-S3 self-host deployment was not crash-safe. (On S3/GCS/Azure a PUT is durable on ack, so this only affected the local backend.)

## The fix

Give the local backend the same durability-on-ack guarantee S3 provides:

- After every `put_opts` (Create / Overwrite / the CAS Update path), fsync the published file and its parent directory. The directory fsync makes the rename, i.e. the new directory entry, durable. This covers the entire commit path, since the WAL segment, manifest body, and pointer CAS all go through `put_opts`.
- Large SST bodies (≥ 4 MiB, including every L1-compacted SST) upload via multipart, which bypasses `put_opts`. Wrap the returned `MultipartUpload` so its `complete()` fsyncs the published file too.

Directory fsync is POSIX-only (`#[cfg(unix)]`); `std` exposes no portable directory fsync on Windows, where the file `sync_all` is the available knob. A file that has since been deleted or moved by a racing overwrite is treated as already durable.

## Tests

- `put_maps_to_on_disk_path_and_round_trips` pins the `key -> root.join(key)` mapping that the fsync relies on, using the commit-path key shape (`wal/0000000001.wal`), and exercises the `put_opts` fsync.
- Existing CAS / manifest-protocol / round-trip tests continue to pass through the new fsync path.

## Verification

- `cargo test -p namidb-storage` (lib + integration: end_to_end, multi_label, csr/node-cache parity, s3): pass
- `cargo clippy -p namidb-storage --lib --tests -- -D warnings -A clippy::doc_lazy_continuation`: clean
- `cargo fmt --all -- --check`: clean

Independent of #72 and #73 (touches only `crates/namidb-storage/src/local.rs`).

## Note

This makes writes durable on the local backend. It does not change `commit_batch`'s ordering guarantees, which were already correct; it closes the gap where "durable" did not actually reach the platter.
