### PR TITLE
feat(query,storage): enforce unique constraints on CREATE

### DIFF
--- a/crates/namidb-bolt/src/session.rs
+++ b/crates/namidb-bolt/src/session.rs
@@ -95,6 +95,8 @@ pub enum BackendError {
     Eval(String),
     /// Storage error.
     Storage(String),
+    /// A declared schema constraint (e.g. a unique property) was violated.
+    Constraint(String),
     /// Anything else.
     Other(String),
 }
@@ -107,6 +109,7 @@ impl BackendError {
             BackendError::Unsupported(_) => "Neo.ClientError.Statement.NotSupported",
             BackendError::Eval(_) => "Neo.ClientError.Statement.ArgumentError",
             BackendError::Storage(_) => "Neo.TransientError.General.DatabaseUnavailable",
+            BackendError::Constraint(_) => "Neo.ClientError.Schema.ConstraintValidationFailed",
             BackendError::Other(_) => "Neo.DatabaseError.General.UnknownError",
         }
     }
@@ -118,6 +121,7 @@ impl BackendError {
             | BackendError::Unsupported(s)
             | BackendError::Eval(s)
             | BackendError::Storage(s)
+            | BackendError::Constraint(s)
             | BackendError::Other(s) => s,
         }
     }

--- a/crates/namidb-query/src/exec/walker.rs
+++ b/crates/namidb-query/src/exec/walker.rs
@@ -35,6 +35,9 @@ pub enum ExecError {
     Eval(EvalError),
     Storage(namidb_storage::Error),
     Runtime(String),
+    /// A declared schema constraint (e.g. a unique property) was violated by
+    /// a write. Maps to `Neo.ClientError.Schema.ConstraintValidationFailed`.
+    Constraint(String),
 }
 
 impl fmt::Display for ExecError {
@@ -43,6 +46,7 @@ impl fmt::Display for ExecError {
             ExecError::Eval(e) => write!(f, "{}", e),
             ExecError::Storage(e) => write!(f, "storage: {}", e),
             ExecError::Runtime(m) => write!(f, "runtime: {}", m),
+            ExecError::Constraint(m) => write!(f, "constraint violation: {}", m),
         }
     }
 }

--- a/crates/namidb-query/src/exec/writer.rs
+++ b/crates/namidb-query/src/exec/writer.rs
@@ -93,7 +93,7 @@ fn execute_write_inner<'a>(
                 let rows = execute_write_inner(input, writer, params, outcome).await?;
                 let mut out = Vec::with_capacity(rows.len());
                 for row in rows {
-                    let new_row = apply_create(elements, row, writer, params, outcome)?;
+                    let new_row = apply_create(elements, row, writer, params, outcome).await?;
                     out.push(new_row);
                 }
                 Ok(out)
@@ -433,7 +433,53 @@ fn apply_spread_properties(
     Ok(())
 }
 
