### PR TITLE
feat(rfc-026): read-your-own-writes overlay for edge traversals

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,22 @@ below and in the release notes.
 
 ## [Unreleased]
 
+### Added
+
+- Read-your-own-writes for edges (RFC-026 edge overlay). A traversal that
+  runs after an edge is staged in the same transaction now sees that edge:
+  every edge read path (`out_edges` / `in_edges` over both the SST scan and
+  the CSR adjacency, plus the WCOJ `sorted_partners` and the edge-type scan
+  and count) merges the writer's staged batch last-LSN-wins, so a staged
+  upsert is traversable and a staged tombstone hides a committed edge. This
+  completes the node overlay shipped in 0.13.0; a read against a plain
+  committed snapshot is unchanged, and reads outside a write context have
+  nothing staged and pay nothing. Running a read pipeline directly above a
+  write within one statement (`CREATE (a)-[:R]->(b) WITH a MATCH
+  (a)-[:R]->(x)`) is still a follow-up: the staged edge is visible to a later
+  statement or an in-transaction read, not to an expand stacked on the same
+  statement's write.
+
 ## [0.13.0] - 2026-06-07: read-your-own-writes for nodes, compaction space reclamation, query timeout and row cap
 
 ### Added

--- a/crates/namidb-query/tests/exec_writes.rs
+++ b/crates/namidb-query/tests/exec_writes.rs
@@ -15,7 +15,9 @@ use object_store::memory::InMemory;
 use object_store::ObjectStore;
 
 use namidb_query::cost::StatsCatalog;
-use namidb_query::{execute, execute_write, lower, optimize, parse, Params, RuntimeValue};
+use namidb_query::{
+    execute, execute_write, execute_write_staged, lower, optimize, parse, Params, RuntimeValue,
+};
 
 fn store() -> Arc<dyn ObjectStore> {
     Arc::new(InMemory::new())
@@ -1032,6 +1034,62 @@ async fn create_then_match_in_one_statement_reads_own_write() {
         }
         other => panic!("expected node p, got {other:?}"),
     }
+}
+
+#[tokio::test]
+async fn staged_edge_is_traversable_via_overlay_snapshot() {
+    // RFC-026 edge overlay at the query boundary: an edge staged by a write
+    // (not yet committed) is traversable by a MATCH run against the writer's
+    // overlay snapshot — the same path the Bolt transaction handler uses for
+    // an in-tx read — while a plain committed snapshot does not see it. The
+    // intra-statement `CREATE ... WITH ... MATCH (expand)` form would need the
+    // executor to run a read pipeline above a write in one statement, which is
+    // a separate, not-yet-supported capability for nodes or edges (RFC-026
+    // follow-up), so this exercises the staged-then-traverse path instead.
+    let mut writer = WriterSession::open(store(), paths("w-ryow-edge-overlay"))
+        .await
+        .unwrap();
+
+    // Stage two persons and a KNOWS edge between them; do NOT commit
+    // (`execute_write_staged` leaves the batch pending, unlike the
+    // auto-committing `execute_write`).
+    let create =
+        lower(&parse("CREATE (a:Person {name: 'Ada'})-[:KNOWS]->(b:Person {name: 'Bo'})").unwrap())
+            .unwrap();
+    let outcome = execute_write_staged(&create, &mut writer, &Params::new())
+        .await
+        .unwrap();
+    assert_eq!(outcome.edges_created, 1);
+
+    let match_plan =
+        lower(&parse("MATCH (:Person {name: 'Ada'})-[:KNOWS]->(x) RETURN x.name AS name").unwrap())
+            .unwrap();
+
+    // Committed snapshot: the staged edge (and its endpoints) are invisible.
+    let committed = writer.snapshot();
+    let rows = execute(&match_plan, &committed, &Params::new())
+        .await
+        .unwrap();
+    assert!(
+        rows.is_empty(),
+        "a plain committed snapshot must not see the staged edge, got {rows:?}"
+    );
+    drop(committed);
+
+    // Overlay snapshot: the staged edge is traversable end-to-end.
+    let overlay = writer.overlay_snapshot();
+    let rows = execute(&match_plan, &overlay, &Params::new())
+        .await
+        .unwrap();
+    assert_eq!(
+        rows.len(),
+        1,
+        "the overlay snapshot must surface the staged edge"
+    );
+    assert_eq!(
+        rows[0].get("name"),
+        Some(&RuntimeValue::String("Bo".into()))
+    );
 }
 
 #[tokio::test]

