### PR TITLE
fix(query): enforce unique constraints on non-string properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,17 @@ below and in the release notes.
   where the LSM invariant (a shallower level holds the newer LSN for a key)
   guarantees the dropped tombstone shadows nothing.
 
+### Fixed
+
+- Unique constraints are enforced for non-string properties. A property
+  declared unique is now checked on `CREATE` and `SET` regardless of type,
+  not only for strings: a duplicate integer, float, bool, date or other value
+  is rejected with a constraint error, the same as a duplicate string. String
+  values keep using the `O(log N)` property index; other types fall back to a
+  label scan and a typed-value compare (a typed index is a later
+  optimisation). The check reads through the read-your-own-writes overlay, so
+  an intra-batch duplicate is caught too.
+
 ## [0.13.0] - 2026-06-07: read-your-own-writes for nodes, compaction space reclamation, query timeout and row cap
 
 ### Added

--- a/crates/namidb-query/src/exec/writer.rs
+++ b/crates/namidb-query/src/exec/writer.rs
@@ -447,13 +447,54 @@ fn apply_spread_properties(
     Ok(())
 }
 
-/// Enforce declared unique constraints for a node about to be created.
-/// Each label's unique string-valued properties are checked against the
-/// read-your-own-writes overlay (RFC-026), so a duplicate value staged
-/// earlier in the same uncommitted statement/transaction is caught too,
-/// not just one already committed. Returns [`ExecError::Constraint`] on the
-/// first duplicate. Non-string unique properties are not checked (the
-/// property index keys on strings).
+/// Find a node, other than `exclude`, that already holds `value` for the
+/// declared-unique property `prop` on `label`. The lookup runs against the
+/// read-your-own-writes overlay (RFC-026), so a value staged earlier in the
+/// same uncommitted statement/transaction is seen too.
+///
+/// A string value uses the `O(log N)` property index. Any other type falls
+/// back to a label scan and a typed-value compare, because the persisted
+/// property index keys on strings; this enforces non-string unique
+/// constraints correctly, at a scan's cost per check (a typed index is a
+/// later optimisation).
+async fn find_unique_conflict(
+    writer: &WriterSession,
+    label: &str,
+    prop: &str,
+    value: &CoreValue,
+    exclude: Option<NodeId>,
+) -> Result<Option<NodeId>, ExecError> {
+    let snap = writer.overlay_snapshot();
+    let conflict = match value {
+        CoreValue::Str(v) => snap
+            .lookup_node_by_property(label, prop, v)
+            .await
+            .map_err(ExecError::Storage)?
+            .map(|node| node.id)
+            .filter(|id| Some(*id) != exclude),
+        other => {
+            let mut found = None;
+            for node in snap.scan_label(label).await.map_err(ExecError::Storage)? {
+                if Some(node.id) == exclude {
+                    continue;
+                }
+                if node.properties.get(prop) == Some(other) {
+                    found = Some(node.id);
+                    break;
+                }
+            }
+            found
+        }
+    };
+    drop(snap);
+    Ok(conflict)
+}
+
+/// Enforce declared unique constraints for a node about to be created. Each
+/// label's unique properties (of any type) are checked against the
+/// read-your-own-writes overlay (RFC-026), so a duplicate value staged earlier
+/// in the same uncommitted statement/transaction is caught too, not just one
+/// already committed. Returns [`ExecError::Constraint`] on the first duplicate.
 async fn enforce_unique_on_create(
     writer: &WriterSession,
     labels: &[String],
@@ -461,15 +502,15 @@ async fn enforce_unique_on_create(
 ) -> Result<(), ExecError> {
     // Collect the (label, property, value) checks first so the borrow of the
     // schema is released before we take a snapshot.
-    let checks: Vec<(&str, &str, &str)> = {
+    let checks: Vec<(String, String, CoreValue)> = {
         let schema = writer.schema();
         let mut checks = Vec::new();
         for label in labels {
             if let Some(def) = schema.label(label) {
                 for prop in &def.properties {
                     if prop.unique {
-                        if let Some(CoreValue::Str(v)) = core_props.get(&prop.name) {
-                            checks.push((label.as_str(), prop.name.as_str(), v.as_str()));
+                        if let Some(v) = core_props.get(&prop.name) {
+                            checks.push((label.clone(), prop.name.clone(), v.clone()));
                         }
                     }
                 }
@@ -478,13 +519,10 @@ async fn enforce_unique_on_create(
         checks
     };
     for (label, prop, value) in checks {
-        let snap = writer.overlay_snapshot();
-        let existing = snap
-            .lookup_node_by_property(label, prop, value)
-            .await
-            .map_err(ExecError::Storage)?;
-        drop(snap);
-        if existing.is_some() {
+        if find_unique_conflict(writer, &label, &prop, &value, None)
+            .await?
+            .is_some()
+        {
             return Err(ExecError::Constraint(format!(
                 "{label}.{prop} = {value:?} already exists (unique constraint)"
             )));
@@ -496,8 +534,8 @@ async fn enforce_unique_on_create(
 /// Enforce a unique constraint when SET assigns `value` to `key` on a node.
 /// If `key` is a declared unique property on any of the node's labels and a
 /// different node already holds `value`, reject. Setting the node's own
-/// current value (self-update) is allowed. Only string values are checked,
-/// matching the property index.
+/// current value (self-update) is allowed. Values of any type are checked;
+/// see [`find_unique_conflict`] for how string vs non-string is resolved.
 async fn enforce_unique_on_set(
     writer: &WriterSession,
     labels: &[String],
@@ -505,9 +543,6 @@ async fn enforce_unique_on_set(
     value: &CoreValue,
     self_id: NodeId,
 ) -> Result<(), ExecError> {
-    let CoreValue::Str(v) = value else {
-        return Ok(());
-    };
     let unique_labels: Vec<String> = {
         let schema = writer.schema();
         labels
@@ -523,23 +558,17 @@ async fn enforce_unique_on_set(
             .collect()
     };
     for label in &unique_labels {
-        // Read-your-own-writes overlay (RFC-026): a SET that follows a
-        // CREATE in the same statement/transaction must see the staged row,
-        // so a duplicate value staged earlier in the batch is caught too,
-        // not just one already committed. Self-update stays allowed via the
-        // `self_id` check below.
-        let snap = writer.overlay_snapshot();
-        let existing = snap
-            .lookup_node_by_property(label, key, v)
-            .await
-            .map_err(ExecError::Storage)?;
-        drop(snap);
-        if let Some(node) = existing {
-            if node.id != self_id {
-                return Err(ExecError::Constraint(format!(
-                    "{label}.{key} = {v:?} already held by another node (unique constraint)"
-                )));
-            }
+        // Read-your-own-writes overlay (RFC-026): a SET that follows a CREATE
+        // in the same statement/transaction must see the staged row. The
+        // node's own row is excluded via `self_id`, so a self-update (or a
+        // no-op write of the same value) is allowed.
+        if find_unique_conflict(writer, label, key, value, Some(self_id))
+            .await?
+            .is_some()
+        {
+            return Err(ExecError::Constraint(format!(
+                "{label}.{key} = {value:?} already held by another node (unique constraint)"
+            )));
         }
     }
     Ok(())

--- a/crates/namidb-query/tests/exec_writes.rs
+++ b/crates/namidb-query/tests/exec_writes.rs
@@ -1158,3 +1158,110 @@ async fn intra_batch_duplicate_unique_value_is_rejected() {
     let snap = writer.snapshot();
     assert_eq!(snap.scan_label("Account").await.unwrap().len(), 1);
 }
+
+/// Schema with a single integer unique property.
+fn int_unique_schema() -> namidb_core::schema::Schema {
+    SchemaBuilder::new()
+        .label(LabelDef {
+            name: "Account".into(),
+            properties: vec![PropertyDef::new("account_no", DataType::Int64, false)
+                .unwrap()
+                .with_unique(true)],
+        })
+        .unwrap()
+        .build()
+}
+
+#[tokio::test]
+async fn nonstring_unique_create_rejects_duplicate() {
+    // A non-string (Int64) unique property is now enforced on CREATE, not
+    // just string properties.
+    let mut writer = WriterSession::open(store(), paths("w-unique-int-create"))
+        .await
+        .unwrap();
+    write_q(&mut writer, "CREATE (:Account {account_no: 1})").await;
+    writer.flush(int_unique_schema()).await.unwrap();
+
+    // A different value is fine.
+    write_q(&mut writer, "CREATE (:Account {account_no: 2})").await;
+
+    // A duplicate of a committed value is rejected.
+    let plan = lower(&parse("CREATE (:Account {account_no: 1})").unwrap()).unwrap();
+    let err = execute_write(&plan, &mut writer, &Params::new())
+        .await
+        .expect_err("duplicate integer unique value must be rejected");
+    assert!(
+        format!("{err:?}").contains("unique"),
+        "expected a unique-constraint error, got: {err:?}"
+    );
+
+    let snap = writer.snapshot();
+    assert_eq!(snap.scan_label("Account").await.unwrap().len(), 2);
+}
+
+#[tokio::test]
+async fn nonstring_unique_intra_batch_duplicate_rejected() {
+    // The non-string check reads the overlay too: two creates of the same
+    // integer value in one uncommitted statement are caught.
+    let mut writer = WriterSession::open(store(), paths("w-unique-int-batch"))
+        .await
+        .unwrap();
+    write_q(&mut writer, "CREATE (:Account {account_no: 7})").await;
+    writer.flush(int_unique_schema()).await.unwrap();
+
+    let plan =
+        lower(&parse("CREATE (:Account {account_no: 9}), (:Account {account_no: 9})").unwrap())
+            .unwrap();
+    let err = execute_write(&plan, &mut writer, &Params::new())
+        .await
+        .expect_err("duplicate integer value in one batch must be rejected");
+    assert!(
+        format!("{err:?}").contains("unique"),
+        "expected a unique-constraint error, got: {err:?}"
+    );
+
+    // The failed batch was discarded: only the committed seed remains.
+    let snap = writer.snapshot();
+    assert_eq!(snap.scan_label("Account").await.unwrap().len(), 1);
+}
+
+#[tokio::test]
+async fn nonstring_unique_set_rejects_collision_but_allows_self_update() {
+    // SET enforces a non-string unique constraint: moving a node onto another
+    // node's value is rejected, while a self-update or a move to a free value
+    // is allowed.
+    let mut writer = WriterSession::open(store(), paths("w-unique-int-set"))
+        .await
+        .unwrap();
+    write_q(&mut writer, "CREATE (:Account {account_no: 1})").await;
+    write_q(&mut writer, "CREATE (:Account {account_no: 2})").await;
+    writer.flush(int_unique_schema()).await.unwrap();
+
+    // Collision: account 1 -> 2 (held by another node) is rejected.
+    let plan =
+        lower(&parse("MATCH (a:Account {account_no: 1}) SET a.account_no = 2").unwrap()).unwrap();
+    let err = execute_write(&plan, &mut writer, &Params::new())
+        .await
+        .expect_err("SET onto another node's unique value must be rejected");
+    assert!(
+        format!("{err:?}").contains("unique"),
+        "expected a unique-constraint error, got: {err:?}"
+    );
+
+    // Self-update: account 1 -> 1 is allowed (the node's own value).
+    write_q(
+        &mut writer,
+        "MATCH (a:Account {account_no: 1}) SET a.account_no = 1",
+    )
+    .await;
+    // Move to a free value: account 1 -> 3 is allowed.
+    write_q(
+        &mut writer,
+        "MATCH (a:Account {account_no: 1}) SET a.account_no = 3",
+    )
+    .await;
+
+    let snap = writer.snapshot();
+    let rows = snap.scan_label("Account").await.unwrap();
+    assert_eq!(rows.len(), 2, "no node was created or dropped by the SETs");
+}


### PR DESCRIPTION
The unique-constraint check on `CREATE` and `SET` only looked at string properties, so a `unique` declaration on an integer, float, bool, date or any other type was silently ignored — duplicates were accepted.

## What changed (`crates/namidb-query/src/exec/writer.rs`)

- A shared `find_unique_conflict(writer, label, prop, value, exclude)` resolves a duplicate against the read-your-own-writes overlay (RFC-026):
  - a **string** value uses the `O(log N)` property index (unchanged fast path);
  - **any other type** falls back to a label scan and a typed `CoreValue` compare, because the persisted property index keys on strings.
- `enforce_unique_on_create` now collects unique props of every type (not just `CoreValue::Str`) and checks each via the helper.
- `enforce_unique_on_set` drops its string-only early return and checks every type, excluding the node's own row so a self-update (or a no-op write of the same value) is still allowed.

Because both paths run against the overlay, an intra-batch duplicate (two creates of the same value in one uncommitted statement/transaction) is caught too.

A typed secondary index for non-string uniques (to avoid the scan) is a later optimisation; correctness comes first.

## Tests (`exec_writes.rs`)

- `nonstring_unique_create_rejects_duplicate`: a duplicate `Int64` value on `CREATE` is rejected; a different value is fine.
- `nonstring_unique_intra_batch_duplicate_rejected`: two creates of the same integer in one statement are rejected via the overlay.
- `nonstring_unique_set_rejects_collision_but_allows_self_update`: `SET` onto another node's integer value is rejected, while a self-update and a move to a free value are allowed.

Full workspace `cargo test` / `clippy` / `fmt` green. The existing string-unique tests are unchanged and still pass.

## Remaining correctness item

The other item from the list — making the read-query timeout fully cooperative (interrupting a single CPU-bound operator mid-flight, not just at operator boundaries) — is a separate, more invasive change (threading a deadline into the storage decode loops) and is not in this PR.