-fn apply_create(
+/// Enforce declared unique constraints for a node about to be created.
+/// Each label's unique string-valued properties are checked against the
+/// committed snapshot through the property index (O(1) on the warm path).
+/// Returns [`ExecError::Constraint`] on the first duplicate. Non-string
+/// unique properties are not checked (the property index keys on strings);
+/// nor are duplicates staged within the same uncommitted batch (that needs
+/// read-your-own-writes).
+async fn enforce_unique_on_create(
+    writer: &WriterSession,
+    labels: &[String],
+    core_props: &BTreeMap<String, CoreValue>,
+) -> Result<(), ExecError> {
+    // Collect the (label, property, value) checks first so the borrow of the
+    // schema is released before we take a snapshot.
+    let checks: Vec<(&str, &str, &str)> = {
+        let schema = writer.schema();
+        let mut checks = Vec::new();
+        for label in labels {
+            if let Some(def) = schema.label(label) {
+                for prop in &def.properties {
+                    if prop.unique {
+                        if let Some(CoreValue::Str(v)) = core_props.get(&prop.name) {
+                            checks.push((label.as_str(), prop.name.as_str(), v.as_str()));
+                        }
+                    }
+                }
+            }
+        }
+        checks
+    };
+    for (label, prop, value) in checks {
+        let snap = writer.snapshot();
+        let existing = snap
+            .lookup_node_by_property(label, prop, value)
+            .await
+            .map_err(ExecError::Storage)?;
+        drop(snap);
+        if existing.is_some() {
+            return Err(ExecError::Constraint(format!(
+                "{label}.{prop} = {value:?} already exists (unique constraint)"
+            )));
+        }
+    }
+    Ok(())
+}
+
+async fn apply_create(
     elements: &[CreateElement],
     mut row: Row,
     writer: &mut WriterSession,
@@ -487,6 +533,11 @@ fn apply_create(
                     Some(id) => id,
                     None => NodeId::new(),
                 };
+                // Enforce declared unique constraints against the committed
+                // snapshot before staging the node. Note: duplicates staged
+                // within the same uncommitted statement/transaction are not
+                // caught yet (needs read-your-own-writes).
+                enforce_unique_on_create(writer, labels, &core_props).await?;
                 let record = NodeWriteRecord {
                     properties: core_props,
                     schema_version: 1,
@@ -885,7 +936,7 @@ async fn apply_merge(
         Ok(out)
     } else {
         // Create branch.
-        let created = apply_create(pattern, row, writer, params, outcome)?;
+        let created = apply_create(pattern, row, writer, params, outcome).await?;
         let mut created = created;
         for op in on_create_sets {
             created = apply_set(op, created, writer, params, outcome)?;
@@ -1390,6 +1441,51 @@ mod tests {
         let stored = &nodes[0].properties;
         assert!(stored.contains_key("name"));
         assert!(stored.contains_key("age"));
+    }
+
+    #[tokio::test]
+    async fn create_rejects_duplicate_unique_property() {
+        use crate::{lower, parse, Params};
+        use namidb_core::{DataType, LabelDef, PropertyDef, SchemaBuilder};
+
+        let mut writer = WriterSession::open(store(), paths("write-unique"))
+            .await
+            .unwrap();
+
+        // Create Ada, then flush a schema that declares Person.name unique.
+        // The flush persists Ada and records the schema on the manifest, so
+        // the next CREATE checks against the committed snapshot.
+        let q = parse("CREATE (a:Person {name: 'Ada'}) RETURN a").unwrap();
+        execute_write(&lower(&q).unwrap(), &mut writer, &Params::new())
+            .await
+            .unwrap();
+
+        let schema = SchemaBuilder::new()
+            .label(LabelDef {
+                name: "Person".into(),
+                properties: vec![PropertyDef::new("name", DataType::Utf8, true)
+                    .unwrap()
+                    .with_unique(true)],
+            })
+            .unwrap()
+            .build();
+        writer.flush(schema).await.unwrap();
+
+        // A second Ada must be rejected as a unique-constraint violation.
+        let dup = parse("CREATE (b:Person {name: 'Ada'}) RETURN b").unwrap();
+        let err = execute_write(&lower(&dup).unwrap(), &mut writer, &Params::new())
+            .await
+            .expect_err("duplicate unique value must be rejected");
+        assert!(
+            matches!(err, ExecError::Constraint(_)),
+            "expected a constraint violation, got: {err:?}"
+        );
+
+        // A different name still succeeds (no false positive).
+        let ok = parse("CREATE (c:Person {name: 'Bob'}) RETURN c").unwrap();
+        execute_write(&lower(&ok).unwrap(), &mut writer, &Params::new())
+            .await
+            .unwrap();
     }
 
     #[tokio::test]

--- a/crates/namidb-server/src/bolt.rs
+++ b/crates/namidb-server/src/bolt.rs
@@ -270,14 +270,20 @@ fn map_lower_err(e: LowerError) -> BackendError {
 }
 
 fn map_exec_err(e: ExecError) -> BackendError {
-    // ExecError today is opaque from outside the crate; format and
-    // bucket as either an eval or a storage error based on a
-    // best-effort substring match.
-    let text = format!("{e}");
-    if text.contains("storage") || text.contains("manifest") {
-        BackendError::Storage(text)
-    } else {
-        BackendError::Eval(text)
+    match e {
+        // A constraint violation has its own Neo4j error class so drivers
+        // can distinguish it from an ordinary evaluation error.
+        ExecError::Constraint(m) => BackendError::Constraint(m),
+        // The rest are opaque from outside the crate; format and bucket as
+        // either an eval or a storage error on a best-effort substring match.
+        other => {
+            let text = format!("{other}");
+            if text.contains("storage") || text.contains("manifest") {
+                BackendError::Storage(text)
+            } else {
+                BackendError::Eval(text)
+            }
+        }
     }
 }
 

--- a/crates/namidb-storage/src/ingest.rs
+++ b/crates/namidb-storage/src/ingest.rs
@@ -404,6 +404,13 @@ impl WriterSession {
         snap
     }
 
+    /// Schema of the current manifest version. The write path consults it to
+    /// enforce declared constraints (e.g. unique properties) before staging
+    /// a mutation.
+    pub fn schema(&self) -> &namidb_core::Schema {
+        &self.current.manifest.schema
+    }
+
     /// Queue a single-label node upsert. Convenience wrapper over
     /// [`upsert_node_with_labels`](Self::upsert_node_with_labels); kept so the
     /// many single-label call sites stay unchanged.


### PR DESCRIPTION
## The bug

`PropertyDef.unique` was a **planner hint only**, never enforced. `CREATE` silently inserted a second node with a duplicate unique value (and `MERGE`'s create branch did too), so declaring a property unique gave no integrity guarantee, duplicate keys and lost updates were routine.

## The fix

Enforce unique constraints on the write path. `apply_create` now, before staging a new node, checks each of the node's declared **unique string properties** against the committed snapshot via the property index (O(1) on the warm path, the same index the planner already uses for unique point lookups). A duplicate is rejected with a new `ExecError::Constraint`, surfaced over Bolt as `Neo.ClientError.Schema.ConstraintValidationFailed` (a dedicated `BackendError::Constraint`). `MERGE`'s create branch inherits the check for free.

Supporting change: `WriterSession::schema()` exposes the active manifest schema so the executor can read which properties are unique.

## Scope (deliberately narrow; follow-ups noted)

This is the core, highest-value slice of the "constraints not enforced" P0. Out of scope here:

- **`SET` to a duplicate unique value** (must allow self-update; needs the same check on the SET path).
- **Existence / node-key constraints** (`PropertyDef` has no `required` field yet).
- **Non-string unique properties** (the property index keys on strings).
- **Duplicates staged within one uncommitted statement/transaction** (e.g. `CREATE (a:P{id:1}),(b:P{id:1})`), which needs read-your-own-writes.

Each is a focused follow-up.

## Test

`create_rejects_duplicate_unique_property`: with `Person.name` declared unique, a second node with name `'Ada'` is rejected as a constraint violation, while a distinct name still succeeds.

## Verification

- `cargo test -p namidb-query -p namidb-server -p namidb-bolt -p namidb-storage`: pass (incl. the new test, `bolt_integration`, `exec_writes`, storage suite)
- `cargo clippy ... --lib --tests -- -D warnings -A clippy::doc_lazy_continuation`: clean
- `cargo fmt --all -- --check`: clean

Independent of #72–#76.
