### PR TITLE
docs(rfc): RFC-026 read-your-own-writes and RFC-027 compaction & space reclamation

### DIFF
--- a/docs/rfc/026-read-your-own-writes.md
+++ b/docs/rfc/026-read-your-own-writes.md
@@ -1,0 +1,238 @@
+# RFC 026: Read-your-own-writes within a statement and transaction
+
+**Status:** draft
+**Author(s):** Matías Fonseca <info@namidb.com>
+**Created:** 2026-06-05
+**Updated:** 2026-06-05
+**Implements:** (pending)
+**Supersedes:** none
+
+## Summary
+
+Make reads inside a write context see the writes that ran before them.
+Today every read sub-plan and every in-transaction read runs against the
+last committed snapshot, so a node a query just created is invisible to a
+later clause in the same statement, and a statement in an open transaction
+cannot see what an earlier statement in that transaction staged. Standard
+Cypher idioms (`CREATE` then `MATCH`, `MERGE` after `CREATE`, multi-step
+transactions) silently return wrong or missing rows.
+
+The fix is a pending overlay: a read-only view layered on top of the
+committed snapshot that resolves the writer's staged-but-uncommitted
+mutations first. Reads in a write context use the overlay; reads outside a
+write context keep using the plain committed snapshot.
+
+## Motivation
+
+The write executor documents the gap in its own header
+(`crates/namidb-query/src/exec/writer.rs`): "No read-your-own-writes: each
+read sub-plan sees the pre-call snapshot. Pieces created mid-query are not
+visible until commit." The Bolt backend documents the same for
+transactions (`crates/namidb-server/src/bolt.rs`, `run_in_tx`): "an in-tx
+read does NOT see the tx's own staged writes."
+
+Concrete failures a user hits:
+
+1. **Create then match in one statement.**
+   `CREATE (a:Person {id: 1}) WITH a MATCH (p:Person {id: 1}) RETURN p`
+   returns zero rows. The `MATCH` reads the committed snapshot, which does
+   not yet contain `a`.
+
+2. **Merge after create in one transaction.**
+   ```
+   BEGIN
+   CREATE (a:Person {id: 1})
+   MERGE (b:Person {id: 1})   // should match a, instead creates a duplicate
+   COMMIT
+   ```
+   `MERGE`'s match phase scans the committed snapshot, misses the staged
+   `a`, and creates a second node. This also blocks the intra-batch half of
+   the unique-constraint work in RFC follow-ups: the constraint check in
+   `apply_create` reads the committed snapshot, so two creates of the same
+   unique value in one uncommitted batch both pass.
+
+3. **Multi-statement transaction.** Any transaction whose later statements
+   depend on earlier ones (the normal reason to open a transaction) is
+   wrong.
+
+The cost of doing nothing is that NamiDB is not correct for the most
+common write-then-read Cypher patterns over the Bolt wire, which is a trust
+problem more than a feature gap.
+
+## Design
+
+### What is already in place
+
+`WriterSession` stages mutations in two parallel structures before a commit
+(`crates/namidb-storage/src/ingest.rs`):
+
+- `pending: WalSegment` is the queued WAL records.
+- `pending_payloads: Vec<(MemKey, u64, MemOp)>` is the matching memtable
+  operations in LSN order, where `MemOp` is `Upsert(bytes)` or a tombstone.
+
+`commit_batch` drains `pending_payloads` into the live memtable only after
+the manifest pointer CAS lands, and `snapshot()` reads the
+`published_memtable` plus the SSTs, never the pending batch. That is why a
+read in a write context cannot see staged work: the staged work is by
+design absent from the snapshot until commit.
+
+### The pending overlay
+
+Add a read-only overlay that resolves the staged mutations on top of a
+committed snapshot.
+
+```rust
+/// A read-only view of a writer's staged-but-uncommitted mutations,
+/// resolved on top of a committed snapshot. Built from `pending_payloads`,
+/// so it reflects exactly what `commit_batch` would make durable.
+pub struct PendingOverlay {
+    /// Latest staged op per key (last write wins by LSN). An `Upsert`
+    /// shadows the snapshot value; a tombstone hides it.
+    nodes: HashMap<NodeId, MemOp>,
+    edges: HashMap<EdgeKey, MemOp>,
+    /// Label and edge-type indexes over the staged upserts, so a scan can
+    /// merge staged rows in without walking the whole overlay.
+    by_label: HashMap<LabelId, Vec<NodeId>>,
+    by_edge_type: HashMap<EdgeTypeId, Vec<EdgeKey>>,
+}
+```
+
+`WriterSession` builds it from the current pending batch:
+
+```rust
+impl WriterSession {
+    /// Snapshot the committed state and overlay the staged batch on top.
+    /// The result resolves staged upserts and tombstones first, then falls
+    /// through to the committed snapshot.
+    pub fn overlay_snapshot(&self) -> OverlaySnapshot<'_> { ... }
+}
+```
+
+`OverlaySnapshot` wraps the existing `Snapshot` and consults the overlay
+before delegating:
+
+- `lookup_node(id)`: if the overlay has the id, return its upsert (or
+  `None` for a tombstone); otherwise delegate to the base snapshot.
+- `scan_label(label)`: take the base snapshot rows, drop any the overlay
+  tombstones, replace any the overlay upserts, and append staged upserts
+  that the base does not have. De-duplicate by id.
+- `lookup_node_by_property(label, prop, value)`: check the staged upserts
+  for that label first, then delegate. This is what makes the unique-
+  constraint check catch intra-batch duplicates.
+- Edge and adjacency lookups follow the same overlay-then-base shape.
+
+The base read methods already live on `Snapshot`; the overlay only adds a
+resolve-staged-first step in front of each, so there is one read engine,
+not two.
+
+### Where the overlay is used
+
+1. **Read sub-plans inside a write statement.** `execute_write_inner`
+   currently delegates its read operators to the read-only walker against a
+   plain snapshot. Switch those to the overlay snapshot built from the
+   writer's current pending batch, so a `MATCH`/`WHERE`/`MERGE`-match that
+   follows a `CREATE` in the same statement sees the created rows.
+
+2. **Reads in an open transaction.** In `run_in_tx` the read branch reads
+   `self.state.snapshot` (committed). Switch it to the transaction writer's
+   overlay snapshot so statement N sees statements 1..N-1.
+
+3. **MERGE match phase.** `apply_merge`'s `find_merge_matches` scans the
+   committed snapshot; move it to the overlay so a `MERGE` matches rows the
+   same statement or transaction just created.
+
+Reads with no writer in scope (auto-commit reads, the HTTP read path, the
+Bolt auto-commit read branch) keep using the plain committed snapshot.
+There is nothing staged for them to see.
+
+### Visibility ordering
+
+Cypher's semantics for read-after-write inside one statement are subtle
+(the standard separates read and write phases). For v1 we adopt the
+operationally useful rule that matches user intent and Neo4j behaviour for
+the common cases: a read operator sees every mutation staged by operators
+that ran before it in execution order. Because `execute_write_inner` is a
+depth-first row-at-a-time evaluator, "before in execution order" is
+"already in `pending_payloads`," which the overlay reflects exactly. We do
+not attempt the full standard read/write phase separation in v1; the open
+questions track the cases where the two differ.
+
+### Cost and lifecycle
+
+The overlay is rebuilt from `pending_payloads` when a write statement
+starts its read sub-plan, or once per in-tx read. Building it is O(pending
+size), which is bounded by the batch the caller staged. For a single
+`CREATE ... MATCH` the pending set is tiny. For a large transaction the
+overlay grows with the transaction, which is the same memory the pending
+batch already holds, so the overlay adds index structures over data already
+resident, not a second copy of it.
+
+The overlay is dropped when the read completes. It never outlives the
+writer borrow, so there is no published-snapshot lifecycle to manage (it is
+not an `OwnedSnapshot` from RFC-021; it is a borrowed, in-writer view).
+
+## Alternatives considered
+
+### A. Commit each statement inside a transaction
+
+Auto-commit every statement so the next one reads it from the committed
+snapshot. Rejected: it destroys transaction atomicity (a later `ROLLBACK`
+could not undo earlier statements) and multiplies manifest CAS traffic.
+
+### B. Apply the pending batch into the live memtable, roll back on discard
+
+Stage directly into the live memtable and reads see it for free. Rejected:
+it mixes committed and uncommitted state in the one structure the snapshot
+reads, so a concurrent reader on the published snapshot could observe
+uncommitted rows, and a discard would have to surgically unwind memtable
+edits. The pending batch exists precisely to keep uncommitted work out of
+the readable state.
+
+### C. Persistent memtable (im::OrdMap) with a staged layer
+
+Use a persistent map so the overlay is a cheap structural share. Rejected
+for the same reasons as RFC-021 alternative C: new dependency and a slower
+insert hot path. Revisit only if overlay build cost shows up in a profile.
+
+## Drawbacks
+
+1. **Two read entry points to keep in step.** The overlay resolve-first
+   logic has to mirror every base read method. Mitigation: the overlay
+   delegates to the one base implementation and only prepends the staged
+   resolution, so drift is bounded to the small overlay layer.
+
+2. **Edge and adjacency overlay is more involved than nodes.** Staged edges
+   have to merge into adjacency scans, including DETACH DELETE's incident-
+   edge enumeration. v1 can land nodes first and edges in a fast follow if
+   the edge overlay proves large; the open questions track this.
+
+3. **Visibility is the operational rule, not the full standard.** Queries
+   that depend on the standard's read/write phase separation (rare, mostly
+   pathological `SET` plus `MATCH` on the same pattern) may differ from a
+   strict openCypher reading. Documented, with the TCK cases called out as
+   they surface.
+
+## Open questions
+
+- **Q1: Node-only v1, edges in a follow-up?** Nodes unblock CREATE-then-
+  MATCH, MERGE, and the intra-batch unique check. Edge overlay unblocks
+  traversals over just-created edges. Leaning land nodes plus the
+  property-lookup overlay first, edges immediately after.
+
+- **Q2: Property index cache interaction.** The cross-snapshot property
+  index cache (see the read path) must not serve a stale negative for a
+  value the overlay has staged. The overlay's `lookup_node_by_property`
+  has to check staged upserts before consulting the cached index. Confirm
+  there is no path that bypasses the overlay.
+
+- **Q3: Statement boundary rebuild vs incremental.** Rebuild the overlay
+  per read, or maintain it incrementally as the write executor stages
+  mutations? Leaning rebuild-per-read for v1 (simpler, correct), measure
+  before optimising.
+
+## References
+
+- RFC-001 (storage engine, pending batch and manifest CAS)
+- RFC-009 (write clauses)
+- RFC-021 (concurrent reads, snapshot model)
+- openCypher semantics, read/write phase separation