--- a/crates/namidb-server/tests/bolt_integration.rs
+++ b/crates/namidb-server/tests/bolt_integration.rs
@@ -802,6 +802,61 @@ async fn bolt_in_tx_read_sees_own_staged_write() {
 }
 
 #[tokio::test]
+async fn bolt_in_tx_read_sees_own_staged_edge() {
+    // RFC-026 edge overlay: a traversal in statement N of a transaction must
+    // see an edge that statements 1..N-1 staged, while another session on the
+    // committed snapshot must not. This is the edge counterpart of
+    // `bolt_in_tx_read_sees_own_staged_write`.
+    let (bolt_addr, task) = boot_bolt("bolt-tx-ryow-edge", Duration::ZERO).await;
+    let mut stream = TcpStream::connect(bolt_addr).await.expect("connect bolt");
+    handshake(&mut stream).await;
+    hello_and_logon(&mut stream, "test-token").await;
+
+    begin(&mut stream).await;
+    // Statement 1: stage two nodes and an edge between them, no commit.
+    pull_all(
+        &mut stream,
+        "CREATE (a:Person {name: 'Uma'})-[:KNOWS]->(b:Person {name: 'Ivo'})",
+    )
+    .await;
+    // Statement 2: a traversal in the SAME transaction follows the staged
+    // edge. Before the edge overlay this returned zero rows.
+    let (_f, rows) = pull_all(
+        &mut stream,
+        "MATCH (:Person {name: 'Uma'})-[:KNOWS]->(x) RETURN x.name AS name",
+    )
+    .await;
+    assert_eq!(
+        rows.len(),
+        1,
+        "an in-tx traversal must see the tx's own staged edge"
+    );
+    assert_eq!(rows[0].get("name"), Some(&Value::String("Ivo".into())));
+
+    // Isolation: a second connection reads the committed snapshot and must
+    // not observe the still-uncommitted edge (nor its endpoints).
+    let mut other = TcpStream::connect(bolt_addr).await.expect("connect other");
+    handshake(&mut other).await;
+    hello_and_logon(&mut other, "test-token").await;
+    let (_f, rows2) = pull_all(
+        &mut other,
+        "MATCH (:Person)-[:KNOWS]->(x) RETURN x.name AS name",
+    )
+    .await;
+    assert!(
+        rows2.is_empty(),
+        "an uncommitted staged edge must not be visible to other sessions, got {rows2:?}"
+    );
+    goodbye(&mut other).await;
+    other.shutdown().await.ok();
+
+    commit(&mut stream).await;
+    goodbye(&mut stream).await;
+    stream.shutdown().await.ok();
+    task.abort();
+}
+
+#[tokio::test]
 async fn bolt_read_query_times_out() {
     // A 1ns read budget: the deadline (now + 1ns) is already past by the
     // time the executor reaches its first operator guard, so a read RUN

--- a/crates/namidb-storage/src/read.rs
+++ b/crates/namidb-storage/src/read.rs
@@ -198,17 +198,19 @@ pub struct Snapshot<'mt> {
     decoded_node_sst_batches: Mutex<HashMap<String, Arc<Vec<RecordBatch>>>>,
     /// Read-your-own-writes overlay (RFC-026). A writer's staged-but-
     /// uncommitted batch, materialised as a second memtable and consulted
-    /// alongside the committed `memtable` on the node read paths. The
-    /// staged ops carry LSNs strictly greater than any committed LSN, so
-    /// the existing last-LSN-wins merge resolves a staged upsert over the
-    /// committed row and a staged tombstone hides it — no separate read
-    /// engine. `None` for every read outside a write context (auto-commit
-    /// reads, the HTTP read path, the Bolt auto-commit branch), which is
-    /// the only behaviour that changes nothing.
+    /// alongside the committed `memtable`. The staged ops carry LSNs
+    /// strictly greater than any committed LSN, so the existing
+    /// last-LSN-wins merge resolves a staged upsert over the committed row
+    /// and a staged tombstone hides it, with no separate read engine.
+    /// `None` for every read outside a write context (auto-commit reads,
+    /// the HTTP read path, the Bolt auto-commit branch), which is the only
+    /// behaviour that changes nothing.
     ///
-    /// v1 wires the node read paths only; edges are a fast follow (RFC-026
-    /// Q1). Edge entries staged in the batch are present in this overlay
-    /// but not yet consulted by the edge read methods.
+    /// The node read paths merge it via [`node_entries`](Self::node_entries)
+    /// and [`node_mem_entry`](Self::node_mem_entry); the edge read paths
+    /// merge it via [`edge_mem_entries`](Self::edge_mem_entries) (RFC-026
+    /// edge overlay), so a traversal over an edge staged earlier in the
+    /// same statement or transaction sees it.
     overlay: Option<MemtableSnapshot>,
 }
 
