### PR TITLE
Read-your-own-writes, query timeout + row cap, and RFC-027 space reclamation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,12 @@ below and in the release notes.
   at operator boundaries and inside the scan and expand loops; a query
   that runs past it aborts with a timeout error instead of pinning a
   worker. Writes are bounded by the transaction lifecycle, not by this.
+- Read query row cap (`NAMIDB_QUERY_ROW_CAP` / `--query-row-cap`, default
+  `0` = unlimited). Bounds the rows any single read-query operator may
+  materialise; a query whose operator output would exceed the cap aborts
+  with a row-cap error. The multiplicative cross product is rejected
+  before it builds, and a runaway expansion fails fast mid-loop, so a
+  pathological query cannot blow up memory first.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,14 @@ below and in the release notes.
   with a row-cap error. The multiplicative cross product is rejected
   before it builds, and a runaway expansion fails fast mid-loop, so a
   pathological query cannot blow up memory first.
+- Reactive compaction trigger and soft write stall (RFC-027 P5).
+  `NAMIDB_COMPACTION_L0_TRIGGER` (default `8`) compacts a bucket as soon
+  as a flush leaves it with that many L0 SSTs, instead of waiting for the
+  periodic compaction tick, so read amplification stays bounded under
+  sustained writes. `NAMIDB_WRITE_STALL_L0` (default `0` = off) with
+  `NAMIDB_WRITE_STALL_DELAY` (default `50ms`) applies backpressure to a
+  committed write when L0 climbs past the threshold, so the writer cannot
+  outrun compaction without bound.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,15 @@ below and in the release notes.
 
 ### Changed
 