--- a/docs/rfc/027-compaction-and-space-reclamation.md
+++ b/docs/rfc/027-compaction-and-space-reclamation.md
@@ -1,0 +1,235 @@
+# RFC 027: Multi-level compaction, tombstone GC, and safe space reclamation
+
+**Status:** draft
+**Author(s):** Matías Fonseca <info@namidb.com>
+**Created:** 2026-06-05
+**Updated:** 2026-06-05
+**Implements:** (pending)
+**Supersedes:** none
+
+## Summary
+
+Bound space and read amplification on a namespace that takes sustained
+updates and deletes. Today compaction only merges L0 into L1, never
+re-compacts L1, never reclaims tombstones or superseded versions, and the
+orphan sweeper runs in dry-run mode by default. An update-heavy or
+delete-heavy workload grows object-store bytes without an upper bound, and
+no operator lever brings them back down.
+
+This RFC proposes three pieces that work together: leveled compaction past
+L1, a snapshot-retention horizon that lets compaction drop tombstones and
+old versions safely, and a reference-counted sweep that deletes unreferenced
+objects (including compaction orphans) instead of leaking them.
+
+## Motivation
+
+The compactor is explicit about its limits
+(`crates/namidb-storage/src/compact.rs` module docs): "Stateless L0 to L1
+compaction," with non-goals "Multi-level compaction (L1 to L2, etc.). Only
+L0 to L1 in v1," and a note that a deleted-row tombstone "preserved in the
+L1 SST has no snapshot-retention policy so a tombstone might still be
+load-bearing for a reader pinned at an old version."
+
+The consequences:
+
+1. **Tombstones live forever.** A delete writes a tombstone that is carried
+   through every compaction and never dropped, because dropping it could
+   change what a reader pinned at an old snapshot sees. Delete a million
+   rows and the million tombstones stay on disk indefinitely.
+
+2. **Old versions live forever.** An update writes a new version; the old
+   value is shadowed at read time but never physically removed, for the
+   same reason. A hot row updated a million times keeps a million versions.
+
+3. **No L1 reclamation.** With only L0 to L1, the L1 footprint per bucket
+   grows with the merged history and is never reorganised, so read
+   amplification and bytes both trend up.
+
+4. **Orphans leak.** A failed commit (WAL or body PUT succeeded, pointer
+   CAS lost) or a superseded compaction input leaves objects the live
+   manifest no longer references. The janitor that should sweep them runs
+   dry-run by default, so on a real deployment they accumulate.
+
+The net effect is that NamiDB's on-disk (on-object-store) size is a
+high-water mark of everything ever written, not a function of the live data
+set. For an object store billed per byte and per request, that is a direct
+cost and operability problem.
+
+## Design
+
+### Piece 1: leveled compaction past L1
+
+Generalise the existing `(kind, scope)` bucketing to a small number of
+levels with a size ratio, in the spirit of RocksDB leveled compaction:
+
+- L0: one SST per flush, overlapping key ranges, scanned together on read.
+- L1..Lk: each level holds non-overlapping SSTs per bucket, each level
+  roughly a fixed factor larger than the one above.
+
+Compaction picks a level whose size exceeds its budget and merges it down
+into the next level, rewriting only the overlapping key ranges rather than
+the whole bucket. This bounds read amplification to roughly the number of
+levels and lets the bytes for a bucket settle near the live data size for
+that bucket instead of its full history.
+
+The existing L0 to L1 merge becomes the first level transition; the merge
+machinery (`compact_node_ssts`, `compact_edge_ssts`) is reused, with the
+input set chosen by the level picker rather than always "all L0 in the
+bucket."
+
+### Piece 2: snapshot-retention horizon
+
+A tombstone or a superseded version can be physically dropped only once no
+live reader could still need it. Define the retention horizon as the oldest
+manifest version any live reader is pinned to.
+
+RFC-021 already publishes `OwnedSnapshot`s carrying a `manifest` version and
+proposes a `namidb_active_snapshot_versions` metric. Extend that into an
+authoritative low-water mark:
+
+```rust
+/// Oldest manifest version any live reader is pinned to. Compaction may
+/// drop tombstones and shadowed versions strictly older than this, because
+/// no reader can observe them.
+fn retention_horizon(&self) -> u64 { ... }
+```
+
+In a single process this is the minimum `manifest.version` over the live
+`OwnedSnapshot` Arcs (plus the writer's current version). During a merge,
+when several versions of a key are present, keep the newest version at or
+below the horizon and every version above it, and drop the rest. A tombstone
+whose newest covering version is below the horizon, with no live value above
+it, is dropped entirely.
+
+This is the standard MVCC GC rule: collect versions no active reader can
+reach. It is safe by construction: a reader pinned at version V keeps the
+horizon at or below V, so nothing V needs is collected.
+
+### Piece 3: reference-counted, horizon-aware sweep
+
+Replace the wall-clock min-age dry-run sweep with a reference-counted one.
+An object is safe to delete when no manifest version at or above the
+retention horizon references it.
+
+```text
+live set = union of objects referenced by every manifest version
+           from retention_horizon() to current, inclusive
+sweep    = (objects present in the store) minus (live set)
+```
+
+The sweeper lists the namespace, subtracts the live set, and deletes the
+remainder. This covers both compaction inputs that have been merged away and
+orphans from failed commits, with no time heuristic. Enable it by default,
+gated behind the horizon so it can never delete an object a retained
+manifest version still points at.
+
+A dry-run mode stays available for operators who want to inspect first, but
+it is no longer the default, and every run logs what it deleted (or would
+delete) so a bounded sweep is never mistaken for "nothing to do."
+
+### Piece 4: reactive compaction trigger and soft write stall
+
+Compaction today runs on a periodic tick. Add an L0-count high-water mark
+that triggers a compaction as soon as L0 for a bucket crosses it, so read
+amplification does not spike between ticks under sustained writes. Pair it
+with a soft write stall: when L0 grows faster than compaction drains it,
+slow the writer (a short delay on `commit_batch`) rather than letting L0 and
+read amplification grow without bound. Both thresholds are config, with
+defaults chosen from the bench workloads.
+
+### Interaction and ordering
+
+The three pieces are independent but compose:
+
+- Leveled compaction reorganises bytes and is correct on its own, but
+  without the horizon it still carries tombstones and old versions forever.
+- The horizon makes a merge able to drop them.
+- The sweep reclaims the objects the merges leave behind, plus orphans.
+
+A reasonable landing order is: horizon plumbing first (it is also needed by
+the sweep), then the horizon-aware sweep enabled by default (immediate win
+on orphan leaks), then tombstone and version GC during the existing L0 to L1
+merge, then the general leveled scheme, then the reactive trigger and stall.
+
+## Alternatives considered
+
+### A. TTL-based tombstone GC
+
+Drop tombstones older than a fixed wall-clock TTL (the Cassandra
+`gc_grace_seconds` model). Simpler than a horizon, no reader tracking.
+Rejected as the primary mechanism: it is unsafe for a reader pinned past the
+TTL (it would resurrect deleted rows for that reader), and once read
+replicas exist the TTL cannot know about a replica's pinned version. The
+horizon is correct by construction; a TTL can be layered on later as an
+upper bound on retained history, not as the safety mechanism.
+
+### B. Size-tiered compaction
+
+Merge SSTs of similar size into a larger one (the Cassandra STCS model)
+instead of leveled. Lower write amplification, higher space amplification
+(up to roughly 2x during a major compaction) and worse read amplification.
+Rejected for the default because the goal here is to bound space; leveled
+trades some write amplification for predictable space and read bounds, which
+matches an object-store cost model. STCS stays a candidate for an
+append-mostly bulk-load profile.
+
+### C. Keep the wall-clock min-age sweep, just enable it
+
+Flip the existing sweep to enabled and trust the min-age window. Rejected:
+min-age is a guess. Too short and it can delete an object a slow reader or
+an in-flight commit still needs; too long and it leaks. The reference-
+counted horizon sweep has neither failure mode.
+
+## Drawbacks
+
+1. **Write amplification.** Leveled compaction rewrites data multiple times
+   as it moves down levels. This is the standard leveled tradeoff; the
+   reactive trigger and stall keep it from running away, and the object-
+   store cost model rewards the smaller, predictable footprint.
+
+2. **GC correctness is load-bearing.** Deleting a live SST corrupts reads.
+   The horizon and the reference-counted live set are the safety net, and
+   both need careful testing (a deliberate fault-injection suite that pins a
+   reader at an old version and asserts compaction and sweep never collect
+   what it can reach).
+
+3. **Cross-process horizon is harder.** In one process the horizon is a
+   local minimum. Once read replicas exist (a future RFC), the horizon must
+   account for versions pinned on other processes, which needs a shared
+   low-water mark (a lease or heartbeat). v1 computes the horizon locally
+   and documents that read replicas depend on extending it.
+
+4. **More moving background work.** Another scheduler dimension to tune and
+   observe. Mitigated by surfacing compaction and sweep activity as metrics
+   (bytes reclaimed, levels, L0 count, horizon) so it is observable rather
+   than opaque.
+
+## Open questions
+
+- **Q1: Per-bucket leveling or global?** The current bucketing is
+  `(kind, scope)`. Does each bucket get its own level hierarchy, or is
+  leveling global with bucket as a partition key? Leaning per-bucket, since
+  reads already scope by bucket.
+
+- **Q2: How aggressive should version GC be?** Drop every shadowed version
+  below the horizon, or keep a small history for future point-in-time reads
+  or time-travel? Leaning drop-all-below-horizon for v1; a retained-history
+  knob is a separate feature.
+
+- **Q3: Sweep cadence and listing cost.** A full namespace list per sweep is
+  an object-store cost. Run it on the compaction tick, or less often? Can the
+  manifest carry enough to avoid a full list? Leaning piggyback on
+  compaction and measure the list cost on a real backend.
+
+- **Q4: Horizon for very long readers.** A reader pinned for minutes holds
+  the horizon down and stalls reclamation. This is the same stale-snapshot
+  tension RFC-021 raises; a max-snapshot-age (query timeout) bounds it. Track
+  alongside the query-timeout follow-up.
+
+## References
+
+- RFC-001 (storage engine, manifest, single writer)
+- RFC-002 (SST format, tombstone column)
+- RFC-021 (concurrent reads, snapshot versions, the basis for the horizon)
+- RocksDB leveled compaction and compaction styles
+- MVCC garbage collection (collect versions below the oldest live read)


### PR DESCRIPTION
## What

Two design docs for the remaining large P0s from the production-readiness audit, the ones too big for a single PR that the audit recommended designing before coding.

### RFC-026: Read-your-own-writes within a statement and transaction

A read inside a write context sees the last committed snapshot, not the writer's staged mutations, so `CREATE` then `MATCH` in one statement, `MERGE` after `CREATE` in one transaction, and any multi-statement transaction return wrong or missing rows. The RFC proposes a **pending overlay**: a read-only view that resolves the staged batch on top of the committed snapshot, used by read sub-plans in a write statement, by in-transaction reads, and by MERGE's match phase. Reads with no writer in scope keep using the plain committed snapshot. Also unblocks the intra-batch half of unique-constraint enforcement.

### RFC-027: Multi-level compaction, tombstone GC, and safe space reclamation

Today compaction is L0 to L1 only, never re-compacts L1, never drops tombstones or shadowed versions, and the orphan sweep is dry-run by default, so an update/delete-heavy namespace grows object-store bytes without bound. The RFC proposes three composing pieces: **leveled compaction** past L1 (bounds read amplification), a **snapshot-retention horizon** (the oldest manifest version any live reader is pinned to, which makes dropping tombstones and old versions safe by construction), and a **reference-counted sweep** (delete objects no retained manifest version references, reclaiming both compaction inputs and failed-commit orphans), plus a reactive L0 trigger and soft write stall. It builds on RFC-021's snapshot-version tracking.

## Why a docs PR

These are proposals, not implementations. Merging them records the design and the tradeoffs (alternatives and drawbacks sections are honest about write amplification, GC correctness as load-bearing, and the cross-process horizon problem that read replicas will reopen). Implementation lands in follow-up PRs against the accepted design.

## Notes

- Both follow the existing `docs/rfc/_template.md` structure and house style.
- Status is `draft`; flip to `accepted` when you sign off.
- Numbering continues after RFC-025 (per-label statistics).
