### PR TITLE
fix(query,server): discard the pending batch when a write fails

### DIFF
--- a/crates/namidb-query/src/exec/writer.rs
+++ b/crates/namidb-query/src/exec/writer.rs
@@ -75,7 +75,17 @@ pub async fn execute_write(
     writer: &mut WriterSession,
     params: &Params,
 ) -> Result<WriteOutcome, ExecError> {
-    let outcome = execute_write_staged(plan, writer, params).await?;
+    let outcome = match execute_write_staged(plan, writer, params).await {
+        Ok(outcome) => outcome,
+        Err(e) => {
+            // The statement failed after staging some mutations into the
+            // pending batch (writers are long-lived and shared, so the
+            // batch outlives this call). Drop them, or the next write on
+            // this writer would seal them with its own commit.
+            writer.discard_batch();
+            return Err(e);
+        }
+    };
     writer.commit_batch().await.map_err(ExecError::Storage)?;
     Ok(outcome)
 }
@@ -1390,6 +1400,44 @@ mod tests {
         let stored = &nodes[0].properties;
         assert!(stored.contains_key("name"));
         assert!(stored.contains_key("age"));
+    }
+
+    #[tokio::test]
+    async fn failed_write_does_not_leak_into_the_next_commit() {
+        use crate::{lower, parse, Params};
+
+        let mut writer = WriterSession::open(store(), paths("write-discard-on-error"))
+            .await
+            .unwrap();
+
+        // Stages (a:Person) then fails on the second element's non-map
+        // spread. Before the fix the staged Person stayed in the pending
+        // batch of this long-lived writer.
+        let q = parse("CREATE (a:Person {name: 'Ada'}), (b:Ghost $props) RETURN a").unwrap();
+        let plan = lower(&q).unwrap();
+        let mut bad = Params::new();
+        bad.insert("props".to_string(), RuntimeValue::Integer(7));
+        let err = execute_write(&plan, &mut writer, &bad)
+            .await
+            .expect_err("non-map spread should fail the statement");
+        assert!(format!("{err:?}").contains("MAP"));
+
+        // A later, unrelated write commits on the same writer.
+        let q2 = parse("CREATE (c:Other {k: 1}) RETURN c").unwrap();
+        let plan2 = lower(&q2).unwrap();
+        execute_write(&plan2, &mut writer, &Params::new())
+            .await
+            .unwrap();
+
+        // The Person staged by the failed statement must NOT have been
+        // sealed by the second statement's commit.
+        let snap = writer.snapshot();
+        assert_eq!(
+            snap.scan_label("Person").await.unwrap().len(),
+            0,
+            "a node staged by a failed write must not leak into the next commit"
+        );
+        assert_eq!(snap.scan_label("Other").await.unwrap().len(), 1);
     }
 
     #[tokio::test]

--- a/crates/namidb-server/src/bolt.rs
+++ b/crates/namidb-server/src/bolt.rs
@@ -159,9 +159,17 @@ impl Backend for ServerBackend {
             let tx = slot
                 .as_mut()
                 .ok_or_else(|| BackendError::Other("no open transaction".into()))?;
-            let outcome = execute_write_staged(&plan, &mut tx.writer, &params)
-                .await
-                .map_err(map_exec_err)?;
+            let outcome = match execute_write_staged(&plan, &mut tx.writer, &params).await {
+                Ok(outcome) => outcome,
+                Err(e) => {
+                    // A failed statement aborts the transaction. Drop whatever
+                    // it (or an earlier statement) staged so a stray COMMIT
+                    // cannot seal a partial write; the session moves to FAILED
+                    // and the client must ROLLBACK / RESET.
+                    tx.writer.discard_batch();
+                    return Err(map_exec_err(e));
+                }
+            };
             tx.staged = true;
             Ok(write_run_outcome(outcome))
         } else {
@@ -186,10 +194,10 @@ impl Backend for ServerBackend {
     async fn rollback_tx(&self) -> std::result::Result<(), BackendError> {
         let mut slot = self.tx.lock().await;
         if let Some(mut tx) = slot.take() {
-            if tx.staged {
-                tx.writer.discard_batch();
-            }
-            // Dropping `tx` releases the writer lock.
+            // Always discard: a statement that failed before `staged` was set
+            // can still have left mutations in the pending batch. Discarding
+            // an empty batch is a no-op. Dropping `tx` releases the writer.
+            tx.writer.discard_batch();
         }
         Ok(())
     }


### PR DESCRIPTION
## The bug

A write statement that errored *after* staging one or more mutations left them in the `WriterSession` pending batch. Writers are long-lived and shared, the HTTP `/cypher` handler and the Bolt auto-commit path both reuse `state.writer`, so the next write's `commit_batch` silently sealed the orphaned mutations from the failed statement.

Example: `CREATE (a:Person {name:'Ada'}), (b:Ghost $props)` where `$props` is not a map. `a` is staged via `upsert_node`, then `b` fails on the spread. `a` stays in the pending batch; the next successful write commits it too.

## The fix

- **`execute_write`** (auto-commit, used by HTTP and Bolt `run`): on a staged-execution error, `discard_batch()` before returning. Commit-time errors are unchanged (those keep the batch for the documented retry / poison semantics).
- **`run_in_tx`** (explicit transaction): on a failed in-tx statement, discard. A failed statement aborts the transaction, so nothing it or an earlier statement staged should remain committable; the session moves to FAILED and the client must ROLLBACK / RESET.
- **`rollback_tx`**: always discard now (previously only when `staged` was set). A statement that failed before `staged` was set could still have left mutations; discarding an empty batch is a no-op.

## Test

`failed_write_does_not_leak_into_the_next_commit`: a statement stages `(a:Person)` then fails on a non-map spread; a subsequent unrelated write commits; the Person staged by the failed statement is absent (it was discarded, not sealed by the second commit).

## Verification

- `cargo test -p namidb-query -p namidb-server`: pass (incl. the new test, `exec_writes`, `bolt_integration`, `concurrent_reads`)
- `cargo clippy -p namidb-query -p namidb-server --lib --tests -- -D warnings -A clippy::doc_lazy_continuation`: clean
- `cargo fmt --all -- --check`: clean

Independent of #72/#73/#74.