+- Compaction reclaims tombstones and superseded versions (RFC-027 P3).
+  Each compaction is now full-bucket: it merges a bucket's existing L1
+  with its new L0s into a single L1, so the result is the bucket's only
+  SST at the new version and a key whose newest version is a tombstone (or
+  a fully-deleted node/edge) is dropped entirely instead of carried
+  forever. A reader pinned at an older version still observes the delete
+  through the retained source bodies. This bounds on-disk size for
+  delete- and update-heavy workloads; the cost is a full-bucket rewrite
+  (write amplification), which leveled compaction will later bound.
 - Orphan sweep is now reference-counted and snapshot-horizon aware
   (RFC-027), and enabled by default. It keeps every object referenced by
   any manifest version from the retention horizon (the oldest version a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,15 @@ below and in the release notes.
 
 ### Changed
 
+- Orphan sweep is now reference-counted and snapshot-horizon aware
+  (RFC-027), and enabled by default. It keeps every object referenced by
+  any manifest version from the retention horizon (the oldest version a
+  live reader is pinned to) up to current, then deletes the rest, so it
+  reclaims compaction inputs and failed-commit orphans without a
+  wall-clock guess and can never delete a body a live reader still needs.
+  `min_age` stays as a small secondary guard for the body-PUT-then-CAS
+  race; `NAMIDB_SWEEP_DELETE=false` keeps a dry-run available.
+
 ### Fixed
 
 - Read-your-own-writes within a statement and an open transaction
@@ -40,6 +49,11 @@ below and in the release notes.
   follow-up.
 
 ### Breaking
+
+- The orphan sweep deletes by default (`NAMIDB_SWEEP_DELETE` now defaults
+  to `true`); the retention horizon makes that safe. Set it to `false` to
+  keep the previous dry-run behaviour. The `namidb_storage::sweep_orphans`
+  function gained a `retention_horizon` parameter.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,15 @@ below and in the release notes.
 
 ### Fixed
 
+- Read-your-own-writes within a statement and an open transaction
+  (RFC-026, node overlay). A read sub-plan that runs after a write in the
+  same statement or transaction now sees the staged rows, so `CREATE` then
+  `MATCH`, `MERGE` after `CREATE`, and duplicate detection inside one
+  uncommitted batch all return the right result instead of reading the
+  pre-call committed snapshot. Reads outside a write context are
+  unchanged. Staged edges are not yet visible to traversals; that is a
+  follow-up.
+
 ### Breaking
 
 ---

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ below and in the release notes.
 
 ### Added
 
+- Read query timeout (`NAMIDB_QUERY_TIMEOUT` / `--query-timeout`, default
+  `30s`, `0s` disables). A single HTTP or Bolt read, including a read
+  inside an open transaction, is bounded by a wall-clock deadline checked
+  at operator boundaries and inside the scan and expand loops; a query
+  that runs past it aborts with a timeout error instead of pinning a
+  worker. Writes are bounded by the transaction lifecycle, not by this.
+
 ### Changed
 
 ### Fixed

--- a/crates/namidb-query/src/exec/limits.rs
+++ b/crates/namidb-query/src/exec/limits.rs
@@ -1,0 +1,47 @@
+//! Read-query execution guards.
+//!
+//! A wall-clock deadline scoped on the current tokio task and checked at
+//! operator boundaries and inside the long scan / expand loops. Mirrors
+//! the [`ProfileCollector`](crate::profile) task-local pattern: the
+//! executor probes the task-local cheaply and the regular query path (no
+//! guard in scope, e.g. tests, the write executor, profiling) keeps its
+//! baseline cost.
+//!
+//! The server scopes a deadline around read queries from its configured
+//! query timeout (env `NAMIDB_QUERY_TIMEOUT`). Writes are not guarded
+//! here; an open Bolt transaction is bounded separately by its idle
+//! timeout.
+
+use std::future::Future;
+use std::time::Instant;
+
+use super::walker::ExecError;
+
+tokio::task_local! {
+    static QUERY_DEADLINE: Instant;
+}
+
+/// Run `fut` with an optional wall-clock deadline scoped on the current
+/// task. `None` runs `fut` unguarded (no overhead, no timeout).
+pub(crate) async fn with_deadline<F: Future>(deadline: Option<Instant>, fut: F) -> F::Output {
+    match deadline {
+        Some(at) => QUERY_DEADLINE.scope(at, fut).await,
+        None => fut.await,
+    }
+}
+
+/// `Err(ExecError::Timeout)` when a deadline is in scope and has passed,
+/// `Ok(())` otherwise. A cheap task-local probe plus an `Instant`
+/// comparison; a no-op when no deadline is scoped.
+#[inline]
+pub(crate) fn check_deadline() -> Result<(), ExecError> {
+    QUERY_DEADLINE
+        .try_with(|at| {
+            if Instant::now() >= *at {
+                Err(ExecError::Timeout)
+            } else {
+                Ok(())
+            }
+        })
+        .unwrap_or(Ok(()))
+}

--- a/crates/namidb-query/src/exec/limits.rs
+++ b/crates/namidb-query/src/exec/limits.rs
@@ -1,33 +1,51 @@
-//! Read-query execution guards.
+//! Read-query execution guards: a wall-clock timeout and a row cap.
 //!
-//! A wall-clock deadline scoped on the current tokio task and checked at
-//! operator boundaries and inside the long scan / expand loops. Mirrors
-//! the [`ProfileCollector`](crate::profile) task-local pattern: the
-//! executor probes the task-local cheaply and the regular query path (no
-//! guard in scope, e.g. tests, the write executor, profiling) keeps its
-//! baseline cost.
+//! Both are carried by a single task-local scoped on the current tokio
+//! task and probed cheaply by the executor. Mirrors the
+//! [`ProfileCollector`](crate::profile) pattern: the regular query path
+//! (no guard in scope, e.g. tests, the write executor, profiling) keeps
+//! its baseline cost.
 //!
-//! The server scopes a deadline around read queries from its configured
-//! query timeout (env `NAMIDB_QUERY_TIMEOUT`). Writes are not guarded
-//! here; an open Bolt transaction is bounded separately by its idle
-//! timeout.
+//! - The deadline is checked at operator boundaries and inside the long
+//!   scan / expand loops.
+//! - The row cap bounds the rows any single operator materialises: the
+//!   executor aborts a query whose operator output would exceed it, plus a
+//!   fast pre-check on the multiplicative `CrossProduct` and a fast-fail
+//!   inside the `Expand` accumulation loop so a runaway never fully
+//!   materialises.
+//!
+//! The server scopes both from its configuration (env `NAMIDB_QUERY_TIMEOUT`
+//! and `NAMIDB_QUERY_ROW_CAP`). Writes are not guarded here; an open Bolt
+//! transaction is bounded separately by its idle timeout.
 
 use std::future::Future;
 use std::time::Instant;
 
 use super::walker::ExecError;
 
-tokio::task_local! {
-    static QUERY_DEADLINE: Instant;
+/// The active limits for one read query.
+struct Limits {
+    /// Wall-clock deadline; `None` leaves the query untimed.
+    deadline: Option<Instant>,
+    /// Maximum rows a single operator may materialise; `None` is unbounded.
+    row_cap: Option<usize>,
 }
 
-/// Run `fut` with an optional wall-clock deadline scoped on the current
-/// task. `None` runs `fut` unguarded (no overhead, no timeout).
-pub(crate) async fn with_deadline<F: Future>(deadline: Option<Instant>, fut: F) -> F::Output {
-    match deadline {
-        Some(at) => QUERY_DEADLINE.scope(at, fut).await,
-        None => fut.await,
+tokio::task_local! {
+    static LIMITS: Limits;
+}
+
+/// Run `fut` with an optional deadline and row cap scoped on the current
+/// task. When both are `None` the future runs unguarded (no overhead).
+pub(crate) async fn with_limits<F: Future>(
+    deadline: Option<Instant>,
+    row_cap: Option<usize>,
+    fut: F,
+) -> F::Output {
+    if deadline.is_none() && row_cap.is_none() {
+        return fut.await;
     }
+    LIMITS.scope(Limits { deadline, row_cap }, fut).await
 }
 
 /// `Err(ExecError::Timeout)` when a deadline is in scope and has passed,
@@ -35,13 +53,23 @@ pub(crate) async fn with_deadline<F: Future>(deadline: Option<Instant>, fut: F) 
 /// comparison; a no-op when no deadline is scoped.
 #[inline]
 pub(crate) fn check_deadline() -> Result<(), ExecError> {
-    QUERY_DEADLINE
-        .try_with(|at| {
-            if Instant::now() >= *at {
-                Err(ExecError::Timeout)
-            } else {
-                Ok(())
-            }
+    LIMITS
+        .try_with(|l| match l.deadline {
+            Some(at) if Instant::now() >= at => Err(ExecError::Timeout),
+            _ => Ok(()),
+        })
+        .unwrap_or(Ok(()))
+}
+
+/// `Err(ExecError::RowCap)` when a row cap is in scope and `len` exceeds
+/// it, `Ok(())` otherwise. `len` is the row count an operator produced (or
+/// is about to produce). A no-op when no cap is scoped.
+#[inline]
+pub(crate) fn check_row_cap(len: usize) -> Result<(), ExecError> {
+    LIMITS
+        .try_with(|l| match l.row_cap {
+            Some(cap) if len > cap => Err(ExecError::RowCap(cap)),
+            _ => Ok(()),
         })
         .unwrap_or(Ok(()))
 }

--- a/crates/namidb-query/src/exec/mod.rs
+++ b/crates/namidb-query/src/exec/mod.rs
@@ -9,6 +9,7 @@
 pub mod expr;
 pub mod factor;
 pub mod leapfrog;
+pub mod limits;
 pub mod row;
 pub mod value;
 pub mod walker;
@@ -21,5 +22,5 @@ pub use factor::{
 pub use leapfrog::{LeapfrogIntersect, MergeSortedUnion, OrdIterator, SortedSliceIter};
 pub use row::Row;
 pub use value::{NodeValue, RelValue, RuntimeValue};
-pub use walker::{execute, execute_factor_path, execute_flat_path, ExecError};
+pub use walker::{execute, execute_factor_path, execute_flat_path, execute_with_limits, ExecError};
 pub use writer::{execute_write, execute_write_staged, WriteOutcome};

--- a/crates/namidb-query/src/exec/walker.rs
+++ b/crates/namidb-query/src/exec/walker.rs
@@ -38,6 +38,10 @@ pub enum ExecError {
     /// A declared schema constraint (e.g. a unique property) was violated by
     /// a write. Maps to `Neo.ClientError.Schema.ConstraintValidationFailed`.
     Constraint(String),
+    /// A read query ran past its wall-clock deadline (the server's
+    /// configured query timeout). Surfaced from the scan / expand loops and
+    /// at operator boundaries; never raised when no deadline is in scope.
+    Timeout,
 }
 
 impl fmt::Display for ExecError {
@@ -47,6 +51,7 @@ impl fmt::Display for ExecError {
             ExecError::Storage(e) => write!(f, "storage: {}", e),
             ExecError::Runtime(m) => write!(f, "runtime: {}", m),
             ExecError::Constraint(m) => write!(f, "constraint violation: {}", m),
+            ExecError::Timeout => write!(f, "query exceeded the configured timeout"),
         }
     }
 }
@@ -110,6 +115,21 @@ pub async fn execute(
     }
 }
 
+/// Like [`execute`], but bounded by an optional wall-clock `deadline`.
+///
+/// The server derives the deadline from its read query timeout. When set,
+/// the executor returns [`ExecError::Timeout`] if a long scan / expand or
+/// the operator dispatch crosses it. `None` is unbounded and behaves
+/// exactly like [`execute`].
+pub async fn execute_with_limits(
+    plan: &LogicalPlan,
+    snapshot: &Snapshot<'_>,
+    params: &Params,
+    deadline: Option<std::time::Instant>,
+) -> Result<Vec<Row>, ExecError> {
+    crate::exec::limits::with_deadline(deadline, execute(plan, snapshot, params)).await
+}
+
 /// Always-flat entry point — bypasses the `NAMIDB_FACTORIZE` env check.
 /// Used by parity tests to compare the two paths side-by-side without
 /// global env mutation.
@@ -161,6 +181,10 @@ pub(crate) fn execute_inner_with_routing<'a>(
     routing: &'a PlanRouting,
 ) -> BoxFuture<'a, Result<Vec<Row>, ExecError>> {
     async move {
+        // Deadline guard (read query timeout): one cheap check per operator
+        // invocation, so a deeply recursive plan is bounded between operators
+        // even before the long scan / expand loops below check it themselves.
+        crate::exec::limits::check_deadline()?;
         // PROFILE hook: when the caller wrapped this `execute` in a
         // `ProfileCollector` scope, time every operator and stash the
         // result against its node pointer. The pointer is stable for
@@ -855,6 +879,9 @@ async fn execute_expand(
 
     let mut out = Vec::new();
     for row in rows {
+        // Deadline guard: a multi-seed (or variable-length) expansion is the
+        // most expensive operator, so bound it at every seed boundary.
+        crate::exec::limits::check_deadline()?;
         // LIMIT-pushdown budget (set only via `execute_capped`, never on
         // the normal path). Checked at the seed boundary BEFORE processing
         // the next input row, so every consumed seed contributes its
@@ -1789,6 +1816,9 @@ pub(crate) fn execute_factor_inner_with_routing<'a>(
     routing: &'a PlanRouting,
 ) -> BoxFuture<'a, Result<FactorRowSet, ExecError>> {
     async move {
+        // Deadline guard (read query timeout): one check per factor-path
+        // operator invocation, mirroring the flat path.
+        crate::exec::limits::check_deadline()?;
         match plan {
             // Operators that benefit directly: keep everything factorised.
             LogicalPlan::Empty => Ok(FactorRowSet::singleton_root()),

--- a/crates/namidb-query/src/exec/walker.rs
+++ b/crates/namidb-query/src/exec/walker.rs
@@ -42,6 +42,10 @@ pub enum ExecError {
     /// configured query timeout). Surfaced from the scan / expand loops and
     /// at operator boundaries; never raised when no deadline is in scope.
     Timeout,
+    /// A read query tried to materialise more rows in one operator than the
+    /// server's configured row cap allows. Carries the cap. Never raised
+    /// when no cap is in scope.
+    RowCap(usize),
 }
 
 impl fmt::Display for ExecError {
@@ -52,6 +56,9 @@ impl fmt::Display for ExecError {
             ExecError::Runtime(m) => write!(f, "runtime: {}", m),
             ExecError::Constraint(m) => write!(f, "constraint violation: {}", m),
             ExecError::Timeout => write!(f, "query exceeded the configured timeout"),
+            ExecError::RowCap(cap) => {
+                write!(f, "query exceeded the configured row cap of {cap}")
+            }
         }
     }
 }
@@ -115,19 +122,23 @@ pub async fn execute(
     }
 }
 
-/// Like [`execute`], but bounded by an optional wall-clock `deadline`.
+/// Like [`execute`], but bounded by an optional wall-clock `deadline` and
+/// an optional `row_cap` (the maximum rows any single operator may
+/// materialise).
 ///
-/// The server derives the deadline from its read query timeout. When set,
-/// the executor returns [`ExecError::Timeout`] if a long scan / expand or
-/// the operator dispatch crosses it. `None` is unbounded and behaves
-/// exactly like [`execute`].
+/// The server derives both from its read query timeout and row cap. When
+/// set, the executor returns [`ExecError::Timeout`] if a long scan / expand
+/// or the operator dispatch crosses the deadline, or [`ExecError::RowCap`]
+/// if an operator would exceed the cap. `None`/`None` is unbounded and
+/// behaves exactly like [`execute`].
 pub async fn execute_with_limits(
     plan: &LogicalPlan,
     snapshot: &Snapshot<'_>,
     params: &Params,
     deadline: Option<std::time::Instant>,
+    row_cap: Option<usize>,
 ) -> Result<Vec<Row>, ExecError> {
-    crate::exec::limits::with_deadline(deadline, execute(plan, snapshot, params)).await
+    crate::exec::limits::with_limits(deadline, row_cap, execute(plan, snapshot, params)).await
 }
 
 /// Always-flat entry point — bypasses the `NAMIDB_FACTORIZE` env check.
@@ -152,7 +163,9 @@ pub async fn execute_factor_path(
 ) -> Result<Vec<Row>, ExecError> {
     let routing = PlanRouting::analyze(plan);
     let set = execute_factor_inner_with_routing(plan, snapshot, params, None, &routing).await?;
-    Ok(set.materialize_all(None))
+    let rows = set.materialize_all(None);
+    crate::exec::limits::check_row_cap(rows.len())?;
+    Ok(rows)
 }
 
 /// Public wrapper for callers outside `walker.rs` (e.g. `writer.rs`,
@@ -466,6 +479,10 @@ pub(crate) fn execute_inner_with_routing<'a>(
             LogicalPlan::CrossProduct { left, right } => {
                 let l = execute_inner_with_routing(left, snapshot, params, outer, routing).await?;
                 let r = execute_inner_with_routing(right, snapshot, params, outer, routing).await?;
+                // Pre-check the multiplicative size before building the
+                // product Vec, so a runaway cross product aborts instead of
+                // allocating `l.len() * r.len()` rows first.
+                crate::exec::limits::check_row_cap(l.len().saturating_mul(r.len()))?;
                 Ok(cross_product(l, r))
             }
 
@@ -724,6 +741,14 @@ pub(crate) fn execute_inner_with_routing<'a>(
                 ])
             }
         };
+        // Row-cap guard: bound the rows any single operator hands up. This
+        // covers every operator uniformly (NodeScan, Expand, CrossProduct,
+        // HashJoin, Unwind, ...); the most explosive producers also fail
+        // fast before fully materialising (see CrossProduct's pre-check and
+        // the Expand accumulation loop).
+        if let Ok(rows) = &result {
+            crate::exec::limits::check_row_cap(rows.len())?;
+        }
         if let Some(start) = profile_start {
             if let Ok(rows) = &result {
                 crate::profile::record_op(plan, start.elapsed(), rows.len() as u64);
@@ -879,9 +904,11 @@ async fn execute_expand(
 
     let mut out = Vec::new();
     for row in rows {
-        // Deadline guard: a multi-seed (or variable-length) expansion is the
-        // most expensive operator, so bound it at every seed boundary.
+        // Deadline + row-cap guards: a multi-seed (or variable-length)
+        // expansion is the most expensive operator, so bound it at every
+        // seed boundary and fail fast before `out` grows past the cap.
         crate::exec::limits::check_deadline()?;
+        crate::exec::limits::check_row_cap(out.len())?;
         // LIMIT-pushdown budget (set only via `execute_capped`, never on
         // the normal path). Checked at the seed boundary BEFORE processing
         // the next input row, so every consumed seed contributes its
@@ -2019,7 +2046,7 @@ pub(crate) fn execute_factor_inner_with_routing<'a>(
                     .await?;
                 let r = execute_factor_inner_with_routing(right, snapshot, params, outer, routing)
                     .await?;
-                Ok(cross_product_factor(l, r))
+                cross_product_factor(l, r)
             }
 
             LogicalPlan::HashJoin {
@@ -2222,6 +2249,9 @@ pub(crate) fn execute_factor_inner_with_routing<'a>(
                         }
                     }
                 }
+                // UNWIND amplifies each input row into its list, so guard the
+                // output (the flat path is bounded by the per-operator check).
+                crate::exec::limits::check_row_cap(out.len())?;
                 Ok(FactorRowSet::from_flat(out))
             }
 
@@ -2385,6 +2415,11 @@ async fn execute_expand_factor(
     let mut out_leaves: Vec<crate::exec::FactorIdx> = Vec::new();
 
     for parent_leaf in input_leaves {
+        // Deadline + row-cap guards, mirroring the flat `execute_expand`:
+        // a factor-path expansion is just as able to run long or to build
+        // an unbounded arena, so bound it at every seed boundary.
+        crate::exec::limits::check_deadline()?;
+        crate::exec::limits::check_row_cap(out_leaves.len())?;
         // Read the source binding from the chain. lookup_binding walks
         // root-ward without materialising the whole row.
         let starting = match arena.lookup_binding(parent_leaf, source) {
@@ -2920,13 +2955,19 @@ fn relationship_to_edge_direction(
 // independence). Bridge keeps the arena topologically simple — every
 // chain still has one parent — at the cost of materialising the right
 // row once per output leaf.
-fn cross_product_factor(left: FactorRowSet, right: FactorRowSet) -> FactorRowSet {
+fn cross_product_factor(
+    left: FactorRowSet,
+    right: FactorRowSet,
+) -> Result<FactorRowSet, ExecError> {
     if left.leaves.is_empty() || right.leaves.is_empty() {
-        return FactorRowSet {
+        return Ok(FactorRowSet {
             arena: left.arena,
             leaves: Vec::new(),
-        };
+        });
     }
+    // Pre-check the multiplicative size before building, mirroring the flat
+    // path, so a runaway cross product aborts instead of allocating first.
+    crate::exec::limits::check_row_cap(left.leaves.len().saturating_mul(right.leaves.len()))?;
     let FactorRowSet {
         mut arena,
         leaves: left_leaves,
@@ -2952,10 +2993,10 @@ fn cross_product_factor(left: FactorRowSet, right: FactorRowSet) -> FactorRowSet
             out_leaves.push(arena.push(l, slots));
         }
     }
-    FactorRowSet {
+    Ok(FactorRowSet {
         arena,
         leaves: out_leaves,
-    }
+    })
 }
 
 // Hash join: build side materialises to flat (the hash table requires
@@ -2981,6 +3022,7 @@ async fn hash_join_factor(
     let build_set =
         execute_factor_inner_with_routing(build_plan, snapshot, params, outer, routing).await?;
     let build_rows = build_set.materialize_all(None);
+    crate::exec::limits::check_row_cap(build_rows.len())?;
     let mut table: std::collections::HashMap<Vec<String>, Vec<Row>> =
         std::collections::HashMap::new();
     for row in build_rows {
@@ -3076,6 +3118,7 @@ async fn hash_semi_join_factor(
     let inner_set =
         execute_factor_inner_with_routing(inner_plan, snapshot, params, outer, routing).await?;
     let inner_rows = inner_set.materialize_all(None);
+    crate::exec::limits::check_row_cap(inner_rows.len())?;
     let mut key_set: std::collections::HashSet<Vec<String>> = std::collections::HashSet::new();
     let mut residual_index: std::collections::HashMap<Vec<String>, Vec<Row>> =
         std::collections::HashMap::new();

--- a/crates/namidb-query/src/exec/writer.rs
+++ b/crates/namidb-query/src/exec/writer.rs
@@ -7,10 +7,14 @@
 //!
 //! See [`docs/rfc/009-write-clauses.md`](../../../../docs/rfc/009-write-clauses.md).
 //!
+//! Read-your-own-writes (RFC-026): read sub-plans run against
+//! [`WriterSession::overlay_snapshot`], so a `MATCH`/`MERGE`-match/unique
+//! check that follows a `CREATE` in the same statement or transaction sees
+//! the staged rows. v1 wires node reads; staged edges are not yet visible
+//! to traversals (RFC-026 Q1, a fast follow).
+//!
 //! Limitations of v0:
 //!
-//! - No read-your-own-writes: each read sub-plan sees the pre-call
-//! snapshot. Pieces created mid-query are not visible until commit.
 //! - MERGE matches by single-element pattern (one node or
 //! node-rel-node chain).
 //! - DETACH DELETE enumerates incident edges across every edge_type
@@ -52,8 +56,8 @@ pub struct WriteOutcome {
 /// `writer.discard_batch()` to roll it back. Used by explicit Bolt
 /// transactions, which stage several statements and commit once at COMMIT.
 /// The RETURN rows are computed during the apply, so they are available
-/// before the commit; like [`execute_write`] there is no
-/// read-your-own-writes (a later read sub-plan sees the pre-call snapshot).
+/// before the commit; a later read sub-plan in the same statement sees the
+/// staged batch through the read-your-own-writes overlay (RFC-026).
 pub async fn execute_write_staged(
     plan: &LogicalPlan,
     writer: &mut WriterSession,
@@ -286,13 +290,13 @@ fn execute_write_inner<'a>(
                 // never touch subtrees that contain writes). In a write
                 // path we delegate to the post-write snapshot reader so
                 // the executor lives in exactly one place.
-                let snap = writer.snapshot();
+                let snap = writer.overlay_snapshot();
                 crate::exec::walker::execute_inner(plan, &snap, params, None).await
             }
 
             LogicalPlan::EdgeTypeCount { .. } => {
                 // Read-only leaf: delegate to the post-write snapshot reader.
-                let snap = writer.snapshot();
+                let snap = writer.overlay_snapshot();
                 crate::exec::walker::execute_inner(plan, &snap, params, None).await
             }
 
@@ -307,7 +311,7 @@ fn execute_write_inner<'a>(
                 id,
             } => {
                 let input_rows = execute_write_inner(input, writer, params, outcome).await?;
-                let snap = writer.snapshot();
+                let snap = writer.overlay_snapshot();
                 let mut out = Vec::with_capacity(input_rows.len());
                 for row in input_rows {
                     let id_value = evaluate(id, &row, params)?;
@@ -342,7 +346,7 @@ fn execute_write_inner<'a>(
                 multi,
             } => {
                 let input_rows = execute_write_inner(input, writer, params, outcome).await?;
-                let snap = writer.snapshot();
+                let snap = writer.overlay_snapshot();
                 let mut out = Vec::with_capacity(input_rows.len());
                 for row in input_rows {
                     let lookup_val = evaluate(value, &row, params)?;
@@ -392,7 +396,7 @@ fn execute_write_inner<'a>(
             | LogicalPlan::SemiApply { .. }
             | LogicalPlan::PatternList { .. }
             | LogicalPlan::MultiwayJoin { .. } => {
-                let snap = writer.snapshot();
+                let snap = writer.overlay_snapshot();
                 execute_inner(plan, &snap, params, None).await
             }
         }
@@ -445,11 +449,11 @@ fn apply_spread_properties(
 
 /// Enforce declared unique constraints for a node about to be created.
 /// Each label's unique string-valued properties are checked against the
-/// committed snapshot through the property index (O(1) on the warm path).
-/// Returns [`ExecError::Constraint`] on the first duplicate. Non-string
-/// unique properties are not checked (the property index keys on strings);
-/// nor are duplicates staged within the same uncommitted batch (that needs
-/// read-your-own-writes).
+/// read-your-own-writes overlay (RFC-026), so a duplicate value staged
+/// earlier in the same uncommitted statement/transaction is caught too,
+/// not just one already committed. Returns [`ExecError::Constraint`] on the
+/// first duplicate. Non-string unique properties are not checked (the
+/// property index keys on strings).
 async fn enforce_unique_on_create(
     writer: &WriterSession,
     labels: &[String],
@@ -474,7 +478,7 @@ async fn enforce_unique_on_create(
         checks
     };
     for (label, prop, value) in checks {
-        let snap = writer.snapshot();
+        let snap = writer.overlay_snapshot();
         let existing = snap
             .lookup_node_by_property(label, prop, value)
             .await
@@ -543,10 +547,10 @@ async fn apply_create(
                     Some(id) => id,
                     None => NodeId::new(),
                 };
-                // Enforce declared unique constraints against the committed
-                // snapshot before staging the node. Note: duplicates staged
-                // within the same uncommitted statement/transaction are not
-                // caught yet (needs read-your-own-writes).
+                // Enforce declared unique constraints against the
+                // read-your-own-writes overlay (RFC-026) before staging the
+                // node, so a duplicate staged earlier in the same uncommitted
+                // batch is caught as well as one already committed.
                 enforce_unique_on_create(writer, labels, &core_props).await?;
                 let record = NodeWriteRecord {
                     properties: core_props,
@@ -898,7 +902,7 @@ async fn detach_incident_edges(
     for et in edge_types {
         let mut to_delete: Vec<(NodeId, NodeId)> = Vec::new();
         {
-            let snap = writer.snapshot();
+            let snap = writer.overlay_snapshot();
             let out_edges = snap
                 .out_edges(&et, node)
                 .await
@@ -999,7 +1003,7 @@ async fn find_merge_matches(
             ));
         }
         let (head_alias, (head_labels, head_props)) = nodes.into_iter().next().expect("len == 1");
-        let snap = writer.snapshot();
+        let snap = writer.overlay_snapshot();
         let candidates = snap
             .scan_label(merge_scan_label(head_labels))
             .await
@@ -1033,7 +1037,7 @@ async fn find_merge_matches(
     //   * a back-reference to an alias already bound on the outer row
     //     (e.g. `MATCH (a), (b) MERGE (a)-[:R]->(b)`) — no scan, just
     //     keep the carried-in NodeValue.
-    let snap = writer.snapshot();
+    let snap = writer.overlay_snapshot();
     let first_head_alias = match rels[0] {
         CreateElement::Rel { source_alias, .. } => source_alias.as_str(),
         _ => unreachable!("rels only contains Rel variants"),

--- a/crates/namidb-query/src/exec/writer.rs
+++ b/crates/namidb-query/src/exec/writer.rs
@@ -523,7 +523,12 @@ async fn enforce_unique_on_set(
             .collect()
     };
     for label in &unique_labels {
-        let snap = writer.snapshot();
+        // Read-your-own-writes overlay (RFC-026): a SET that follows a
+        // CREATE in the same statement/transaction must see the staged row,
+        // so a duplicate value staged earlier in the batch is caught too,
+        // not just one already committed. Self-update stays allowed via the
+        // `self_id` check below.
+        let snap = writer.overlay_snapshot();
         let existing = snap
             .lookup_node_by_property(label, key, v)
             .await

--- a/crates/namidb-query/src/lib.rs
+++ b/crates/namidb-query/src/lib.rs
@@ -35,8 +35,9 @@ pub use cost::{
     estimate, BindingMeta, Cardinality, EdgeTypeStats, LabelStats, PropStats, StatsCatalog,
 };
 pub use exec::{
-    evaluate, execute, execute_factor_path, execute_flat_path, execute_write, execute_write_staged,
-    factorize_enabled, EvalError, ExecError, Params, Row, RuntimeValue, WriteOutcome,
+    evaluate, execute, execute_factor_path, execute_flat_path, execute_with_limits, execute_write,
+    execute_write_staged, factorize_enabled, EvalError, ExecError, Params, Row, RuntimeValue,
+    WriteOutcome,
 };
 pub use optimize::{convert_cross_to_hash, normalize_filters, optimize, predicate_pushdown};
 pub use parser::{parse, ParseError, ParseResult, Query};

--- a/crates/namidb-query/tests/exec_limits.rs
+++ b/crates/namidb-query/tests/exec_limits.rs
@@ -1,6 +1,9 @@
-//! Read-query execution guards: the wall-clock timeout (RFC query-timeout
-//! follow-up). A deadline already in the past aborts with
-//! `ExecError::Timeout`; a generous deadline (or none) runs to completion.
+//! Read-query execution guards: the wall-clock timeout and the operator
+//! row cap. A deadline already in the past aborts with `ExecError::Timeout`
+//! (a generous deadline or none runs to completion); an operator that would
+//! materialise more rows than the cap aborts with `ExecError::RowCap`,
+//! including the multiplicative cross product, which is rejected before it
+//! materialises.
 
 use std::collections::BTreeMap;
 use std::sync::Arc;
@@ -52,7 +55,7 @@ async fn past_deadline_aborts_with_timeout() {
     // A deadline already in the past: the per-operator guard fires on the
     // first check.
     let past = Instant::now() - Duration::from_millis(1);
-    let err = execute_with_limits(&plan, &snap, &Params::new(), Some(past))
+    let err = execute_with_limits(&plan, &snap, &Params::new(), Some(past), None)
         .await
         .expect_err("a past deadline must abort the read");
     assert!(matches!(err, ExecError::Timeout), "got {err:?}");
@@ -65,7 +68,7 @@ async fn generous_deadline_completes() {
     let plan = lower(&parse("MATCH (p:Person) RETURN p").unwrap()).unwrap();
 
     let future = Instant::now() + Duration::from_secs(60);
-    let rows = execute_with_limits(&plan, &snap, &Params::new(), Some(future))
+    let rows = execute_with_limits(&plan, &snap, &Params::new(), Some(future), None)
         .await
         .expect("a generous deadline must not abort");
     assert_eq!(rows.len(), 3);
@@ -77,8 +80,48 @@ async fn no_deadline_is_unbounded() {
     let snap = writer.snapshot();
     let plan = lower(&parse("MATCH (p:Person) RETURN p").unwrap()).unwrap();
 
-    let rows = execute_with_limits(&plan, &snap, &Params::new(), None)
+    let rows = execute_with_limits(&plan, &snap, &Params::new(), None, None)
         .await
         .expect("no deadline runs unbounded");
     assert_eq!(rows.len(), 3);
+}
+
+#[tokio::test]
+async fn row_cap_aborts_a_scan_over_the_cap() {
+    // Three Person nodes; a cap of 2 must reject the scan.
+    let writer = seed("limits-rowcap").await;
+    let snap = writer.snapshot();
+    let plan = lower(&parse("MATCH (p:Person) RETURN p").unwrap()).unwrap();
+
+    let err = execute_with_limits(&plan, &snap, &Params::new(), None, Some(2))
+        .await
+        .expect_err("a scan over the row cap must abort");
+    assert!(matches!(err, ExecError::RowCap(2)), "got {err:?}");
+}
+
+#[tokio::test]
+async fn row_cap_at_or_above_result_size_completes() {
+    let writer = seed("limits-rowcap-ok").await;
+    let snap = writer.snapshot();
+    let plan = lower(&parse("MATCH (p:Person) RETURN p").unwrap()).unwrap();
+
+    // Exactly the result size is allowed (cap is "must not exceed").
+    let rows = execute_with_limits(&plan, &snap, &Params::new(), None, Some(3))
+        .await
+        .expect("a cap at the result size must not abort");
+    assert_eq!(rows.len(), 3);
+}
+
+#[tokio::test]
+async fn row_cap_rejects_a_cross_product_before_materialising() {
+    // Two Person scans (3 each) crossed = 9 rows; a cap of 5 must abort,
+    // and via the pre-multiply check, before building the product.
+    let writer = seed("limits-rowcap-cross").await;
+    let snap = writer.snapshot();
+    let plan = lower(&parse("MATCH (a:Person) MATCH (b:Person) RETURN a, b").unwrap()).unwrap();
+
+    let err = execute_with_limits(&plan, &snap, &Params::new(), None, Some(5))
+        .await
+        .expect_err("a cross product over the cap must abort");
+    assert!(matches!(err, ExecError::RowCap(5)), "got {err:?}");
 }

--- a/crates/namidb-query/tests/exec_limits.rs
+++ b/crates/namidb-query/tests/exec_limits.rs
@@ -1,0 +1,84 @@
+//! Read-query execution guards: the wall-clock timeout (RFC query-timeout
+//! follow-up). A deadline already in the past aborts with
+//! `ExecError::Timeout`; a generous deadline (or none) runs to completion.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use namidb_core::id::{NamespaceId, NodeId};
+use namidb_core::value::Value as CoreValue;
+use namidb_storage::{NamespacePaths, NodeWriteRecord, WriterSession};
+use object_store::memory::InMemory;
+use object_store::ObjectStore;
+
+use namidb_query::{execute_with_limits, lower, parse, ExecError, Params};
+
+fn store() -> Arc<dyn ObjectStore> {
+    Arc::new(InMemory::new())
+}
+
+fn paths(name: &str) -> NamespacePaths {
+    NamespacePaths::new("tenants", NamespaceId::new(name).unwrap())
+}
+
+async fn seed(name: &str) -> WriterSession {
+    let mut writer = WriterSession::open(store(), paths(name)).await.unwrap();
+    for n in ["Alice", "Bob", "Carol"] {
+        let mut p = BTreeMap::new();
+        p.insert("name".into(), CoreValue::Str(n.into()));
+        writer
+            .upsert_node(
+                "Person",
+                NodeId::new(),
+                &NodeWriteRecord {
+                    properties: p,
+                    schema_version: 1,
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+    }
+    writer.commit_batch().await.unwrap();
+    writer
+}
+
+#[tokio::test]
+async fn past_deadline_aborts_with_timeout() {
+    let writer = seed("limits-timeout").await;
+    let snap = writer.snapshot();
+    let plan = lower(&parse("MATCH (p:Person) RETURN p").unwrap()).unwrap();
+
+    // A deadline already in the past: the per-operator guard fires on the
+    // first check.
+    let past = Instant::now() - Duration::from_millis(1);
+    let err = execute_with_limits(&plan, &snap, &Params::new(), Some(past))
+        .await
+        .expect_err("a past deadline must abort the read");
+    assert!(matches!(err, ExecError::Timeout), "got {err:?}");
+}
+
+#[tokio::test]
+async fn generous_deadline_completes() {
+    let writer = seed("limits-ok").await;
+    let snap = writer.snapshot();
+    let plan = lower(&parse("MATCH (p:Person) RETURN p").unwrap()).unwrap();
+
+    let future = Instant::now() + Duration::from_secs(60);
+    let rows = execute_with_limits(&plan, &snap, &Params::new(), Some(future))
+        .await
+        .expect("a generous deadline must not abort");
+    assert_eq!(rows.len(), 3);
+}
+
+#[tokio::test]
+async fn no_deadline_is_unbounded() {
+    let writer = seed("limits-none").await;
+    let snap = writer.snapshot();
+    let plan = lower(&parse("MATCH (p:Person) RETURN p").unwrap()).unwrap();
+
+    let rows = execute_with_limits(&plan, &snap, &Params::new(), None)
+        .await
+        .expect("no deadline runs unbounded");
+    assert_eq!(rows.len(), 3);
+}

--- a/crates/namidb-query/tests/exec_writes.rs
+++ b/crates/namidb-query/tests/exec_writes.rs
@@ -8,6 +8,7 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 
 use namidb_core::id::{NamespaceId, NodeId};
+use namidb_core::schema::{DataType, LabelDef, PropertyDef, SchemaBuilder};
 use namidb_core::value::Value as CoreValue;
 use namidb_storage::{NamespacePaths, NodeWriteRecord, WriterSession};
 use object_store::memory::InMemory;
@@ -993,4 +994,109 @@ async fn merge_rel_over_matched_nodes_is_idempotent() {
         outcome2.edges_created, 0,
         "second MERGE should not duplicate the edge"
     );
+}
+
+// ─────────────────── RFC-026: read-your-own-writes ───────────────────
+
+#[tokio::test]
+async fn create_then_match_in_one_statement_reads_own_write() {
+    // RFC-026 example 1: a MATCH that follows a CREATE in the same
+    // statement must see the just-created node. Before read-your-own-
+    // writes this returned zero rows.
+    let mut writer = WriterSession::open(store(), paths("w-ryow-create-match"))
+        .await
+        .unwrap();
+    let q = parse(
+        "CREATE (a:Person {name: 'Ada'}) \
+         WITH a \
+         MATCH (p:Person {name: 'Ada'}) \
+         RETURN p",
+    )
+    .unwrap();
+    let plan = lower(&q).unwrap();
+    let outcome = execute_write(&plan, &mut writer, &Params::new())
+        .await
+        .unwrap();
+    assert_eq!(outcome.nodes_created, 1);
+    assert_eq!(
+        outcome.rows.len(),
+        1,
+        "the MATCH must see the node staged by the CREATE in the same statement"
+    );
+    match outcome.rows[0].get("p") {
+        Some(RuntimeValue::Node(n)) => {
+            assert_eq!(
+                n.properties.get("name"),
+                Some(&RuntimeValue::String("Ada".into()))
+            );
+        }
+        other => panic!("expected node p, got {other:?}"),
+    }
+}
+
+#[tokio::test]
+async fn merge_after_create_in_one_statement_does_not_duplicate() {
+    // RFC-026 example 2: MERGE's match phase must see a node the same
+    // statement just created, so it matches instead of creating a
+    // duplicate.
+    let mut writer = WriterSession::open(store(), paths("w-ryow-merge-create"))
+        .await
+        .unwrap();
+    let q = parse(
+        "CREATE (a:Person {name: 'Ada'}) \
+         MERGE (b:Person {name: 'Ada'}) \
+         RETURN b",
+    )
+    .unwrap();
+    let plan = lower(&q).unwrap();
+    let outcome = execute_write(&plan, &mut writer, &Params::new())
+        .await
+        .unwrap();
+    assert_eq!(
+        outcome.nodes_created, 1,
+        "MERGE must match the staged CREATE, not create a second node"
+    );
+
+    // Exactly one Person is durable after commit.
+    let snap = writer.snapshot();
+    assert_eq!(snap.scan_label("Person").await.unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn intra_batch_duplicate_unique_value_is_rejected() {
+    // RFC-026: the unique-constraint check reads the overlay, so two
+    // creates of the same unique value in one uncommitted statement are
+    // caught — the second now sees the first.
+    let mut writer = WriterSession::open(store(), paths("w-ryow-unique"))
+        .await
+        .unwrap();
+    let schema = SchemaBuilder::new()
+        .label(LabelDef {
+            name: "Account".into(),
+            properties: vec![PropertyDef::new("email", DataType::Utf8, false)
+                .unwrap()
+                .with_unique(true)],
+        })
+        .unwrap()
+        .build();
+    // Seed one committed Account so the flush is non-empty and persists the
+    // unique schema into the manifest (an empty flush is a no-op).
+    write_q(&mut writer, "CREATE (:Account {email: 'seed@x.com'})").await;
+    writer.flush(schema).await.unwrap();
+
+    let q =
+        parse("CREATE (:Account {email: 'dup@x.com'}), (:Account {email: 'dup@x.com'})").unwrap();
+    let plan = lower(&q).unwrap();
+    let err = execute_write(&plan, &mut writer, &Params::new())
+        .await
+        .expect_err("duplicate unique value in one batch must be rejected");
+    let msg = format!("{err:?}");
+    assert!(
+        msg.contains("unique"),
+        "expected a unique-constraint error, got: {msg}"
+    );
+
+    // The failed statement discarded its batch: only the seed remains.
+    let snap = writer.snapshot();
+    assert_eq!(snap.scan_label("Account").await.unwrap().len(), 1);
 }

--- a/crates/namidb-server/src/bolt.rs
+++ b/crates/namidb-server/src/bolt.rs
@@ -103,9 +103,15 @@ impl Backend for ServerBackend {
             // snapshot; the Arc keeps the underlying memtable alive for
             // the duration of the query, no writer lock needed.
             let snap = owned.borrow();
-            let rows = execute_with_limits(&plan, &snap, &params, self.state.query_deadline())
-                .await
-                .map_err(map_exec_err)?;
+            let rows = execute_with_limits(
+                &plan,
+                &snap,
+                &params,
+                self.state.query_deadline(),
+                self.state.query_row_cap(),
+            )
+            .await
+            .map_err(map_exec_err)?;
             Ok(read_run_outcome(rows))
         }
     }
@@ -185,9 +191,15 @@ impl Backend for ServerBackend {
                 .as_mut()
                 .ok_or_else(|| BackendError::Other("no open transaction".into()))?;
             let snap = tx.writer.overlay_snapshot();
-            let rows = execute_with_limits(&plan, &snap, &params, self.state.query_deadline())
-                .await
-                .map_err(map_exec_err)?;
+            let rows = execute_with_limits(
+                &plan,
+                &snap,
+                &params,
+                self.state.query_deadline(),
+                self.state.query_row_cap(),
+            )
+            .await
+            .map_err(map_exec_err)?;
             Ok(read_run_outcome(rows))
         }
     }

--- a/crates/namidb-server/src/bolt.rs
+++ b/crates/namidb-server/src/bolt.rs
@@ -14,8 +14,8 @@ use namidb_bolt::{
     AuthPolicy, Backend, BackendError, RunOutcome, ServerInfo, Session, StatementType,
 };
 use namidb_query::{
-    execute, execute_write, execute_write_staged, parse as cypher_parse, plan as build_plan,
-    ExecError, LowerError, Params, ParseError, Row, WriteOutcome,
+    execute_with_limits, execute_write, execute_write_staged, parse as cypher_parse,
+    plan as build_plan, ExecError, LowerError, Params, ParseError, Row, WriteOutcome,
 };
 use namidb_storage::WriterSession;
 use tokio::net::TcpListener;
@@ -103,7 +103,9 @@ impl Backend for ServerBackend {
             // snapshot; the Arc keeps the underlying memtable alive for
             // the duration of the query, no writer lock needed.
             let snap = owned.borrow();
-            let rows = execute(&plan, &snap, &params).await.map_err(map_exec_err)?;
+            let rows = execute_with_limits(&plan, &snap, &params, self.state.query_deadline())
+                .await
+                .map_err(map_exec_err)?;
             Ok(read_run_outcome(rows))
         }
     }
@@ -183,7 +185,9 @@ impl Backend for ServerBackend {
                 .as_mut()
                 .ok_or_else(|| BackendError::Other("no open transaction".into()))?;
             let snap = tx.writer.overlay_snapshot();
-            let rows = execute(&plan, &snap, &params).await.map_err(map_exec_err)?;
+            let rows = execute_with_limits(&plan, &snap, &params, self.state.query_deadline())
+                .await
+                .map_err(map_exec_err)?;
             Ok(read_run_outcome(rows))
         }
     }

--- a/crates/namidb-server/src/bolt.rs
+++ b/crates/namidb-server/src/bolt.rs
@@ -128,9 +128,10 @@ impl Backend for ServerBackend {
         cypher: &str,
         params: Params,
     ) -> std::result::Result<RunOutcome, BackendError> {
-        // Introspection and reads run against the published snapshot, same
-        // as auto-commit — an in-tx read does NOT see the tx's own staged
-        // writes (no read-your-own-writes; documented limitation).
+        // Introspection runs against the published snapshot (schema only).
+        // Data reads, below, run against the transaction's own writer with
+        // its staged batch overlaid, so an in-tx read sees the tx's own
+        // staged writes (read-your-own-writes, RFC-026).
         {
             let owned = self.state.snapshot.load();
             let snap = owned.borrow();
@@ -173,7 +174,15 @@ impl Backend for ServerBackend {
             tx.staged = true;
             Ok(write_run_outcome(outcome))
         } else {
-            let snap = owned.borrow();
+            // Read against the transaction's own writer so the staged batch
+            // is visible (RFC-026). The writer pins the committed state at
+            // tx-begin (no commit happens mid-tx while we hold the lock) and
+            // overlays everything statements 1..N-1 staged.
+            let mut slot = self.tx.lock().await;
+            let tx = slot
+                .as_mut()
+                .ok_or_else(|| BackendError::Other("no open transaction".into()))?;
+            let snap = tx.writer.overlay_snapshot();
             let rows = execute(&plan, &snap, &params).await.map_err(map_exec_err)?;
             Ok(read_run_outcome(rows))
         }

--- a/crates/namidb-server/src/bolt.rs
+++ b/crates/namidb-server/src/bolt.rs
@@ -97,6 +97,13 @@ impl Backend for ServerBackend {
                 .await
                 .map_err(map_exec_err)?;
             self.state.snapshot.store(writer.owned_snapshot());
+            // Soft write stall (RFC-027 P5): sample under the lock, release,
+            // then back off this request if L0 is piling up.
+            let stall = self.state.write_stall_for(writer.max_l0_bucket_len());
+            drop(writer);
+            if let Some(delay) = stall {
+                tokio::time::sleep(delay).await;
+            }
             Ok(write_run_outcome(outcome))
         } else {
             // Read path: borrow a short-lived `Snapshot` from the owned

--- a/crates/namidb-server/src/lib.rs
+++ b/crates/namidb-server/src/lib.rs
@@ -68,6 +68,17 @@ pub struct Config {
     /// instead of risking an out-of-memory blow-up (e.g. a cross product).
     /// `0` disables it.
     pub query_row_cap: usize,
+    /// L0-count high-water mark per bucket that triggers a compaction as
+    /// soon as a flush crosses it, instead of waiting for the periodic
+    /// compaction tick (RFC-027 P5). Keeps read amplification bounded under
+    /// sustained writes. `0` disables the reactive trigger.
+    pub compaction_l0_trigger: usize,
+    /// L0-count per bucket above which writes are softly stalled by
+    /// `write_stall_delay` (RFC-027 P5), so the writer cannot outrun
+    /// compaction without bound. `0` disables the stall.
+    pub write_stall_l0: usize,
+    /// Delay applied to a write when L0 is above `write_stall_l0`.
+    pub write_stall_delay: Duration,
 }
 
 /// `(manifest_version, catalog)` memoised behind a mutex and shared across
@@ -95,6 +106,13 @@ pub struct AppState {
     /// Per-read-query operator row cap. `0` disables it. Defaults to
     /// disabled; the server sets it from [`Config`] at boot.
     query_row_cap: usize,
+    /// Soft write-stall threshold and delay (RFC-027 P5). When the worst
+    /// bucket's L0 count reaches `write_stall_l0` (and it is non-zero), a
+    /// committed write waits `write_stall_delay` before returning, applying
+    /// backpressure so the writer cannot outrun compaction. Defaults to
+    /// disabled; the server sets them from [`Config`] at boot.
+    write_stall_l0: usize,
+    write_stall_delay: Duration,
 }
 
 impl AppState {
@@ -108,7 +126,28 @@ impl AppState {
             namespace,
             query_timeout: Duration::ZERO,
             query_row_cap: 0,
+            write_stall_l0: 0,
+            write_stall_delay: Duration::ZERO,
         }
+    }
+
+    /// Set the soft write-stall threshold and delay (builder style). A
+    /// threshold of `0` leaves writes unstalled.
+    pub fn with_write_stall(mut self, l0_threshold: usize, delay: Duration) -> Self {
+        self.write_stall_l0 = l0_threshold;
+        self.write_stall_delay = delay;
+        self
+    }
+
+    /// If a write should be stalled given the worst bucket's current L0
+    /// count, the delay to apply; otherwise `None`. The caller samples
+    /// `max_l0_bucket_len()` while holding the writer lock, then sleeps
+    /// after releasing it.
+    pub(crate) fn write_stall_for(&self, max_l0: usize) -> Option<Duration> {
+        (self.write_stall_l0 > 0
+            && max_l0 >= self.write_stall_l0
+            && self.write_stall_delay > Duration::ZERO)
+            .then_some(self.write_stall_delay)
     }
 
     /// Set the per-read-query timeout (builder style). `Duration::ZERO`
@@ -200,12 +239,18 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
 
     let state = AppState::new(writer, config.auth_token.clone(), namespace)
         .with_query_timeout(config.query_timeout)
-        .with_query_row_cap(config.query_row_cap);
+        .with_query_row_cap(config.query_row_cap)
+        .with_write_stall(config.write_stall_l0, config.write_stall_delay);
 
     // Periodic flush task — keeps the WAL bounded and L0 SSTs current.
     if config.flush_interval > Duration::ZERO {
         let state_for_flush = state.clone();
         let interval = config.flush_interval;
+        // Reactive compaction trigger (RFC-027 P5): when a flush leaves a
+        // bucket with >= this many L0 SSTs, compact immediately under the
+        // same writer lock rather than waiting for the periodic compaction
+        // tick, so read amplification does not spike between ticks.
+        let l0_trigger = config.compaction_l0_trigger;
         tokio::spawn(async move {
             let mut tick = tokio::time::interval(interval);
             tick.tick().await; // first tick fires immediately; skip.
@@ -213,8 +258,24 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
                 tick.tick().await;
                 let mut w = state_for_flush.writer.lock().await;
                 let schema = w.snapshot().manifest().manifest.schema.clone();
-                match w.flush(schema).await {
-                    Ok(_) => state_for_flush.snapshot.store(w.owned_snapshot()),
+                match w.flush(schema.clone()).await {
+                    Ok(_) => {
+                        state_for_flush.snapshot.store(w.owned_snapshot());
+                        if l0_trigger > 0 && w.max_l0_bucket_len() >= l0_trigger {
+                            match w.compact_l0(&schema).await {
+                                Ok(outcome) if outcome.source_ssts_removed > 0 => {
+                                    state_for_flush.snapshot.store(w.owned_snapshot());
+                                    info!(
+                                        removed = outcome.source_ssts_removed,
+                                        written = outcome.new_ssts_written,
+                                        "reactive compaction (L0 high-water)"
+                                    );
+                                }
+                                Ok(_) => {}
+                                Err(e) => error!(error = %e, "reactive compaction failed"),
+                            }
+                        }
+                    }
                     Err(e) => error!(error = %e, "periodic flush failed"),
                 }
             }
@@ -483,11 +544,24 @@ async fn cypher(State(state): State<AppState>, Json(req): Json<CypherRequest>) -
 
     if plan.contains_write() {
         let mut writer = state.writer.lock().await;
-        match execute_write(&plan, &mut writer, &params).await {
+        let result = execute_write(&plan, &mut writer, &params).await;
+        // Sample the soft write-stall decision while still holding the lock
+        // (RFC-027 P5), then release it and sleep — backpressure applies to
+        // this request, not to the writer mutex other connections need.
+        let stall = if result.is_ok() {
+            // Refresh the published snapshot so subsequent reads see the
+            // just-committed records (RFC-021).
+            state.snapshot.store(writer.owned_snapshot());
+            state.write_stall_for(writer.max_l0_bucket_len())
+        } else {
+            None
+        };
+        drop(writer);
+        if let Some(delay) = stall {
+            tokio::time::sleep(delay).await;
+        }
+        match result {
             Ok(outcome) => {
-                // Refresh the published snapshot so subsequent reads
-                // see the just-committed records (RFC-021).
-                state.snapshot.store(writer.owned_snapshot());
                 let summary = WriteSummary::from(&outcome);
                 let (columns, rows) = rows_to_json(&outcome.rows);
                 Json(CypherResponse {
@@ -743,6 +817,41 @@ mod tests {
         );
         let c4 = state.catalog_for(&m1);
         assert!(Arc::ptr_eq(&c3, &c4));
+    }
+
+    #[tokio::test]
+    async fn write_stall_for_respects_threshold() {
+        // RFC-027 P5 backpressure decision. Disabled by default.
+        let (store, paths) = namidb_storage::parse_uri("memory://test-stall-off").unwrap();
+        let off = AppState::new(
+            WriterSession::open(store, paths).await.unwrap(),
+            None,
+            "t".into(),
+        );
+        assert!(
+            off.write_stall_for(1_000).is_none(),
+            "disabled: never stalls"
+        );
+
+        // Enabled: stall only at or above the threshold.
+        let (store2, paths2) = namidb_storage::parse_uri("memory://test-stall-on").unwrap();
+        let on = AppState::new(
+            WriterSession::open(store2, paths2).await.unwrap(),
+            None,
+            "t".into(),
+        )
+        .with_write_stall(8, Duration::from_millis(50));
+        assert_eq!(on.write_stall_for(7), None, "below threshold");
+        assert_eq!(
+            on.write_stall_for(8),
+            Some(Duration::from_millis(50)),
+            "at threshold"
+        );
+        assert_eq!(
+            on.write_stall_for(99),
+            Some(Duration::from_millis(50)),
+            "above threshold"
+        );
     }
 
     #[tokio::test]

--- a/crates/namidb-server/src/lib.rs
+++ b/crates/namidb-server/src/lib.rs
@@ -61,6 +61,11 @@ pub struct Config {
     /// timeout error rather than pinning a worker. Writes are bounded by the
     /// transaction lifecycle, not this. `Duration::ZERO` disables it.
     pub query_timeout: Duration,
+    /// Maximum rows a single read-query operator may materialise. A query
+    /// whose operator output would exceed this aborts with a row-cap error
+    /// instead of risking an out-of-memory blow-up (e.g. a cross product).
+    /// `0` disables it.
+    pub query_row_cap: usize,
 }
 
 /// `(manifest_version, catalog)` memoised behind a mutex and shared across
@@ -85,6 +90,9 @@ pub struct AppState {
     /// Per-read-query wall-clock budget. `Duration::ZERO` disables it.
     /// Defaults to disabled; the server sets it from [`Config`] at boot.
     query_timeout: Duration,
+    /// Per-read-query operator row cap. `0` disables it. Defaults to
+    /// disabled; the server sets it from [`Config`] at boot.
+    query_row_cap: usize,
 }
 
 impl AppState {
@@ -97,6 +105,7 @@ impl AppState {
             auth_token: auth_token.map(Arc::from),
             namespace,
             query_timeout: Duration::ZERO,
+            query_row_cap: 0,
         }
     }
 
@@ -107,11 +116,23 @@ impl AppState {
         self
     }
 
+    /// Set the per-read-query operator row cap (builder style). `0` leaves
+    /// reads uncapped.
+    pub fn with_query_row_cap(mut self, row_cap: usize) -> Self {
+        self.query_row_cap = row_cap;
+        self
+    }
+
     /// Deadline for a read query starting now, or `None` when the timeout
     /// is disabled. Computed per query so each read gets the full budget.
     pub(crate) fn query_deadline(&self) -> Option<std::time::Instant> {
         (self.query_timeout > Duration::ZERO)
             .then(|| std::time::Instant::now() + self.query_timeout)
+    }
+
+    /// Operator row cap for a read query, or `None` when disabled.
+    pub(crate) fn query_row_cap(&self) -> Option<usize> {
+        (self.query_row_cap > 0).then_some(self.query_row_cap)
     }
 
     /// Optimizer [`StatsCatalog`] for `manifest`, built once per manifest
@@ -176,7 +197,8 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
     let writer = WriterSession::open(store, paths).await?;
 
     let state = AppState::new(writer, config.auth_token.clone(), namespace)
-        .with_query_timeout(config.query_timeout);
+        .with_query_timeout(config.query_timeout)
+        .with_query_row_cap(config.query_row_cap);
 
     // Periodic flush task — keeps the WAL bounded and L0 SSTs current.
     if config.flush_interval > Duration::ZERO {
@@ -473,7 +495,15 @@ async fn cypher(State(state): State<AppState>, Json(req): Json<CypherRequest>) -
         // from the owned one; the `OwnedSnapshot` Arc keeps the
         // underlying memtable alive for the duration of the query.
         let snap = owned.borrow();
-        match execute_with_limits(&plan, &snap, &params, state.query_deadline()).await {
+        match execute_with_limits(
+            &plan,
+            &snap,
+            &params,
+            state.query_deadline(),
+            state.query_row_cap(),
+        )
+        .await
+        {
             Ok(rows) => {
                 let (columns, rows) = rows_to_json(&rows);
                 Json(CypherResponse {

--- a/crates/namidb-server/src/lib.rs
+++ b/crates/namidb-server/src/lib.rs
@@ -24,8 +24,8 @@ use tokio::sync::Mutex;
 use tracing::{error, info, warn};
 
 use namidb_query::{
-    execute, execute_write, parse as cypher_parse, plan as build_plan, Params, RuntimeValue,
-    StatsCatalog, WriteOutcome,
+    execute_with_limits, execute_write, parse as cypher_parse, plan as build_plan, Params,
+    RuntimeValue, StatsCatalog, WriteOutcome,
 };
 use namidb_storage::{sweep_orphans, Manifest, ManifestStore, SnapshotCell, WriterSession};
 
@@ -56,6 +56,11 @@ pub struct Config {
     /// pin it; after this long without a message the transaction is rolled
     /// back and failed. `Duration::ZERO` disables the timeout.
     pub bolt_tx_timeout: Duration,
+    /// Wall-clock deadline for a single read query (HTTP and Bolt, including
+    /// in-transaction reads). A runaway scan or expansion is aborted with a
+    /// timeout error rather than pinning a worker. Writes are bounded by the
+    /// transaction lifecycle, not this. `Duration::ZERO` disables it.
+    pub query_timeout: Duration,
 }
 
 /// `(manifest_version, catalog)` memoised behind a mutex and shared across
@@ -77,6 +82,9 @@ pub struct AppState {
     catalog_cache: CatalogCache,
     auth_token: Option<Arc<str>>,
     namespace: String,
+    /// Per-read-query wall-clock budget. `Duration::ZERO` disables it.
+    /// Defaults to disabled; the server sets it from [`Config`] at boot.
+    query_timeout: Duration,
 }
 
 impl AppState {
@@ -88,7 +96,22 @@ impl AppState {
             catalog_cache: Arc::new(std::sync::Mutex::new(None)),
             auth_token: auth_token.map(Arc::from),
             namespace,
+            query_timeout: Duration::ZERO,
         }
+    }
+
+    /// Set the per-read-query timeout (builder style). `Duration::ZERO`
+    /// leaves reads unbounded.
+    pub fn with_query_timeout(mut self, timeout: Duration) -> Self {
+        self.query_timeout = timeout;
+        self
+    }
+
+    /// Deadline for a read query starting now, or `None` when the timeout
+    /// is disabled. Computed per query so each read gets the full budget.
+    pub(crate) fn query_deadline(&self) -> Option<std::time::Instant> {
+        (self.query_timeout > Duration::ZERO)
+            .then(|| std::time::Instant::now() + self.query_timeout)
     }
 
     /// Optimizer [`StatsCatalog`] for `manifest`, built once per manifest
@@ -152,7 +175,8 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
     let maint_manifest_store = ManifestStore::new(store.clone(), paths.clone());
     let writer = WriterSession::open(store, paths).await?;
 
-    let state = AppState::new(writer, config.auth_token.clone(), namespace);
+    let state = AppState::new(writer, config.auth_token.clone(), namespace)
+        .with_query_timeout(config.query_timeout);
 
     // Periodic flush task — keeps the WAL bounded and L0 SSTs current.
     if config.flush_interval > Duration::ZERO {
@@ -449,7 +473,7 @@ async fn cypher(State(state): State<AppState>, Json(req): Json<CypherRequest>) -
         // from the owned one; the `OwnedSnapshot` Arc keeps the
         // underlying memtable alive for the duration of the query.
         let snap = owned.borrow();
-        match execute(&plan, &snap, &params).await {
+        match execute_with_limits(&plan, &snap, &params, state.query_deadline()).await {
             Ok(rows) => {
                 let (columns, rows) = rows_to_json(&rows);
                 Json(CypherResponse {

--- a/crates/namidb-server/src/lib.rs
+++ b/crates/namidb-server/src/lib.rs
@@ -46,8 +46,10 @@ pub struct Config {
     /// body — the sole guard against deleting a file a slow reader's pinned
     /// snapshot still references.
     pub sweep_min_age: Duration,
-    /// When `false` the orphan sweep is a dry-run (logs what it would free
-    /// without deleting). Operators opt in after reviewing the volume.
+    /// When `true` (the default) the orphan sweep deletes unreferenced SST
+    /// bodies; the retention horizon (RFC-027) makes that safe by
+    /// construction. Set `false` for a dry-run that only logs what it would
+    /// free.
     pub sweep_delete: bool,
     /// Bolt listener address. `None` keeps the protocol off (HTTP only).
     pub bolt_listen: Option<std::net::SocketAddr>,
@@ -224,9 +226,9 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
     // compaction. Compaction is a writer mutation, so it goes through the
     // ONE writer lock — never a second `WriterSession`, which would bump the
     // epoch and fence the foreground writer. The sweep takes no lock (it
-    // reads the committed manifest itself) and is gated to a dry-run by
-    // default; `sweep_min_age` is the only thing keeping it from deleting a
-    // body a slow reader's pinned snapshot still references.
+    // reads the committed manifest itself); the retention horizon (RFC-027)
+    // is what keeps it from deleting a body a slow reader's pinned snapshot
+    // still references, so it is safe to enable by default.
     if config.compaction_interval > Duration::ZERO {
         let state_for_maint = state.clone();
         let interval = config.compaction_interval;
@@ -259,8 +261,21 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
                     }
                 }
                 // Orphan sweep — no writer lock. `max_level = 1` because the
-                // engine only produces L0 + L1 today.
-                match sweep_orphans(&maint_manifest_store, sweep_min_age, 1, sweep_delete).await {
+                // engine only produces L0 + L1 today. The retention horizon
+                // (RFC-027) is the oldest manifest version any live reader is
+                // pinned to; the sweep keeps every object referenced from the
+                // horizon to current, so it can never delete a body a reader
+                // still needs.
+                let horizon = state_for_maint.snapshot.retention_horizon();
+                match sweep_orphans(
+                    &maint_manifest_store,
+                    horizon,
+                    sweep_min_age,
+                    1,
+                    sweep_delete,
+                )
+                .await
+                {
                     Ok(report) if report.orphans_found > 0 => info!(
                         found = report.orphans_found,
                         deleted = report.orphans_deleted,

--- a/crates/namidb-server/src/main.rs
+++ b/crates/namidb-server/src/main.rs
@@ -67,10 +67,17 @@ struct Cli {
     )]
     sweep_min_age: Duration,
 
-    /// Actually delete orphaned SST bodies during the sweep. Off by
-    /// default: the sweep runs as a dry-run and only logs what it would
-    /// free, so an operator can review the volume before opting in.
-    #[arg(long, env = "NAMIDB_SWEEP_DELETE", default_value_t = false)]
+    /// Delete orphaned SST bodies during the sweep. On by default: the
+    /// retention horizon (RFC-027) makes deletion safe by construction (an
+    /// object referenced by no manifest version from the horizon to current
+    /// is unreachable by any reader). Set to `false` for a dry-run that only
+    /// logs what it would free.
+    #[arg(
+        long,
+        env = "NAMIDB_SWEEP_DELETE",
+        default_value_t = true,
+        action = clap::ArgAction::Set
+    )]
     sweep_delete: bool,
 
     /// Address for the Bolt protocol listener (Neo4j driver

--- a/crates/namidb-server/src/main.rs
+++ b/crates/namidb-server/src/main.rs
@@ -90,6 +90,18 @@ struct Cli {
         value_parser = humantime::parse_duration,
     )]
     bolt_tx_timeout: Duration,
+
+    /// Wall-clock budget for a single read query (HTTP and Bolt, including
+    /// in-transaction reads). A runaway scan or expansion is aborted with a
+    /// timeout error instead of pinning a worker. Set to `0s` to allow read
+    /// queries to run unbounded.
+    #[arg(
+        long,
+        env = "NAMIDB_QUERY_TIMEOUT",
+        default_value = "30s",
+        value_parser = humantime::parse_duration,
+    )]
+    query_timeout: Duration,
 }
 
 fn main() -> anyhow::Result<()> {
@@ -111,6 +123,7 @@ fn main() -> anyhow::Result<()> {
         sweep_delete: cli.sweep_delete,
         bolt_listen: cli.bolt_listen,
         bolt_tx_timeout: cli.bolt_tx_timeout,
+        query_timeout: cli.query_timeout,
     };
 
     let rt = tokio::runtime::Builder::new_multi_thread()

--- a/crates/namidb-server/src/main.rs
+++ b/crates/namidb-server/src/main.rs
@@ -102,6 +102,13 @@ struct Cli {
         value_parser = humantime::parse_duration,
     )]
     query_timeout: Duration,
+
+    /// Maximum rows a single read-query operator may materialise. A query
+    /// whose operator output would exceed this aborts with a row-cap error
+    /// instead of risking an out-of-memory blow-up. Set to `0` to allow read
+    /// queries to materialise without limit.
+    #[arg(long, env = "NAMIDB_QUERY_ROW_CAP", default_value_t = 0)]
+    query_row_cap: usize,
 }
 
 fn main() -> anyhow::Result<()> {
@@ -124,6 +131,7 @@ fn main() -> anyhow::Result<()> {
         bolt_listen: cli.bolt_listen,
         bolt_tx_timeout: cli.bolt_tx_timeout,
         query_timeout: cli.query_timeout,
+        query_row_cap: cli.query_row_cap,
     };
 
     let rt = tokio::runtime::Builder::new_multi_thread()

--- a/crates/namidb-server/src/main.rs
+++ b/crates/namidb-server/src/main.rs
@@ -116,6 +116,29 @@ struct Cli {
     /// queries to materialise without limit.
     #[arg(long, env = "NAMIDB_QUERY_ROW_CAP", default_value_t = 0)]
     query_row_cap: usize,
+
+    /// L0-count high-water mark per bucket that triggers a compaction as
+    /// soon as a flush crosses it, instead of waiting for the periodic
+    /// compaction tick. Bounds read amplification under sustained writes.
+    /// Set to `0` to disable the reactive trigger.
+    #[arg(long, env = "NAMIDB_COMPACTION_L0_TRIGGER", default_value_t = 8)]
+    compaction_l0_trigger: usize,
+
+    /// L0-count per bucket above which a committed write is softly stalled
+    /// by `--write-stall-delay`, so the writer cannot outrun compaction
+    /// without bound. Set to `0` (the default) to disable the stall.
+    #[arg(long, env = "NAMIDB_WRITE_STALL_L0", default_value_t = 0)]
+    write_stall_l0: usize,
+
+    /// Delay applied to a committed write while L0 is above
+    /// `--write-stall-l0`. Ignored when the stall is disabled.
+    #[arg(
+        long,
+        env = "NAMIDB_WRITE_STALL_DELAY",
+        default_value = "50ms",
+        value_parser = humantime::parse_duration,
+    )]
+    write_stall_delay: Duration,
 }
 
 fn main() -> anyhow::Result<()> {
@@ -139,6 +162,9 @@ fn main() -> anyhow::Result<()> {
         bolt_tx_timeout: cli.bolt_tx_timeout,
         query_timeout: cli.query_timeout,
         query_row_cap: cli.query_row_cap,
+        compaction_l0_trigger: cli.compaction_l0_trigger,
+        write_stall_l0: cli.write_stall_l0,
+        write_stall_delay: cli.write_stall_delay,
     };
 
     let rt = tokio::runtime::Builder::new_multi_thread()

--- a/crates/namidb-server/tests/background_maintenance.rs
+++ b/crates/namidb-server/tests/background_maintenance.rs
@@ -13,8 +13,6 @@
 //! 4. The orphan sweep finds the now-unreferenced L0 bodies, deletes them
 //!    when asked, and a re-run finds nothing — and reads still hold.
 
-use std::sync::Arc;
-
 use namidb_query::{
     execute, execute_write, parse as cypher_parse, plan as build_plan, Params, RuntimeValue,
     StatsCatalog,
@@ -62,7 +60,7 @@ fn node_ssts(snap: &OwnedSnapshot, level: SstLevel) -> usize {
 }
 
 /// `MATCH (p:Person) RETURN count(p)` against a pinned snapshot.
-async fn count_persons(snap: &Arc<OwnedSnapshot>) -> i64 {
+async fn count_persons(snap: &OwnedSnapshot) -> i64 {
     let parsed = cypher_parse("MATCH (p:Person) RETURN count(p) AS c").expect("parse");
     let catalog = StatsCatalog::from_manifest(&snap.manifest().manifest);
     let plan = build_plan(&parsed, &catalog).expect("plan");
@@ -97,17 +95,21 @@ async fn compaction_collapses_l0_and_sweep_reclaims_orphans() {
     }
     let total = (BATCHES * PER_BATCH) as i64;
 
-    let before = state.snapshot.load();
-    assert!(
-        node_ssts(&before, SstLevel::L0) >= 2,
-        "expected >= 2 L0 Person SSTs before compaction, got {}",
-        node_ssts(&before, SstLevel::L0)
-    );
-    assert_eq!(count_persons(&before).await, total, "baseline count");
+    {
+        let before = state.snapshot.load();
+        assert!(
+            node_ssts(&before, SstLevel::L0) >= 2,
+            "expected >= 2 L0 Person SSTs before compaction, got {}",
+            node_ssts(&before, SstLevel::L0)
+        );
+        assert_eq!(count_persons(&before).await, total, "baseline count");
+    } // drop `before` so only the explicit pin below holds the old version
 
     // Pin a snapshot from before compaction: its source L0 bodies must
-    // remain readable even after compaction drops them from the manifest.
+    // remain readable even after compaction drops them from the manifest,
+    // and the retention horizon must keep the sweep off them (RFC-027).
     let pinned_pre_compaction = state.snapshot.load();
+    let pinned_version = pinned_pre_compaction.manifest_version();
 
     // ── One maintenance tick: compaction under the writer lock ──
     {
@@ -127,50 +129,94 @@ async fn compaction_collapses_l0_and_sweep_reclaims_orphans() {
         state.snapshot.store(w.owned_snapshot());
     }
 
-    let after = state.snapshot.load();
-    assert_eq!(
-        node_ssts(&after, SstLevel::L0),
-        0,
-        "no L0 Person SSTs should remain after compaction"
-    );
-    assert_eq!(
-        node_ssts(&after, SstLevel(1)),
-        1,
-        "the bucket should collapse to a single L1 SST"
-    );
+    {
+        let after = state.snapshot.load();
+        assert_eq!(
+            node_ssts(&after, SstLevel::L0),
+            0,
+            "no L0 Person SSTs should remain after compaction"
+        );
+        assert_eq!(
+            node_ssts(&after, SstLevel(1)),
+            1,
+            "the bucket should collapse to a single L1 SST"
+        );
+        // Reads stay correct on the new snapshot AND on the pre-compaction one.
+        assert_eq!(count_persons(&after).await, total, "count after compaction");
+    } // drop `after` so the post-compaction version is not separately pinned
 
-    // Reads stay correct on the new snapshot AND on the pre-compaction one.
-    assert_eq!(count_persons(&after).await, total, "count after compaction");
     assert_eq!(
         count_persons(&pinned_pre_compaction).await,
         total,
         "a snapshot pinned before compaction still reads its source bodies"
     );
 
-    // ── Orphan sweep: the dropped L0 bodies are now unreferenced. ──
-    // min_age = 0 in-test (production default is 24h); max_level = 1.
-    let dry = sweep_orphans(&manifest_store, std::time::Duration::ZERO, 1, false)
-        .await
-        .expect("dry-run sweep");
-    assert!(
-        dry.orphans_found >= 2,
-        "dry-run should find >= 2 orphaned L0 bodies, found {}",
-        dry.orphans_found
-    );
-    assert_eq!(dry.orphans_deleted, 0, "dry-run deletes nothing");
-
-    let del = sweep_orphans(&manifest_store, std::time::Duration::ZERO, 1, true)
-        .await
-        .expect("delete sweep");
+    // ── Horizon-aware orphan sweep (RFC-027). min_age = 0 in-test
+    // (production default is 24h); max_level = 1. ──
+    //
+    // While the pre-compaction reader is alive it holds the horizon at its
+    // version, which still references the dropped L0 bodies, so the sweep
+    // must NOT delete them even with delete = true.
+    let horizon_pinned = state.snapshot.retention_horizon();
     assert_eq!(
-        del.orphans_deleted, dry.orphans_found,
-        "delete sweep removes exactly the orphans the dry-run found"
+        horizon_pinned, pinned_version,
+        "the pinned reader holds the retention horizon at its version"
+    );
+    let guarded = sweep_orphans(
+        &manifest_store,
+        horizon_pinned,
+        std::time::Duration::ZERO,
+        1,
+        true,
+    )
+    .await
+    .expect("guarded sweep");
+    assert_eq!(
+        guarded.orphans_found, 0,
+        "the pinned version still references the L0 bodies; none are orphans"
+    );
+    assert_eq!(guarded.orphans_deleted, 0, "nothing deleted under the pin");
+    assert_eq!(
+        count_persons(&pinned_pre_compaction).await,
+        total,
+        "the pinned reader still reads its source bodies after the guarded sweep"
     );
 
-    let dry2 = sweep_orphans(&manifest_store, std::time::Duration::ZERO, 1, false)
-        .await
-        .expect("second dry-run");
-    assert_eq!(dry2.orphans_found, 0, "no orphans remain after the sweep");
+    // Drop the reader: the horizon advances to current and the L0 bodies,
+    // now referenced by no retained version, become reclaimable.
+    drop(pinned_pre_compaction);
+    let horizon_free = state.snapshot.retention_horizon();
+    assert_eq!(
+        horizon_free,
+        state.snapshot.manifest_version(),
+        "with no readers the horizon is the current version"
+    );
+    let del = sweep_orphans(
+        &manifest_store,
+        horizon_free,
+        std::time::Duration::ZERO,
+        1,
+        true,
+    )
+    .await
+    .expect("delete sweep");
+    assert!(
+        del.orphans_deleted >= 2,
+        "after the reader leaves, the orphaned L0 bodies are reclaimed, deleted {}",
+        del.orphans_deleted
+    );
+
+    // Idempotent: a second sweep finds nothing.
+    let again = sweep_orphans(
+        &manifest_store,
+        state.snapshot.retention_horizon(),
+        std::time::Duration::ZERO,
+        1,
+        true,
+    )
+    .await
+    .expect("second sweep");
+    assert_eq!(again.orphans_found, 0, "no orphans remain after the sweep");
 
     // The live L1 SST was untouched: a fresh read still returns everything.
     let final_snap = state.snapshot.load();

--- a/crates/namidb-server/tests/bolt_integration.rs
+++ b/crates/namidb-server/tests/bolt_integration.rs
@@ -297,6 +297,7 @@ async fn boot_bolt_full(
         bolt_listen: Some(bolt_addr),
         bolt_tx_timeout: tx_timeout,
         query_timeout,
+        query_row_cap: 0,
     };
     let task = tokio::spawn(async move {
         if let Err(e) = namidb_server::run(config).await {
@@ -339,6 +340,7 @@ async fn bolt_create_then_match_roundtrip() {
         bolt_listen: Some(bolt_addr),
         bolt_tx_timeout: Duration::ZERO,
         query_timeout: Duration::ZERO,
+        query_row_cap: 0,
     };
 
     let server_task = tokio::spawn(async move {
@@ -408,6 +410,7 @@ async fn bolt_bad_token_yields_failure() {
         bolt_listen: Some(bolt_addr),
         bolt_tx_timeout: Duration::ZERO,
         query_timeout: Duration::ZERO,
+        query_row_cap: 0,
     };
 
     let server_task = tokio::spawn(async move {
@@ -541,6 +544,7 @@ async fn bolt_memgraph_introspection_populates_schema() {
         bolt_listen: Some(bolt_addr),
         bolt_tx_timeout: Duration::ZERO,
         query_timeout: Duration::ZERO,
+        query_row_cap: 0,
     };
     let server_task = tokio::spawn(async move {
         let _ = namidb_server::run(config).await;

--- a/crates/namidb-server/tests/bolt_integration.rs
+++ b/crates/namidb-server/tests/bolt_integration.rs
@@ -726,6 +726,53 @@ async fn bolt_multi_statement_commit_is_atomic() {
 }
 
 #[tokio::test]
+async fn bolt_in_tx_read_sees_own_staged_write() {
+    // RFC-026 read-your-own-writes: a read in statement N of a transaction
+    // must see what statements 1..N-1 staged, while other sessions (on the
+    // committed snapshot) must NOT see the uncommitted work.
+    let (bolt_addr, task) = boot_bolt("bolt-tx-ryow", Duration::ZERO).await;
+    let mut stream = TcpStream::connect(bolt_addr).await.expect("connect bolt");
+    handshake(&mut stream).await;
+    hello_and_logon(&mut stream, "test-token").await;
+
+    begin(&mut stream).await;
+    // Statement 1: stage a node, no commit.
+    pull_all(&mut stream, "CREATE (a:Person {name: 'Uma'})").await;
+    // Statement 2: a read in the SAME transaction sees the staged node.
+    // Before read-your-own-writes this returned zero rows.
+    let (_f, rows) = pull_all(
+        &mut stream,
+        "MATCH (p:Person {name: 'Uma'}) RETURN p.name AS name",
+    )
+    .await;
+    assert_eq!(
+        rows.len(),
+        1,
+        "an in-tx read must see the tx's own staged write"
+    );
+    assert_eq!(rows[0].get("name"), Some(&Value::String("Uma".into())));
+
+    // Isolation: a second connection reads the committed snapshot and must
+    // not observe the still-uncommitted node. (A read never needs the writer
+    // lock that the open transaction holds.)
+    let mut other = TcpStream::connect(bolt_addr).await.expect("connect other");
+    handshake(&mut other).await;
+    hello_and_logon(&mut other, "test-token").await;
+    let (_f, rows2) = pull_all(&mut other, "MATCH (p:Person) RETURN p.name AS name").await;
+    assert!(
+        rows2.is_empty(),
+        "an uncommitted staged write must not be visible to other sessions, got {rows2:?}"
+    );
+    goodbye(&mut other).await;
+    other.shutdown().await.ok();
+
+    commit(&mut stream).await;
+    goodbye(&mut stream).await;
+    stream.shutdown().await.ok();
+    task.abort();
+}
+
+#[tokio::test]
 async fn bolt_idle_transaction_times_out_and_releases_writer() {
     // A short idle timeout keeps the test fast.
     let (bolt_addr, task) = boot_bolt("bolt-tx-timeout", Duration::from_millis(300)).await;

--- a/crates/namidb-server/tests/bolt_integration.rs
+++ b/crates/namidb-server/tests/bolt_integration.rs
@@ -270,6 +270,15 @@ async fn boot_bolt(
     ns: &str,
     tx_timeout: Duration,
 ) -> (std::net::SocketAddr, tokio::task::JoinHandle<()>) {
+    boot_bolt_full(ns, tx_timeout, Duration::ZERO).await
+}
+
+/// Like [`boot_bolt`] but also sets the per-read-query timeout.
+async fn boot_bolt_full(
+    ns: &str,
+    tx_timeout: Duration,
+    query_timeout: Duration,
+) -> (std::net::SocketAddr, tokio::task::JoinHandle<()>) {
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let bolt_addr = listener.local_addr().unwrap();
     drop(listener);
@@ -287,6 +296,7 @@ async fn boot_bolt(
         sweep_delete: false,
         bolt_listen: Some(bolt_addr),
         bolt_tx_timeout: tx_timeout,
+        query_timeout,
     };
     let task = tokio::spawn(async move {
         if let Err(e) = namidb_server::run(config).await {
@@ -328,6 +338,7 @@ async fn bolt_create_then_match_roundtrip() {
         sweep_delete: false,
         bolt_listen: Some(bolt_addr),
         bolt_tx_timeout: Duration::ZERO,
+        query_timeout: Duration::ZERO,
     };
 
     let server_task = tokio::spawn(async move {
@@ -396,6 +407,7 @@ async fn bolt_bad_token_yields_failure() {
         sweep_delete: false,
         bolt_listen: Some(bolt_addr),
         bolt_tx_timeout: Duration::ZERO,
+        query_timeout: Duration::ZERO,
     };
 
     let server_task = tokio::spawn(async move {
@@ -528,6 +540,7 @@ async fn bolt_memgraph_introspection_populates_schema() {
         sweep_delete: false,
         bolt_listen: Some(bolt_addr),
         bolt_tx_timeout: Duration::ZERO,
+        query_timeout: Duration::ZERO,
     };
     let server_task = tokio::spawn(async move {
         let _ = namidb_server::run(config).await;
@@ -768,6 +781,38 @@ async fn bolt_in_tx_read_sees_own_staged_write() {
 
     commit(&mut stream).await;
     goodbye(&mut stream).await;
+    stream.shutdown().await.ok();
+    task.abort();
+}
+
+#[tokio::test]
+async fn bolt_read_query_times_out() {
+    // A 1ns read budget: the deadline (now + 1ns) is already past by the
+    // time the executor reaches its first operator guard, so a read RUN
+    // fails with a timeout instead of returning rows. Planning alone takes
+    // far longer than a nanosecond, so this is deterministic.
+    let (bolt_addr, task) =
+        boot_bolt_full("bolt-qtimeout", Duration::ZERO, Duration::from_nanos(1)).await;
+    let mut stream = TcpStream::connect(bolt_addr).await.expect("connect bolt");
+    handshake(&mut stream).await;
+    hello_and_logon(&mut stream, "test-token").await;
+
+    let run = Value::Struct {
+        tag: struct_tag::RUN,
+        fields: vec![
+            Value::String("MATCH (p:Person) RETURN p".into()),
+            Value::Map(BTreeMap::new()),
+            Value::Map(BTreeMap::new()),
+        ],
+    };
+    send_msg(&mut stream, &pack(&run)).await;
+    let resp = recv_msg(&mut stream).await;
+    assert!(
+        matches!(resp, Response::Failure(_)),
+        "a read past its 1ns budget must fail, got {resp:?}"
+    );
+
+    // Session is FAILED after the error; just drop the connection.
     stream.shutdown().await.ok();
     task.abort();
 }

--- a/crates/namidb-server/tests/bolt_integration.rs
+++ b/crates/namidb-server/tests/bolt_integration.rs
@@ -298,6 +298,9 @@ async fn boot_bolt_full(
         bolt_tx_timeout: tx_timeout,
         query_timeout,
         query_row_cap: 0,
+        compaction_l0_trigger: 0,
+        write_stall_l0: 0,
+        write_stall_delay: Duration::ZERO,
     };
     let task = tokio::spawn(async move {
         if let Err(e) = namidb_server::run(config).await {
@@ -341,6 +344,9 @@ async fn bolt_create_then_match_roundtrip() {
         bolt_tx_timeout: Duration::ZERO,
         query_timeout: Duration::ZERO,
         query_row_cap: 0,
+        compaction_l0_trigger: 0,
+        write_stall_l0: 0,
+        write_stall_delay: Duration::ZERO,
     };
 
     let server_task = tokio::spawn(async move {
@@ -411,6 +417,9 @@ async fn bolt_bad_token_yields_failure() {
         bolt_tx_timeout: Duration::ZERO,
         query_timeout: Duration::ZERO,
         query_row_cap: 0,
+        compaction_l0_trigger: 0,
+        write_stall_l0: 0,
+        write_stall_delay: Duration::ZERO,
     };
 
     let server_task = tokio::spawn(async move {
@@ -545,6 +554,9 @@ async fn bolt_memgraph_introspection_populates_schema() {
         bolt_tx_timeout: Duration::ZERO,
         query_timeout: Duration::ZERO,
         query_row_cap: 0,
+        compaction_l0_trigger: 0,
+        write_stall_l0: 0,
+        write_stall_delay: Duration::ZERO,
     };
     let server_task = tokio::spawn(async move {
         let _ = namidb_server::run(config).await;

--- a/crates/namidb-storage/src/compact.rs
+++ b/crates/namidb-storage/src/compact.rs
@@ -1,32 +1,37 @@
-//! Stateless L0 → L1 compaction.
+//! Full-bucket compaction to a single L1.
 //!
 //! Each [`crate::flush::flush`] call appends a new L0 SST per `(kind,
 //! scope)` bucket that had memtable rows. Without compaction, a
 //! namespace's L0 footprint grows monotonically with every batch and
 //! every point lookup pays an `O(L0 count)` candidate-SST scan.
 //!
-//! The compactor groups L0 SSTs by `(kind, scope)`, merges them into a
-//! single L1 SST per bucket, and commits a manifest version that
-//! removes the source descriptors and adds the new ones in a single
-//! CAS. The source SST bodies become orphans in object storage (no
-//! manifest version references them after the commit); a future
-//! janitor sweeps them.
+//! The compactor groups every SST by `(kind, scope)` — the new L0s *and*
+//! the bucket's existing L1 — merges them into a single L1 SST per bucket,
+//! and commits a manifest version that removes the source descriptors and
+//! adds the new one in a single CAS. The source SST bodies become orphans
+//! in object storage (no current manifest version references them after the
+//! commit); the horizon-aware [`crate::janitor::sweep_orphans`] reclaims
+//! them once no pinned reader needs them.
 //!
 //! ## Merge semantics
 //!
-//! Per `(node_id)` (nodes) or `(key_id, partner_id)` (edges): the row
-//! with the highest LSN wins. Tombstones at the winning LSN are
-//! preserved in the L1 SST — has no snapshot-retention policy
-//! so a tombstone might still be load-bearing for a reader pinned at
-//! a manifest version that pre-dates the compaction.
+//! Per `(node_id)` (nodes) or `(key_id, partner_id)` (edges): the row with
+//! the highest LSN wins; lower-LSN versions are dropped. Because the merge
+//! is full-bucket the resulting L1 is the bucket's only SST in the new
+//! version, so a winning **tombstone** shadows nothing and is dropped
+//! entirely (RFC-027 P3) rather than carried forever. A reader pinned at an
+//! older manifest version still observes the delete through the retained
+//! source bodies, never through this L1.
 //!
 //! ## What's deliberately not here
 //!
-//! - Multi-level compaction (L1 → L2, etc.). Only L0 → L1 in v1.
-//! - Background scheduling. The caller invokes [`compact_l0_to_l1`]
-//! manually; auto-trigger lands when the bench shape demands it.
-//! - Range-partitioned compaction (split a bucket into multiple L1
-//! files by key range). Each bucket emits exactly one L1 SST today.
+//! - Multi-level compaction (L1 → L2, etc.) with a size ratio. The bucket
+//! collapses to one L1; leveled compaction to bound write amplification is
+//! RFC-027 P4.
+//! - Background scheduling beyond the periodic maintenance tick; a reactive
+//! L0-count trigger and write stall are RFC-027 P5.
+//! - Range-partitioned compaction (split a bucket into multiple L1 files by
+//! key range). Each bucket emits exactly one L1 SST.
 //!
 //! Declared edge property streams (RFC-002 §3.2.7) are preserved
 //! end-to-end: the compactor reads each declared stream from every
@@ -91,14 +96,20 @@ pub async fn compact_l0_to_l1(
 ) -> Result<CompactionOutcome> {
     fence.assert_alive(base.manifest.epoch)?;
 
-    // Group L0 SSTs by (kind, scope).
+    // Group every SST by (kind, scope) — both L0 and any existing L1.
+    // Including the prior L1 makes each compaction a full-bucket merge: the
+    // resulting L1 is the bucket's only SST in the new manifest version, so
+    // it is authoritative for every key. That is what lets the merge drop
+    // tombstones and superseded versions safely (RFC-027 P3): no other SST
+    // at the new version can hold a live row the tombstone was shadowing,
+    // and a reader pinned at an older version reads the retained source
+    // bodies, not this L1 (the horizon-aware sweep keeps them alive). It
+    // also collapses the bucket back to one L1, bounding the footprint a
+    // pure L0->L1 merge let grow.
     let mut node_buckets: BTreeMap<String, Vec<&SstDescriptor>> = BTreeMap::new();
     let mut fwd_buckets: BTreeMap<String, Vec<&SstDescriptor>> = BTreeMap::new();
     let mut inv_buckets: BTreeMap<String, Vec<&SstDescriptor>> = BTreeMap::new();
     for desc in &base.manifest.ssts {
-        if desc.level != SstLevel::L0 {
-            continue;
-        }
         match desc.kind {
             SstKind::Nodes => node_buckets
                 .entry(desc.scope.clone())
@@ -121,6 +132,24 @@ pub async fn compact_l0_to_l1(
     let mut removed_ids: Vec<Uuid> = Vec::new();
     let mut bloom_count: usize = 0;
 
+    // Node tombstone GC is safe only when the merge is authoritative for
+    // every node key it touches. Nodes are id-primary, so a key can live in
+    // any node SST regardless of scope; if more than one node scope is
+    // present (a legacy per-label SST alongside the id-primary `""` one), a
+    // full-bucket merge of a single scope is NOT authoritative and dropping
+    // a tombstone could resurrect a live row from the other scope. Restrict
+    // node GC to the single-scope case (the id-primary norm). Edges are
+    // keyed within `(edge_type, direction)`, so every edge bucket is
+    // authoritative on its own and GC is always safe there.
+    let node_scopes: HashSet<&str> = base
+        .manifest
+        .ssts
+        .iter()
+        .filter(|d| d.kind == SstKind::Nodes)
+        .map(|d| d.scope.as_str())
+        .collect();
+    let node_gc_safe = node_scopes.len() <= 1;
+
     // Nodes.
     for (label, sources) in node_buckets {
         if sources.len() < 2 {
@@ -135,7 +164,7 @@ pub async fn compact_l0_to_l1(
             let body = get_sst_body(store.as_ref(), paths, desc).await?;
             readers.push(NodeSstReader::open(label_def.clone(), body)?);
         }
-        let (finish, merged_rows) = compact_node_ssts(&label_def, &readers)?;
+        let (finish, merged_rows) = compact_node_ssts(&label_def, &readers, node_gc_safe)?;
         if finish.stats.row_count == 0 {
             // Nothing to write; still mark sources for removal so the
             // bucket truly shrinks.
@@ -267,6 +296,7 @@ async fn compact_and_write_edges(
 fn compact_node_ssts(
     label_def: &LabelDef,
     sources: &[NodeSstReader],
+    gc_tombstones: bool,
 ) -> Result<(NodeSstFinish, Vec<NodeRow>)> {
     let mut rows: Vec<NodeRow> = Vec::new();
     for reader in sources {
@@ -276,6 +306,17 @@ fn compact_node_ssts(
     // dedup_by_key below preserves the winner.
     rows.sort_by(|a, b| a.id.cmp(&b.id).then(b.lsn.cmp(&a.lsn)));
     rows.dedup_by_key(|r| r.id);
+    // Tombstone GC (RFC-027 P3): a key whose winning op is a tombstone has
+    // no live value, and when this merge is authoritative for the node
+    // keyspace (`gc_tombstones`, see the caller) it is the only SST that
+    // could hold the key at the new manifest version, so the tombstone
+    // shadows nothing and is dropped entirely. Readers pinned at older
+    // versions still see the delete through the retained source bodies (the
+    // horizon-aware sweep keeps them). This is what stops a delete-heavy
+    // workload from carrying its tombstones forever.
+    if gc_tombstones {
+        rows.retain(|r| !matches!(r.op, MemOp::Tombstone));
+    }
     let finish = build_node_sst(label_def, &rows)?;
     // Caller (`put_node_sst_l1`) consumes the merged rows to re-emit
     // the unique-property side-cars; without this, post-compaction
@@ -446,6 +487,11 @@ fn compact_edge_ssts(
             .then(b.lsn.cmp(&a.lsn))
     });
     rows.dedup_by_key(|r| (r.key_id, r.partner_id));
+    // Tombstone GC (RFC-027 P3), same reasoning as the node path: a
+    // full-bucket merge is authoritative for the (edge_type, direction)
+    // bucket, so a winning tombstone shadows nothing in the new version and
+    // is dropped. Old readers see the delete through retained source bodies.
+    rows.retain(|r| !r.tombstone);
 
     build_edge_sst(edge_type, edge_def, &rows, direction)
 }
@@ -978,13 +1024,113 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(out.source_ssts_removed, 2);
-        assert_eq!(out.new_ssts_written, 1);
+        // RFC-027 P3: the winning op for `alice` is a tombstone, so the
+        // full-bucket merge drops it entirely — the node bucket is now empty
+        // and no L1 SST is written at all (the delete is fully reclaimed).
+        assert_eq!(out.new_ssts_written, 0);
 
         let mt = Memtable::new();
         let mt_view = mt.snapshot_view();
         let snap = Snapshot::new(out.committed.clone(), &mt_view, s, p);
         let v = snap.lookup_node("Person", alice).await.unwrap();
-        assert!(v.is_none(), "tombstone in L1 must hide the upsert");
+        assert!(v.is_none(), "the deleted node stays absent after GC");
+    }
+
+    #[tokio::test]
+    async fn full_bucket_compaction_gcs_tombstone_arriving_after_l1() {
+        // Steady-state GC: alice+bob land and compact to an L1, then alice is
+        // deleted in a later flush. The next compaction is full-bucket (it
+        // pulls the prior L1 in as a source), so alice's tombstone is GC'd
+        // without resurrecting her, bob survives, and the bucket stays at one
+        // L1. This is the case a pure L0->L1 merge could never reclaim.
+        let s = store();
+        let p = paths("compact-gc-steady");
+        let ms = ManifestStore::new(s.clone(), p.clone());
+        let mut base = ms.bootstrap(Uuid::now_v7()).await.unwrap();
+        // Seed the dict so the on-row LabelId(0) resolves to "Person".
+        base.manifest.label_dict.intern("Person");
+        let fence = WriterFence::new(base.manifest.epoch);
+
+        let alice = sorted_node_id(1);
+        let bob = sorted_node_id(2);
+
+        // Flush alice (L0 #1) and bob (L0 #2), then compact to one L1.
+        let mut mt1 = Memtable::new();
+        mt1.apply(
+            MemKey::Node { id: alice },
+            1,
+            MemOp::Upsert(node_payload("Alice", Some(30))),
+        );
+        let after1 = flush(&ms, &fence, &base, &mt1.freeze(), schema())
+            .await
+            .unwrap();
+        let mut mt2 = Memtable::new();
+        mt2.apply(
+            MemKey::Node { id: bob },
+            2,
+            MemOp::Upsert(node_payload("Bob", Some(40))),
+        );
+        let after2 = flush(&ms, &fence, &after1.committed, &mt2.freeze(), schema())
+            .await
+            .unwrap();
+        let comp1 = compact_l0_to_l1(&ms, &fence, &after2.committed, &schema())
+            .await
+            .unwrap();
+        assert_eq!(comp1.new_ssts_written, 1, "alice+bob collapse to one L1");
+        let l1_count = comp1
+            .committed
+            .manifest
+            .ssts
+            .iter()
+            .filter(|d| d.kind == SstKind::Nodes)
+            .count();
+        assert_eq!(l1_count, 1);
+
+        // Delete alice in a later flush (L0 #3).
+        let mut mt3 = Memtable::new();
+        mt3.apply(MemKey::Node { id: alice }, 9, MemOp::Tombstone);
+        let after3 = flush(&ms, &fence, &comp1.committed, &mt3.freeze(), schema())
+            .await
+            .unwrap();
+
+        // Full-bucket compaction: prior L1 + the tombstone L0 are both
+        // sources, so alice's tombstone is dropped and bob is kept.
+        let comp2 = compact_l0_to_l1(&ms, &fence, &after3.committed, &schema())
+            .await
+            .unwrap();
+        assert_eq!(
+            comp2.source_ssts_removed, 2,
+            "the prior L1 and the tombstone L0 are both merged"
+        );
+        assert_eq!(comp2.new_ssts_written, 1, "bob remains in one L1");
+        let node_ssts = comp2
+            .committed
+            .manifest
+            .ssts
+            .iter()
+            .filter(|d| d.kind == SstKind::Nodes)
+            .collect::<Vec<_>>();
+        assert_eq!(node_ssts.len(), 1, "bucket stays at one L1");
+        let tombstone_count = match &node_ssts[0].kind_specific {
+            KindSpecificStats::Nodes { tombstone_count } => *tombstone_count,
+            other => panic!("expected node stats, got {other:?}"),
+        };
+        assert_eq!(
+            tombstone_count, 0,
+            "the GC'd tombstone is not carried into the new L1"
+        );
+
+        let mt = Memtable::new();
+        let mt_view = mt.snapshot_view();
+        let snap = Snapshot::new(comp2.committed.clone(), &mt_view, s, p);
+        assert!(
+            snap.lookup_node("Person", alice).await.unwrap().is_none(),
+            "alice stays deleted after GC, not resurrected"
+        );
+        assert!(
+            snap.lookup_node("Person", bob).await.unwrap().is_some(),
+            "bob survives the GC compaction"
+        );
     }
 
     #[tokio::test]

--- a/crates/namidb-storage/src/ingest.rs
+++ b/crates/namidb-storage/src/ingest.rs
@@ -60,7 +60,9 @@ use crate::compact::{compact_l0_to_l1, CompactionOutcome};
 use crate::error::{Error, Result};
 use crate::fence::WriterFence;
 use crate::flush::{flush, EdgeWriteRecord, FlushOutcome, NodeWriteRecord};
-use crate::manifest::{LoadedManifest, Manifest, ManifestStore, WalSegmentDescriptor};
+use crate::manifest::{
+    LoadedManifest, Manifest, ManifestStore, SstKind, SstLevel, WalSegmentDescriptor,
+};
 use crate::memtable::{MemKey, MemOp, Memtable, MemtableSnapshot};
 use crate::node_cache::{node_cache_budget_bytes, node_cache_enabled, NodeViewCache};
 use crate::paths::NamespacePaths;
@@ -307,6 +309,23 @@ impl WriterSession {
     /// Current manifest version visible to this writer.
     pub fn manifest_version(&self) -> u64 {
         self.current.manifest.version
+    }
+
+    /// The largest number of L0 SSTs in any single `(kind, scope)` bucket
+    /// of the current manifest. A point lookup on a bucket pays an
+    /// `O(L0 count)` candidate scan, so this is the worst-case read
+    /// amplification right now. The server uses it to trigger compaction
+    /// reactively (rather than only on the periodic tick) and to apply a
+    /// soft write stall when L0 outpaces compaction (RFC-027 P5).
+    pub fn max_l0_bucket_len(&self) -> usize {
+        let mut counts: std::collections::HashMap<(SstKind, &str), usize> =
+            std::collections::HashMap::new();
+        for sst in &self.current.manifest.ssts {
+            if sst.level == SstLevel::L0 {
+                *counts.entry((sst.kind, sst.scope.as_str())).or_insert(0) += 1;
+            }
+        }
+        counts.values().copied().max().unwrap_or(0)
     }
 
     /// Number of mutations queued and not yet durable.
@@ -1796,6 +1815,36 @@ mod tests {
         // Nothing was applied to the memtable: the batch never ACKed.
         let snap = session.snapshot();
         assert!(snap.lookup_node("Person", alice).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn max_l0_bucket_len_counts_l0_and_drops_after_compaction() {
+        // RFC-027 P5 signal: each flush adds one L0 SST to the node bucket,
+        // so the worst-bucket L0 count grows with flushes and collapses to
+        // zero L0 once compaction folds them into an L1.
+        let store = make_store();
+        let paths = make_paths("ingest-l0-count");
+        let mut session = WriterSession::open(store, paths).await.unwrap();
+        assert_eq!(session.max_l0_bucket_len(), 0);
+
+        for i in 0..3u8 {
+            session
+                .upsert_node("Person", sorted_node_id(i), &node_record("p", None))
+                .unwrap();
+            session.flush(schema()).await.unwrap();
+        }
+        assert_eq!(
+            session.max_l0_bucket_len(),
+            3,
+            "three flushes leave three L0 SSTs in the node bucket"
+        );
+
+        session.compact_l0(&schema()).await.unwrap();
+        assert_eq!(
+            session.max_l0_bucket_len(),
+            0,
+            "compaction folds the L0 SSTs into an L1, clearing the L0 count"
+        );
     }
 
     #[tokio::test]

--- a/crates/namidb-storage/src/ingest.rs
+++ b/crates/namidb-storage/src/ingest.rs
@@ -404,6 +404,59 @@ impl WriterSession {
         snap
     }
 
+    /// Read-your-own-writes snapshot (RFC-026): the committed
+    /// [`snapshot`](Self::snapshot) with this writer's staged-but-
+    /// uncommitted batch overlaid on top, so a read sub-plan that runs
+    /// after a `CREATE`/`MERGE`/`SET`/`DELETE` in the same statement or
+    /// transaction sees the staged work. Reads outside a write context
+    /// keep using [`snapshot`](Self::snapshot); there is nothing staged
+    /// for them to see.
+    ///
+    /// When nothing is staged this is exactly [`snapshot`](Self::snapshot)
+    /// (same caches, no overlay), so a write statement's first read before
+    /// any mutation pays nothing.
+    ///
+    /// The overlay is built from `pending_payloads`, so it reflects exactly
+    /// what [`commit_batch`](Self::commit_batch) would make durable. The
+    /// cross-snapshot NodeView and property-index caches are deliberately
+    /// NOT attached: they are keyed by manifest version and shared across
+    /// sessions, so caching a staged (uncommitted) row in them would leak
+    /// it to a concurrent reader pinned at the same version. The immutable
+    /// SST/adjacency body caches are safe to keep.
+    pub fn overlay_snapshot(&self) -> Snapshot<'_> {
+        if self.pending_payloads.is_empty() {
+            return self.snapshot();
+        }
+        // Materialise the staged batch as a second memtable. `apply` in
+        // pending (LSN-ascending) order leaves each key at its highest-LSN
+        // op, exactly as `commit_batch` would drain it into the live
+        // memtable.
+        let mut staged = Memtable::new();
+        for (key, lsn, op) in &self.pending_payloads {
+            staged.apply(key.clone(), *lsn, op.clone());
+        }
+        // Resolve labels through the writer's live dictionary, not the
+        // committed manifest's: a node staged in this batch may carry a
+        // label name first interned in the same batch, which the committed
+        // `current.manifest.label_dict` does not know about yet. The live
+        // dict is a superset, so committed labels still resolve.
+        let mut current = self.current.clone();
+        current.manifest.label_dict = self.label_dict.clone();
+        let mut snap = Snapshot::new(
+            current,
+            &self.published_memtable,
+            self.manifest_store.store().clone(),
+            self.manifest_store.paths().clone(),
+        );
+        if let Some(cache) = &self.sst_cache {
+            snap = snap.with_cache(cache.clone());
+        }
+        if let Some(cache) = &self.adjacency_cache {
+            snap = snap.with_adjacency_cache(cache.clone());
+        }
+        snap.with_overlay(staged.snapshot_view())
+    }
+
     /// Schema of the current manifest version. The write path consults it to
     /// enforce declared constraints (e.g. unique properties) before staging
     /// a mutation.
@@ -1094,6 +1147,66 @@ mod tests {
             view.properties.get("name"),
             Some(&Value::Str("Alice".into()))
         );
+    }
+
+    #[tokio::test]
+    async fn overlay_snapshot_sees_staged_batch_but_plain_snapshot_does_not() {
+        // RFC-026 read-your-own-writes at the storage layer: a writer's
+        // staged-but-uncommitted batch is visible through `overlay_snapshot`
+        // (a staged upsert appears, a staged tombstone hides a committed
+        // row) while `snapshot` keeps showing only committed state.
+        let store = make_store();
+        let paths = make_paths("ingest-overlay");
+        let mut session = WriterSession::open(store, paths).await.unwrap();
+
+        // Commit Alice so there is committed state to overlay on top of.
+        let alice = sorted_node_id(1);
+        session
+            .upsert_node("Person", alice, &node_record("Alice", Some(30)))
+            .unwrap();
+        session.commit_batch().await.unwrap();
+
+        // Stage Bob (create) and a tombstone of Alice (delete), no commit.
+        let bob = sorted_node_id(2);
+        session
+            .upsert_node("Person", bob, &node_record("Bob", Some(40)))
+            .unwrap();
+        session.tombstone_node("Person", alice).unwrap();
+
+        // Plain snapshot: committed only — Alice visible, Bob not.
+        let committed = session.snapshot();
+        assert!(committed
+            .lookup_node("Person", alice)
+            .await
+            .unwrap()
+            .is_some());
+        assert!(committed
+            .lookup_node("Person", bob)
+            .await
+            .unwrap()
+            .is_none());
+        assert_eq!(committed.scan_label("Person").await.unwrap().len(), 1);
+        drop(committed);
+
+        // Overlay snapshot: Bob is visible; Alice is hidden by the staged
+        // tombstone; the label scan reflects exactly the staged batch.
+        let overlay = session.overlay_snapshot();
+        assert!(overlay.lookup_node("Person", bob).await.unwrap().is_some());
+        assert!(overlay
+            .lookup_node("Person", alice)
+            .await
+            .unwrap()
+            .is_none());
+        let scanned = overlay.scan_label("Person").await.unwrap();
+        assert_eq!(scanned.len(), 1);
+        assert_eq!(scanned[0].id, bob);
+        drop(overlay);
+
+        // Nothing staged: overlay_snapshot collapses to the committed view.
+        session.discard_batch();
+        let after = session.overlay_snapshot();
+        assert!(after.lookup_node("Person", alice).await.unwrap().is_some());
+        assert!(after.lookup_node("Person", bob).await.unwrap().is_none());
     }
 
     #[tokio::test]

--- a/crates/namidb-storage/src/janitor.rs
+++ b/crates/namidb-storage/src/janitor.rs
@@ -22,30 +22,30 @@
 //!
 //! ## What the janitor does
 //!
-//! 1. Loads `manifest/current.json` and builds the set of "live" relative
-//! paths from `Manifest::ssts[i].path` and `Manifest::ssts[i].bloom`.
+//! 1. Loads `manifest/current.json` and, for every manifest version from
+//! the caller-supplied retention horizon to current, unions the "live"
+//! relative paths (SST body, bloom side-car, unique/equality/label index
+//! side-cars). The horizon is the oldest version any live reader is
+//! pinned to (RFC-027), so a reader still reading an old version keeps
+//! every object that version needs in the live set.
 //! 2. Lists `sst/level0/`, `sst/level1/`, … up to a configurable max level.
 //! 3. For every listed object not in the live set, checks its
 //! `last_modified` age. Any object younger than `min_age` is skipped —
-//! this is the safety margin against in-flight writers whose body PUT
-//! succeeded a moment ago and whose manifest CAS is still in flight.
+//! this is a secondary guard against an in-flight writer whose body PUT
+//! succeeded a moment ago and whose manifest CAS is still in flight (the
+//! object is referenced by no version yet).
 //! 4. Older objects are reported as orphans and (when `delete = true`)
 //! removed via `ObjectStore::delete`.
 //!
-//! ## Production discipline
+//! ## Safety
 //!
-//! - **Operate on dry-run mode first.** `delete = false` returns the same
-//! [`JanitorReport`] without mutating the store. Skim the report before
-//! enabling deletion in a new environment.
-//! - **Pick `min_age` conservatively.** 24 h is a safe default for most
-//! deployments; lower values can keep storage cleaner but risk racing a
-//! slow writer.
-//! - **Snapshot pinning.** A long-running reader pinned on a manifest
-//! version older than the current one may still reference an SST that
-//! compaction removed. Either the operator runs the janitor with a
-//! safety window larger than the longest expected snapshot lifetime,
-//! or a future "snapshot anchor" RFC pins those SSTs via a side-table.
-//! Until then, prefer the conservative `min_age`.
+//! The retention horizon is the correctness mechanism: an object the sweep
+//! deletes is referenced by no manifest version at or above the horizon, so
+//! no live reader can reach it. This covers both compaction inputs merged
+//! away before the horizon and orphans from failed commits, with no
+//! time-based guess. `min_age` remains as a small secondary guard for the
+//! body-PUT-then-CAS race; `delete = false` keeps a dry-run available for
+//! operators who want to review a run before trusting it.
 
 use std::collections::HashSet;
 
@@ -90,6 +90,7 @@ pub struct JanitorReport {
  skip(manifest_store),
  fields(
  namespace = %manifest_store.paths().namespace(),
+ retention_horizon,
  min_age_secs = min_age.as_secs(),
  delete,
  max_level,
@@ -97,30 +98,53 @@ pub struct JanitorReport {
 )]
 pub async fn sweep_orphans(
     manifest_store: &ManifestStore,
+    retention_horizon: u64,
     min_age: std::time::Duration,
     max_level: u32,
     delete: bool,
 ) -> Result<JanitorReport> {
-    let manifest = manifest_store.load_current().await?;
+    let current = manifest_store.load_current().await?;
+    let current_version = current.manifest.version;
+    // The horizon is the oldest manifest version any live reader is pinned
+    // to (RFC-027). Clamp defensively to the current version.
+    let horizon = retention_horizon.min(current_version);
+
+    // Build the live object set from the union of every retained manifest
+    // version from the horizon to current (inclusive). A reader pinned at
+    // `horizon` still needs every object that version references, so none of
+    // them can be swept; an object only an older version referenced (a
+    // compaction input merged away before the horizon, say) drops out of the
+    // set and becomes reclaimable. This is what makes deletion safe by
+    // construction rather than by a wall-clock guess.
     let mut referenced: HashSet<String> = HashSet::new();
-    for desc in &manifest.manifest.ssts {
-        referenced.insert(desc.path.clone());
-        if let Some(b) = &desc.bloom {
-            referenced.insert(b.path.clone());
+    let mut mark_live = |ssts: &[crate::manifest::SstDescriptor]| {
+        for desc in ssts {
+            referenced.insert(desc.path.clone());
+            if let Some(b) = &desc.bloom {
+                referenced.insert(b.path.clone());
+            }
+            // Side-car bodies live in the same `sst/level{N}/` prefix the
+            // sweep scans, so they must be marked live too — otherwise the
+            // sweep deletes unique/equality/label-index side-cars a retained
+            // manifest still references, breaking point lookups and (with the
+            // typed-column layout) label scans.
+            for u in &desc.unique_property_indices {
+                referenced.insert(u.path.clone());
+            }
+            for e in &desc.equality_property_indices {
+                referenced.insert(e.path.clone());
+            }
+            if let Some(li) = &desc.label_index {
+                referenced.insert(li.path.clone());
+            }
         }
-        // Side-car bodies live in the same `sst/level{N}/` prefix the sweep
-        // scans, so they must be marked live too — otherwise the sweep deletes
-        // unique/equality/label-index side-cars that the current manifest still
-        // references, breaking point lookups and (with the typed-column layout)
-        // label scans.
-        for u in &desc.unique_property_indices {
-            referenced.insert(u.path.clone());
-        }
-        for e in &desc.equality_property_indices {
-            referenced.insert(e.path.clone());
-        }
-        if let Some(li) = &desc.label_index {
-            referenced.insert(li.path.clone());
+    };
+    for version in horizon..=current_version {
+        if version == current_version {
+            mark_live(&current.manifest.ssts);
+        } else {
+            let manifest = manifest_store.load_manifest_at(version).await?;
+            mark_live(&manifest.ssts);
         }
     }
 
@@ -252,7 +276,7 @@ mod tests {
 
         let _after = flush_one_node(&ms, &fence, &base, &schema, sorted_node_id(1), "A", 1).await;
 
-        let report = sweep_orphans(&ms, Duration::from_secs(0), 4, true)
+        let report = sweep_orphans(&ms, u64::MAX, Duration::from_secs(0), 4, true)
             .await
             .unwrap();
         assert_eq!(report.orphans_found, 0);
@@ -280,7 +304,7 @@ mod tests {
         store.put(&orphan, PutPayload::from(body)).await.unwrap();
 
         // Dry run: report should flag the orphan but the body must remain.
-        let dry = sweep_orphans(&ms, Duration::from_secs(0), 4, false)
+        let dry = sweep_orphans(&ms, u64::MAX, Duration::from_secs(0), 4, false)
             .await
             .unwrap();
         assert_eq!(dry.orphans_found, 1);
@@ -289,7 +313,7 @@ mod tests {
         assert!(store.head(&orphan).await.is_ok(), "dry run must not delete");
 
         // Real run: deletes the orphan.
-        let real = sweep_orphans(&ms, Duration::from_secs(0), 4, true)
+        let real = sweep_orphans(&ms, u64::MAX, Duration::from_secs(0), 4, true)
             .await
             .unwrap();
         assert_eq!(real.orphans_found, 1);
@@ -301,7 +325,7 @@ mod tests {
         );
 
         // Idempotent: a second sweep finds nothing.
-        let again = sweep_orphans(&ms, Duration::from_secs(0), 4, true)
+        let again = sweep_orphans(&ms, u64::MAX, Duration::from_secs(0), 4, true)
             .await
             .unwrap();
         assert_eq!(again.orphans_found, 0);
@@ -322,7 +346,7 @@ mod tests {
             .unwrap();
 
         // min_age = 24h → the freshly-written orphan must be skipped.
-        let report = sweep_orphans(&ms, Duration::from_secs(86_400), 4, true)
+        let report = sweep_orphans(&ms, u64::MAX, Duration::from_secs(86_400), 4, true)
             .await
             .unwrap();
         assert_eq!(report.orphans_found, 0);
@@ -354,7 +378,7 @@ mod tests {
             .unwrap();
 
         // max_level = 1 catches only the L0 body.
-        let report = sweep_orphans(&ms, Duration::from_secs(0), 1, true)
+        let report = sweep_orphans(&ms, u64::MAX, Duration::from_secs(0), 1, true)
             .await
             .unwrap();
         assert_eq!(report.orphans_found, 1);

--- a/crates/namidb-storage/src/lib.rs
+++ b/crates/namidb-storage/src/lib.rs
@@ -60,7 +60,9 @@ pub use node_cache::{
 };
 pub use parquet_loader::{load_nodes as load_nodes_from_parquet, LoadOutcome};
 pub use paths::NamespacePaths;
-pub use read::{EdgeListView, EdgeView, NodeView, OwnedSnapshot, Snapshot, SnapshotCell};
+pub use read::{
+    EdgeListView, EdgeView, NodeView, OwnedSnapshot, PinnedSnapshot, Snapshot, SnapshotCell,
+};
 pub use recovery::{
     recover_memtable, recover_memtable_with_snapshot, write_memtable_snapshot,
     MemtableSnapshotEntry, MemtableSnapshotFile, RecoveredMemtable, WalEntry, WalOp,

--- a/crates/namidb-storage/src/manifest.rs
+++ b/crates/namidb-storage/src/manifest.rs
@@ -491,6 +491,19 @@ impl ManifestStore {
         ))
     }
 
+    /// Load a specific historical manifest version's immutable body
+    /// (`manifest/v{version}.json`). Manifest bodies are written once per
+    /// commit / flush / compaction and never mutated, so every version from
+    /// genesis to current is readable. The horizon-aware sweep uses this to
+    /// union the live object set across every retained version.
+    pub async fn load_manifest_at(&self, version: u64) -> Result<Manifest> {
+        let path = self.paths.manifest_version(version);
+        let res = self.store.get(&path).await?;
+        let body = res.bytes().await?;
+        let manifest: Manifest = serde_json::from_slice(&body)?;
+        Ok(manifest)
+    }
+
     /// Read `current.json`, then read the manifest it points at.
     #[instrument(skip(self), fields(namespace = %self.paths.namespace()))]
     pub async fn load_current(&self) -> Result<LoadedManifest> {

--- a/crates/namidb-storage/src/read.rs
+++ b/crates/namidb-storage/src/read.rs
@@ -67,7 +67,7 @@ use crate::cache::{EdgeStreamBundle, SstCache};
 use crate::error::{Error, Result};
 use crate::flush::{EdgeWriteRecord, NodeWriteRecord};
 use crate::manifest::{LoadedManifest, SstDescriptor, SstKind};
-use crate::memtable::{MemKey, MemOp, MemtableSnapshot};
+use crate::memtable::{MemEntry, MemKey, MemOp, MemtableSnapshot};
 use crate::node_cache::{NodeCacheKey, NodeViewCache};
 use crate::paths::NamespacePaths;
 use crate::sst::bloom::BloomFilter;
@@ -196,6 +196,20 @@ pub struct Snapshot<'mt> {
     /// per-parent batch calls the factor-path executor issues during a
     /// 2-hop Expand chain (LDBC SNB IC09: 150+ calls/query).
     decoded_node_sst_batches: Mutex<HashMap<String, Arc<Vec<RecordBatch>>>>,
+    /// Read-your-own-writes overlay (RFC-026). A writer's staged-but-
+    /// uncommitted batch, materialised as a second memtable and consulted
+    /// alongside the committed `memtable` on the node read paths. The
+    /// staged ops carry LSNs strictly greater than any committed LSN, so
+    /// the existing last-LSN-wins merge resolves a staged upsert over the
+    /// committed row and a staged tombstone hides it — no separate read
+    /// engine. `None` for every read outside a write context (auto-commit
+    /// reads, the HTTP read path, the Bolt auto-commit branch), which is
+    /// the only behaviour that changes nothing.
+    ///
+    /// v1 wires the node read paths only; edges are a fast follow (RFC-026
+    /// Q1). Edge entries staged in the batch are present in this overlay
+    /// but not yet consulted by the edge read methods.
+    overlay: Option<MemtableSnapshot>,
 }
 
 /// Cold-path routing policy for [`Snapshot::lookup_node`]. See
@@ -253,6 +267,7 @@ impl<'mt> Snapshot<'mt> {
             shared_node_cache: None,
             property_index_cache: None,
             decoded_node_sst_batches: Mutex::new(HashMap::new()),
+            overlay: None,
         }
     }
 
@@ -316,6 +331,62 @@ impl<'mt> Snapshot<'mt> {
         self
     }
 
+    /// Attach a read-your-own-writes overlay (RFC-026): a writer's staged
+    /// batch, materialised as a second memtable, that the node read paths
+    /// consult alongside the committed `memtable`. Built by
+    /// [`crate::ingest::WriterSession::overlay_snapshot`]. See the
+    /// [`Self::overlay`] field for the merge semantics.
+    pub fn with_overlay(mut self, overlay: MemtableSnapshot) -> Self {
+        self.overlay = Some(overlay);
+        self
+    }
+
+    /// Node memtable entries to merge at read time: the committed
+    /// `memtable`, with the staged overlay (RFC-026) chained on when this
+    /// is an overlay snapshot. Staged LSNs are strictly greater than any
+    /// committed LSN, so callers' [`update_node_winner`] last-LSN-wins
+    /// merge picks the staged op for a key present in both. The overlay
+    /// yields only `MemKey::Node` entries, matching `iter_nodes`.
+    fn node_entries(&self) -> impl Iterator<Item = (&MemKey, &MemEntry)> {
+        self.memtable
+            .iter_nodes()
+            .chain(self.overlay.iter().flat_map(|o| o.iter_nodes()))
+    }
+
+    /// Point read of a single node's memtable entry with the staged
+    /// overlay (RFC-026) winning when present. A staged tombstone returns
+    /// the tombstone entry (high LSN), so the caller's last-LSN-wins merge
+    /// hides the committed row.
+    ///
+    /// Staged LSNs are strictly greater than any committed LSN (the writer
+    /// seeds `next_lsn` past every committed LSN on open). We compare the
+    /// two LSNs anyway, rather than blindly trusting the overlay, so a
+    /// future regression in LSN allocation degrades to the same
+    /// last-LSN-wins rule the scan path uses instead of silently surfacing
+    /// a stale row.
+    fn node_mem_entry(&self, id: NodeId) -> Option<&MemEntry> {
+        let key = MemKey::Node { id };
+        let committed = self.memtable.get(&key);
+        let staged = self.overlay.as_ref().and_then(|o| o.get(&key));
+        match (staged, committed) {
+            (Some(s), Some(c)) => {
+                debug_assert!(
+                    s.lsn > c.lsn,
+                    "overlay LSN {} must exceed committed LSN {}",
+                    s.lsn,
+                    c.lsn
+                );
+                if s.lsn >= c.lsn {
+                    Some(s)
+                } else {
+                    Some(c)
+                }
+            }
+            (Some(s), None) => Some(s),
+            (None, c) => c,
+        }
+    }
+
     /// Point-lookup a node by a *unique* user property. The first call
     /// per (label, prop) pays a full label scan to populate the
     /// cross-snapshot cache; subsequent calls are `O(1)`. Caller is
@@ -369,7 +440,7 @@ impl<'mt> Snapshot<'mt> {
             // ours. Materialise as a full label scan over the memtable
             // — bounded by memtable size, not the SST.
             let mut winner: Option<(u64, namidb_core::id::NodeId, bool)> = None;
-            for (mk, e) in self.memtable.iter() {
+            for (mk, e) in self.node_entries() {
                 if let MemKey::Node { id } = mk {
                     match &e.op {
                         MemOp::Upsert(payload) => {
@@ -538,7 +609,7 @@ impl<'mt> Snapshot<'mt> {
         // union of every SST posting list under `value`.
         let mut candidates: std::collections::BTreeSet<namidb_core::id::NodeId> =
             std::collections::BTreeSet::new();
-        for (mk, e) in self.memtable.iter() {
+        for (mk, e) in self.node_entries() {
             if let MemKey::Node { id } = mk {
                 if let MemOp::Upsert(payload) = &e.op {
                     let rec = NodeWriteRecord::decode(payload)?;
@@ -1038,7 +1109,7 @@ impl<'mt> Snapshot<'mt> {
         // 1. Memtable: probe each pending id.
         for id_bytes in &pending {
             let id = NodeId::from_uuid(Uuid::from_bytes(*id_bytes));
-            if let Some(entry) = self.memtable.get(&MemKey::Node { id }) {
+            if let Some(entry) = self.node_mem_entry(id) {
                 let view = match &entry.op {
                     MemOp::Tombstone => None,
                     MemOp::Upsert(payload) => Some(node_view_from_payload(
@@ -1191,7 +1262,7 @@ impl<'mt> Snapshot<'mt> {
         let mut winner: Option<(u64, Option<NodeView>)> = None;
 
         // 1. Memtable (highest LSN typically).
-        if let Some(entry) = self.memtable.get(&MemKey::Node { id }) {
+        if let Some(entry) = self.node_mem_entry(id) {
             let view = match &entry.op {
                 MemOp::Tombstone => None,
                 MemOp::Upsert(payload) => {
@@ -1349,7 +1420,7 @@ impl<'mt> Snapshot<'mt> {
         // 1. Memtable rows. Apply predicates after materialising the view; a
         // failing predicate yields a tombstone-like None so a lower-LSN SST row
         // for the same id is not spuriously surfaced.
-        for (mk, entry) in self.memtable.iter() {
+        for (mk, entry) in self.node_entries() {
             let MemKey::Node { id } = mk else {
                 continue;
             };

--- a/crates/namidb-storage/src/read.rs
+++ b/crates/namidb-storage/src/read.rs
@@ -2859,6 +2859,96 @@ impl OwnedSnapshot {
     }
 }
 
+/// Tracks the manifest versions live readers are pinned to (RFC-027).
+///
+/// Each [`SnapshotCell::load`] registers the version of the snapshot it
+/// hands out; the returned [`PinnedSnapshot`] deregisters it on drop. The
+/// compactor's sweep and version GC read the resulting retention horizon —
+/// the oldest version any reader could still need — so they never reclaim
+/// an object a live reader can still reach. `min_live()` is monotonically
+/// non-decreasing while a given set of readers runs (readers only ever
+/// register the current version, which increases), so a sweep that samples
+/// it gets a safe lower bound.
+#[derive(Debug, Default)]
+struct SnapshotRegistry {
+    /// `manifest version -> number of live readers pinned to it`.
+    live: std::sync::Mutex<BTreeMap<u64, usize>>,
+}
+
+impl SnapshotRegistry {
+    fn acquire(&self, version: u64) {
+        *self
+            .live
+            .lock()
+            .expect("snapshot registry poisoned")
+            .entry(version)
+            .or_insert(0) += 1;
+    }
+
+    fn release(&self, version: u64) {
+        let mut g = self.live.lock().expect("snapshot registry poisoned");
+        if let Some(count) = g.get_mut(&version) {
+            *count -= 1;
+            if *count == 0 {
+                g.remove(&version);
+            }
+        }
+    }
+
+    /// Oldest manifest version any live reader is pinned to, or `None` when
+    /// no reader is active.
+    fn min_live(&self) -> Option<u64> {
+        self.live
+            .lock()
+            .expect("snapshot registry poisoned")
+            .keys()
+            .next()
+            .copied()
+    }
+}
+
+/// An [`OwnedSnapshot`] handed to a reader with its manifest version
+/// registered as live for the duration (RFC-027). Deref-transparent to
+/// `OwnedSnapshot`, so call sites use `.borrow()` / `.manifest()` as
+/// before. Dropping it releases the reader's hold on the retention
+/// horizon, letting the sweep / GC reclaim that version once no reader
+/// needs it.
+pub struct PinnedSnapshot {
+    snap: Arc<OwnedSnapshot>,
+    registry: Arc<SnapshotRegistry>,
+    version: u64,
+}
+
+impl std::ops::Deref for PinnedSnapshot {
+    type Target = OwnedSnapshot;
+    fn deref(&self) -> &OwnedSnapshot {
+        &self.snap
+    }
+}
+
+impl Drop for PinnedSnapshot {
+    fn drop(&mut self) {
+        self.registry.release(self.version);
+    }
+}
+
+impl PinnedSnapshot {
+    /// Clone the shared `Arc` for callers that need to store or republish
+    /// it. The clone is NOT separately registered; the horizon hold lives
+    /// with this `PinnedSnapshot`.
+    pub fn arc(&self) -> Arc<OwnedSnapshot> {
+        Arc::clone(&self.snap)
+    }
+}
+
+impl std::fmt::Debug for PinnedSnapshot {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("PinnedSnapshot")
+            .field("version", &self.version)
+            .finish()
+    }
+}
+
 /// Atomic publisher cell for the currently-active [`OwnedSnapshot`].
 ///
 /// `SnapshotCell` is the lock-light handoff between the writer (which
@@ -2873,21 +2963,34 @@ impl OwnedSnapshot {
 #[derive(Debug)]
 pub struct SnapshotCell {
     inner: std::sync::Mutex<Arc<OwnedSnapshot>>,
+    registry: Arc<SnapshotRegistry>,
 }
 
 impl SnapshotCell {
     pub fn new(snap: Arc<OwnedSnapshot>) -> Self {
         Self {
             inner: std::sync::Mutex::new(snap),
+            registry: Arc::new(SnapshotRegistry::default()),
         }
     }
 
-    /// Pick up the current snapshot. Cheap: one mutex acquire plus
-    /// one `Arc::clone`. The returned `Arc` is independent of any
-    /// future `store` calls, so the read can run for as long as it
-    /// needs without holding any cell lock.
-    pub fn load(&self) -> Arc<OwnedSnapshot> {
-        Arc::clone(&self.inner.lock().expect("snapshot cell poisoned"))
+    /// Pick up the current snapshot, registering its version as live until
+    /// the returned [`PinnedSnapshot`] drops. Cheap: one mutex acquire plus
+    /// an `Arc::clone` and a counter bump. The version is registered while
+    /// the cell lock is held, so it is selected and recorded atomically and
+    /// the retention horizon never excludes a version a reader is about to
+    /// read.
+    pub fn load(&self) -> PinnedSnapshot {
+        let guard = self.inner.lock().expect("snapshot cell poisoned");
+        let snap = Arc::clone(&guard);
+        let version = snap.manifest_version();
+        self.registry.acquire(version);
+        drop(guard);
+        PinnedSnapshot {
+            snap,
+            registry: Arc::clone(&self.registry),
+            version,
+        }
     }
 
     /// Publish a new snapshot. The previous Arc is dropped once
@@ -2904,6 +3007,20 @@ impl SnapshotCell {
             .lock()
             .expect("snapshot cell poisoned")
             .manifest_version()
+    }
+
+    /// Retention horizon (RFC-027): the oldest manifest version any live
+    /// reader is pinned to, or the currently-published version when no
+    /// reader is active. The sweep / GC may reclaim any object that no
+    /// manifest version at or above this references — by construction a
+    /// reader pinned at version `V` keeps the horizon at or below `V`, so
+    /// nothing `V` needs is collected.
+    pub fn retention_horizon(&self) -> u64 {
+        let current = self.manifest_version();
+        self.registry
+            .min_live()
+            .map(|m| m.min(current))
+            .unwrap_or(current)
     }
 }
 
@@ -4750,5 +4867,31 @@ mod tests {
         // happens to store it as Int64 in the SST, the declared type
         // is what surfaces in the schema introspection.
         assert_eq!(props.get("age"), Some(&DataType::Int32));
+    }
+
+    #[test]
+    fn snapshot_registry_tracks_oldest_live_version() {
+        // The retention horizon (RFC-027) is min_live(); it must reflect the
+        // oldest version with at least one live holder and advance only when
+        // every holder of that version releases.
+        let reg = SnapshotRegistry::default();
+        assert_eq!(reg.min_live(), None);
+
+        reg.acquire(5);
+        reg.acquire(7);
+        reg.acquire(5);
+        assert_eq!(reg.min_live(), Some(5));
+
+        reg.release(5);
+        assert_eq!(reg.min_live(), Some(5), "one holder of v5 remains");
+        reg.release(5);
+        assert_eq!(
+            reg.min_live(),
+            Some(7),
+            "v5 fully released, v7 is now the oldest live version"
+        );
+
+        reg.release(7);
+        assert_eq!(reg.min_live(), None, "no live readers");
     }
 }

--- a/docs/rfc/026-read-your-own-writes.md
+++ b/docs/rfc/026-read-your-own-writes.md
@@ -4,7 +4,7 @@
 **Author(s):** Matías Fonseca <info@namidb.com>
 **Created:** 2026-06-05
 **Updated:** 2026-06-05
-**Implements:** (pending)
+**Implements:** node overlay (v1) landed; edge overlay pending (Q1)
 **Supersedes:** none
 
 ## Summary

--- a/docs/rfc/027-compaction-and-space-reclamation.md
+++ b/docs/rfc/027-compaction-and-space-reclamation.md
@@ -4,7 +4,7 @@
 **Author(s):** Matías Fonseca <info@namidb.com>
 **Created:** 2026-06-05
 **Updated:** 2026-06-05
-**Implements:** P1 (horizon) + P2 (horizon-aware sweep) + P3 (tombstone/version GC via full-bucket merge) landed; P4 (leveled), P5 (reactive trigger) pending
+**Implements:** P1 (horizon) + P2 (horizon-aware sweep) + P3 (tombstone/version GC via full-bucket merge) + P5 (reactive L0 trigger + soft write stall) landed; P4 (leveled compaction) deferred — see the follow-up note in Piece 1
 **Supersedes:** none
 
 ## Summary
@@ -76,6 +76,26 @@ The existing L0 to L1 merge becomes the first level transition; the merge
 machinery (`compact_node_ssts`, `compact_edge_ssts`) is reused, with the
 input set chosen by the level picker rather than always "all L0 in the
 bucket."
+
+**Status / follow-up (P4 deferred).** P1, P2, P3 and P5 have landed; P4 is
+deferred. Compaction today is full-bucket (every compaction merges all of a
+bucket's SSTs into one L1), which bounds space and read amplification but
+trades write amplification — it rewrites the whole bucket each time. True
+leveled compaction as described above needs key-range-partitioned SSTs
+(multiple non-overlapping files per level), which the current one-SST-per-
+bucket writer does not produce; that is its own piece of work.
+
+The interim plan for the follow-up is **leveled-lite**: keep one SST per
+`(bucket, level)` across L1..Lk with a per-level size budget
+(`budget(Li) = base * ratio^(i-1)`). Most compactions merge `L0 + L1 -> L1`
+(cheap); a level only cascades down (`Li + Li+1 -> Li+1`) when it exceeds
+its budget, so the large base level is rewritten rarely. Tombstone GC moves
+to "the merge whose output is the deepest occupied level," which is safe
+because the LSM invariant (lower level number holds the newer LSN for a
+key) guarantees any copy in a shallower level is newer and wins at read
+time, so dropping a deepest-level tombstone can never resurrect a row.
+Key-range-partitioned leveled (rewriting only overlapping ranges) is a
+later step on top of that.
 
 ### Piece 2: snapshot-retention horizon
 

--- a/docs/rfc/027-compaction-and-space-reclamation.md
+++ b/docs/rfc/027-compaction-and-space-reclamation.md
@@ -4,7 +4,7 @@
 **Author(s):** Matías Fonseca <info@namidb.com>
 **Created:** 2026-06-05
 **Updated:** 2026-06-05
-**Implements:** (pending)
+**Implements:** P1 (horizon) + P2 (horizon-aware sweep) landed; P3 (version GC), P4 (leveled), P5 (reactive trigger) pending
 **Supersedes:** none
 
 ## Summary

--- a/docs/rfc/027-compaction-and-space-reclamation.md
+++ b/docs/rfc/027-compaction-and-space-reclamation.md
@@ -4,7 +4,7 @@
 **Author(s):** Matías Fonseca <info@namidb.com>
 **Created:** 2026-06-05
 **Updated:** 2026-06-05
-**Implements:** P1 (horizon) + P2 (horizon-aware sweep) landed; P3 (version GC), P4 (leveled), P5 (reactive trigger) pending
+**Implements:** P1 (horizon) + P2 (horizon-aware sweep) + P3 (tombstone/version GC via full-bucket merge) landed; P4 (leveled), P5 (reactive trigger) pending
 **Supersedes:** none
 
 ## Summary


### PR DESCRIPTION
Implements the four production-readiness items from the prod audit, one per
commit so they can be reviewed (or split into separate PRs) independently.

## What's here

- **RFC-026 read-your-own-writes (node overlay)** `feat(rfc-026): ...`
  Reads in a write context resolve the writer's staged batch over the
  committed snapshot, so CREATE-then-MATCH, MERGE-after-CREATE, multi
  statement transactions, and intra-batch unique dedup behave correctly.
  Cross-session isolation preserved (shared caches not attached on overlay
  snapshots). v1 covers nodes; staged edges are a fast follow.

- **Read query timeout** `feat(server): read query timeout`
  Task-local wall-clock deadline (NAMIDB_QUERY_TIMEOUT, default 30s),
  checked at operator boundaries and in the scan/expand loops. Read-only.

- **Query row cap** `feat(server): read query row cap`
  NAMIDB_QUERY_ROW_CAP bounds per-operator rows; cross product pre-checked
  before building, expand fails fast mid-loop. Flat and factor paths.

- **RFC-027 space reclamation** (4 commits)
  - P1 retention horizon + P2 horizon-aware orphan sweep, enabled by
    default (fixes the orphan-leak P0).
  - P3 full-bucket compaction with tombstone/version GC (deletes and
    updates no longer accumulate forever).
  - P5 reactive L0 compaction trigger + soft write stall.
  P4 (leveled compaction) is deferred; the leveled-lite follow-up design is
  sketched in docs/rfc/027.

## Notes for the reviewer

- Each commit is self-contained and green. `cargo fmt --all -- --check`,
  `cargo clippy --workspace --lib --tests --exclude namidb-py -D warnings`,
  and `cargo test --workspace --exclude namidb-py` all pass on the branch.
- This branch predates PR #79 (enforce unique constraints on SET), which
  also edits `crates/namidb-query/src/exec/writer.rs`. Expect a conflict
  there at merge; the two changes are in different areas (overlay snapshot
  wiring vs the SET constraint check) so resolution should be mechanical.
- Breaking: the orphan sweep now deletes by default (NAMIDB_SWEEP_DELETE
  defaults true; the retention horizon makes it safe), and
  `sweep_orphans` gained a `retention_horizon` parameter.