@@ -351,6 +353,23 @@ impl<'mt> Snapshot<'mt> {
         self.memtable
             .iter_nodes()
             .chain(self.overlay.iter().flat_map(|o| o.iter_nodes()))
+    }
+
+    /// Memtable entries to consult on the edge read paths (RFC-026 edge
+    /// overlay): the committed `memtable`, with the writer's staged batch
+    /// chained on when this is an overlay snapshot. Staged LSNs are
+    /// strictly greater than any committed LSN, so the per-partner /
+    /// per-edge last-LSN-wins merge in every edge read path picks a staged
+    /// upsert or tombstone over the committed edge. Unlike
+    /// [`node_entries`](Self::node_entries) this yields every entry; the
+    /// edge paths filter `MemKey::Edge` inline, exactly as they did over
+    /// the bare committed `memtable`, so node entries are skipped. When
+    /// nothing is staged (`overlay` is `None`) this is the committed
+    /// `memtable` alone.
+    fn edge_mem_entries(&self) -> impl Iterator<Item = (&MemKey, &MemEntry)> {
+        self.memtable
+            .iter()
+            .chain(self.overlay.iter().flat_map(|o| o.iter()))
     }
 
     /// Point read of a single node's memtable entry with the staged
@@ -1569,8 +1588,8 @@ impl<'mt> Snapshot<'mt> {
     pub async fn scan_edge_type(&self, edge_type: &str) -> Result<Vec<EdgeView>> {
         let mut latest: BTreeMap<(NodeId, NodeId), (u64, Option<EdgeView>)> = BTreeMap::new();
 
-        // 1. Memtable.
-        for (mk, entry) in self.memtable.iter() {
+        // 1. Memtable, then the writer's staged overlay (RFC-026 edge RYOW).
+        for (mk, entry) in self.edge_mem_entries() {
             let MemKey::Edge {
                 edge_type: et,
                 src,
@@ -1665,8 +1684,8 @@ impl<'mt> Snapshot<'mt> {
         // merge exactly, minus the EdgeView materialisation.
         let mut latest: BTreeMap<(NodeId, NodeId), (u64, bool)> = BTreeMap::new();
 
-        // 1. Memtable.
-        for (mk, entry) in self.memtable.iter() {
+        // 1. Memtable, then the writer's staged overlay (RFC-026 edge RYOW).
+        for (mk, entry) in self.edge_mem_entries() {
             let MemKey::Edge {
                 edge_type: et,
                 src,
@@ -1759,9 +1778,10 @@ impl<'mt> Snapshot<'mt> {
         // Partner bytes -> (lsn, is_upsert).
         let mut latest: BTreeMap<[u8; 16], (u64, bool)> = BTreeMap::new();
 
-        // Memtable sweep first; the SST/CSR path below shadows whatever
-        // the memtable contributed only when its LSN is strictly higher.
-        for (mk, entry) in self.memtable.iter() {
+        // Committed memtable then the staged overlay (RFC-026 edge RYOW)
+        // first; the SST/CSR path below shadows whatever they contributed
+        // only when its LSN is strictly higher.
+        for (mk, entry) in self.edge_mem_entries() {
             let MemKey::Edge {
                 edge_type: et,
                 src: s,
@@ -1951,8 +1971,8 @@ impl<'mt> Snapshot<'mt> {
         // Per-partner last-write-wins state.
         let mut latest: BTreeMap<[u8; 16], (u64, Option<EdgeView>)> = BTreeMap::new();
 
-        // 1. Memtable.
-        for (mk, entry) in self.memtable.iter() {
+        // 1. Memtable, then the writer's staged overlay (RFC-026 edge RYOW).
+        for (mk, entry) in self.edge_mem_entries() {
             let MemKey::Edge {
                 edge_type: et,
                 src: s,
@@ -2103,10 +2123,10 @@ impl<'mt> Snapshot<'mt> {
         // 2. Per-partner last-write-wins state. Memtable + CSR feed it.
         let mut latest: BTreeMap<[u8; 16], (u64, Option<EdgeView>)> = BTreeMap::new();
 
-        // 2a. Memtable sweep — same shape as the SST path but unchanged
-        // because the memtable is already in-RAM. Tombstones from
-        // here can shadow CSR upserts of equal-or-lower LSN.
-        for (mk, entry) in self.memtable.iter() {
+        // 2a. Memtable sweep, then the writer's staged overlay (RFC-026
+        // edge RYOW): same shape as the SST path. A staged or committed
+        // tombstone here shadows a CSR upsert of equal-or-lower LSN.
+        for (mk, entry) in self.edge_mem_entries() {
             let MemKey::Edge {
                 edge_type: et,
                 src: s,
@@ -3663,6 +3683,142 @@ mod tests {
         // bob's edge tombstoned, only carol remains.
         assert_eq!(out.edges.len(), 1);
         assert_eq!(out.edges[0].dst, carol);
+    }
+
+    #[tokio::test]
+    async fn edge_overlay_read_your_own_writes_sst_and_csr() {
+        // RFC-026 edge overlay: a writer's staged-but-uncommitted edge is
+        // visible through the overlay (a staged upsert appears, a staged
+        // tombstone hides a committed edge) on BOTH edge read paths — the
+        // legacy SST scan and the CSR adjacency — and through both the
+        // partner list (out/in_edges) and the WCOJ topology
+        // (sorted_partners). The overlay is built by hand here; the query
+        // and Bolt suites cover the real `overlay_snapshot()` wiring.
+        let store = make_store();
+        let paths = make_paths("read-edge-overlay");
+        let ms = ManifestStore::new(store.clone(), paths.clone());
+        let base = ms.bootstrap(Uuid::now_v7()).await.unwrap();
+        let fence = WriterFence::new(base.manifest.epoch);
+        let schema = SchemaBuilder::new()
+            .label(person_label())
+            .unwrap()
+            .edge_type(knows_edge())
+            .unwrap()
+            .build();
+
+        let alice = sorted_node_id(1);
+        let bob = sorted_node_id(2);
+        let carol = sorted_node_id(3);
+        let dave = sorted_node_id(4);
+
+        // Commit (flush to SST) alice→bob (LSN 10) and alice→dave (LSN 11).
+        let mut mt_flush = Memtable::new();
+        for (dst, lsn) in [(bob, 10u64), (dave, 11)] {
+            mt_flush.apply(
+                MemKey::Edge {
+                    edge_type: "KNOWS".into(),
+                    src: alice,
+                    dst,
+                },
+                lsn,
+                MemOp::Upsert(edge_payload()),
+            );
+        }
+        let frozen = mt_flush.freeze();
+        let outcome = flush(&ms, &fence, &base, &frozen, schema.clone())
+            .await
+            .unwrap();
+
+        // The committed (live) memtable is empty; the staged batch lives only
+        // in the overlay: upsert alice→carol (LSN 30) and tombstone alice→bob
+        // (LSN 31). Staged LSNs exceed every committed LSN, as the real
+        // `overlay_snapshot` guarantees.
+        let live = Memtable::new();
+        let live_view = live.snapshot_view();
+
+        let mut staged = Memtable::new();
+        staged.apply(
+            MemKey::Edge {
+                edge_type: "KNOWS".into(),
+                src: alice,
+                dst: carol,
+            },
+            30,
+            MemOp::Upsert(edge_payload()),
+        );
+        staged.apply(
+            MemKey::Edge {
+                edge_type: "KNOWS".into(),
+                src: alice,
+                dst: bob,
+            },
+            31,
+            MemOp::Tombstone,
+        );
+
+        // Baseline (no overlay): the committed edges are alice→{bob, dave}.
+        let plain = Snapshot::new(
+            outcome.committed.clone(),
+            &live_view,
+            store.clone(),
+            paths.clone(),
+        );
+        let base_out = plain.out_edges_via_sst("KNOWS", alice).await.unwrap();
+        assert_eq!(
+            base_out.edges.iter().map(|e| e.dst).collect::<Vec<_>>(),
+            vec![bob, dave],
+            "without the overlay only the committed edges are visible"
+        );
+        drop(plain);
+
+        // With the overlay attached: bob is hidden by the staged tombstone,
+        // carol appears from the staged upsert, dave stays committed. The
+        // result must be identical on the SST path and the CSR path.
+        for use_csr in [false, true] {
+            let mut snap = Snapshot::new(
+                outcome.committed.clone(),
+                &live_view,
+                store.clone(),
+                paths.clone(),
+            )
+            .with_overlay(staged.snapshot_view());
+            if use_csr {
+                snap = snap
+                    .with_adjacency_cache(Arc::new(AdjacencyCache::new(adjacency_budget_bytes())));
+            }
+
+            let out = if use_csr {
+                snap.out_edges_via_csr("KNOWS", alice).await.unwrap()
+            } else {
+                snap.out_edges_via_sst("KNOWS", alice).await.unwrap()
+            };
+            assert_eq!(
+                out.edges.iter().map(|e| e.dst).collect::<Vec<_>>(),
+                vec![carol, dave],
+                "out_edges (csr={use_csr}) must hide the tombstoned edge and surface the staged one"
+            );
+
+            let inc = if use_csr {
+                snap.in_edges_via_csr("KNOWS", carol).await.unwrap()
+            } else {
+                snap.in_edges_via_sst("KNOWS", carol).await.unwrap()
+            };
+            assert_eq!(
+                inc.edges.iter().map(|e| e.src).collect::<Vec<_>>(),
+                vec![alice],
+                "in_edges (csr={use_csr}) must see the staged edge in reverse"
+            );
+
+            let partners = snap
+                .sorted_partners("KNOWS", alice, EdgeDirection::Forward)
+                .await
+                .unwrap();
+            assert_eq!(
+                partners,
+                vec![carol, dave],
+                "sorted_partners (csr={use_csr}) must reflect the staged upsert and tombstone"
+            );
+        }
     }
 
     #[tokio::test]

--- a/docs/rfc/026-read-your-own-writes.md
+++ b/docs/rfc/026-read-your-own-writes.md
@@ -4,7 +4,7 @@
 **Author(s):** Matías Fonseca <info@namidb.com>
 **Created:** 2026-06-05
 **Updated:** 2026-06-05
-**Implements:** node overlay (v1) landed; edge overlay pending (Q1)
+**Implements:** node overlay and edge overlay landed
 **Supersedes:** none
 
 ## Summary
@@ -203,8 +203,12 @@ insert hot path. Revisit only if overlay build cost shows up in a profile.
 
 2. **Edge and adjacency overlay is more involved than nodes.** Staged edges
    have to merge into adjacency scans, including DETACH DELETE's incident-
-   edge enumeration. v1 can land nodes first and edges in a fast follow if
-   the edge overlay proves large; the open questions track this.
+   edge enumeration. Resolved: the edge overlay landed as a fast follow.
+   Every edge read path (`out_edges`/`in_edges` over both the SST scan and
+   the CSR adjacency, plus `sorted_partners`, `scan_edge_type` and
+   `count_edge_type`) merges the staged batch through
+   `Snapshot::edge_mem_entries`, the edge counterpart of `node_entries`, so
+   there is still one read engine with a resolve-staged-first step in front.
 
 3. **Visibility is the operational rule, not the full standard.** Queries
    that depend on the standard's read/write phase separation (rare, mostly
@@ -214,10 +218,16 @@ insert hot path. Revisit only if overlay build cost shows up in a profile.
 
 ## Open questions
 
-- **Q1: Node-only v1, edges in a follow-up?** Nodes unblock CREATE-then-
-  MATCH, MERGE, and the intra-batch unique check. Edge overlay unblocks
-  traversals over just-created edges. Leaning land nodes plus the
-  property-lookup overlay first, edges immediately after.
+- **Q1: Node-only v1, edges in a follow-up?** Resolved. Nodes landed first
+  (CREATE-then-MATCH, MERGE, the intra-batch unique check); the edge overlay
+  followed, so a traversal over an edge staged earlier in the same statement
+  or transaction now sees it. One capability is still a follow-up: running a
+  read pipeline (an `Expand`) directly above a write within a single
+  statement, `CREATE (a)-[:R]->(b) WITH a MATCH (a)-[:R]->(x)`. The write
+  executor delegates such a sub-plan to the read-only walker, which rejects
+  the embedded write; it is unsupported for nodes and edges alike. The staged
+  edge is visible through `overlay_snapshot` to a later statement or an
+  in-transaction read, which is the common case.
 
 - **Q2: Property index cache interaction.** The cross-snapshot property
   index cache (see the read path) must not serve a stale negative for a


### PR DESCRIPTION
Completes RFC-026 by extending the read-your-own-writes overlay from nodes to edges. A traversal that runs after an edge is staged in the same transaction now sees that edge; before this it read the pre-call committed snapshot and missed staged edges.

## What changed

All in `crates/namidb-storage/src/read.rs`:

- New `Snapshot::edge_mem_entries`, the edge counterpart of `node_entries`: chains the committed memtable with the writer's staged overlay.
- Every edge read path now sweeps `edge_mem_entries` instead of the bare committed memtable: `out_edges`/`in_edges` over both the SST scan and the CSR adjacency, the WCOJ `sorted_partners`, and `scan_edge_type`/`count_edge_type`. Staged ops carry higher LSNs, so the existing last-LSN-wins merge surfaces a staged upsert and a staged tombstone hides a committed edge.

Query and server reads already run against `overlay_snapshot()` (write executor and Bolt `run_in_tx`), so no changes were needed there.

## Tests

- `read.rs`: storage parity test asserting the overlay merge on both the SST and CSR paths, for `out_edges`/`in_edges`/`sorted_partners`, with a staged upsert and a staged tombstone.
- `exec_writes.rs`: a staged (uncommitted) edge is traversable via `overlay_snapshot` while a plain committed snapshot does not see it.
- `bolt_integration.rs`: an in-transaction traversal sees the tx's own staged edge, and a second session on the committed snapshot does not.

## Follow-up

Running a read pipeline (an `Expand`) directly above a write in one statement, `CREATE (a)-[:R]->(b) WITH a MATCH (a)-[:R]->(x)`, is still unsupported: the write executor delegates such a sub-plan to the read-only walker, which rejects the embedded write. This holds for nodes and edges alike; the staged edge is visible to a later statement or an in-transaction read, which is the common case. Tracked in the RFC-026 open questions.