### PR TITLE
feat(query,storage): cooperative read-query cancellation in storage decode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,14 @@ below and in the release notes.
   label scan and a typed-value compare (a typed index is a later
   optimisation). The check reads through the read-your-own-writes overlay, so
   an intra-batch duplicate is caught too.
+- The read-query timeout now cancels cooperatively inside the storage decode,
+  not only at query operator boundaries. The deadline rides a task-local in
+  `namidb-storage`, so the CPU-bound SST body fetch and the per-batch /
+  per-row decode and merge loops probe it and abort a single long-running
+  operator (for example a large scan or a big leveled SST decode) mid-flight
+  with a timeout, instead of pinning a worker until the operator returns.
+  Untimed reads, writes and compaction are unaffected (the probe is a no-op
+  when no deadline is in scope).
 
 ## [0.13.0] - 2026-06-07: read-your-own-writes for nodes, compaction space reclamation, query timeout and row cap
 

--- a/crates/namidb-query/src/exec/limits.rs
+++ b/crates/namidb-query/src/exec/limits.rs
@@ -1,13 +1,14 @@
 //! Read-query execution guards: a wall-clock timeout and a row cap.
 //!
-//! Both are carried by a single task-local scoped on the current tokio
-//! task and probed cheaply by the executor. Mirrors the
-//! [`ProfileCollector`](crate::profile) pattern: the regular query path
-//! (no guard in scope, e.g. tests, the write executor, profiling) keeps
-//! its baseline cost.
+//! The deadline rides a tokio task-local in [`namidb_storage::cancel`] so the
+//! storage crate's CPU-bound SST decode and merge loops can probe it too and
+//! abort a single long operator mid-flight (cooperative cancellation), not
+//! only at the query operator boundaries here. The row cap is a query-local
+//! concern on a separate task-local. The regular query path (no guard in
+//! scope: tests, the write executor, profiling) keeps its baseline cost.
 //!
-//! - The deadline is checked at operator boundaries and inside the long
-//!   scan / expand loops.
+//! - The deadline is checked at operator boundaries, inside the long scan /
+//!   expand loops, and inside the storage decode loops.
 //! - The row cap bounds the rows any single operator materialises: the
 //!   executor aborts a query whose operator output would exceed it, plus a
 //!   fast pre-check on the multiplicative `CrossProduct` and a fast-fail
@@ -23,53 +24,54 @@ use std::time::Instant;
 
 use super::walker::ExecError;
 
-/// The active limits for one read query.
-struct Limits {
-    /// Wall-clock deadline; `None` leaves the query untimed.
-    deadline: Option<Instant>,
-    /// Maximum rows a single operator may materialise; `None` is unbounded.
-    row_cap: Option<usize>,
-}
-
 tokio::task_local! {
-    static LIMITS: Limits;
+    /// Maximum rows a single operator may materialise, when a cap is in scope.
+    static ROW_CAP: usize;
 }
 
 /// Run `fut` with an optional deadline and row cap scoped on the current
-/// task. When both are `None` the future runs unguarded (no overhead).
+/// task. The deadline is installed on [`namidb_storage::cancel`]'s task-local
+/// so storage decode loops observe it; the row cap on a query-local one. When
+/// both are `None` the future runs unguarded (no overhead).
 pub(crate) async fn with_limits<F: Future>(
     deadline: Option<Instant>,
     row_cap: Option<usize>,
     fut: F,
 ) -> F::Output {
-    if deadline.is_none() && row_cap.is_none() {
-        return fut.await;
-    }
-    LIMITS.scope(Limits { deadline, row_cap }, fut).await
+    let capped = async move {
+        match row_cap {
+            Some(cap) => ROW_CAP.scope(cap, fut).await,
+            None => fut.await,
+        }
+    };
+    namidb_storage::cancel::with_deadline(deadline, capped).await
 }
 
 /// `Err(ExecError::Timeout)` when a deadline is in scope and has passed,
-/// `Ok(())` otherwise. A cheap task-local probe plus an `Instant`
-/// comparison; a no-op when no deadline is scoped.
+/// `Ok(())` otherwise. Delegates to the shared storage task-local so the
+/// query and storage layers observe the same deadline. A no-op when none is
+/// scoped.
 #[inline]
 pub(crate) fn check_deadline() -> Result<(), ExecError> {
-    LIMITS
-        .try_with(|l| match l.deadline {
-            Some(at) if Instant::now() >= at => Err(ExecError::Timeout),
-            _ => Ok(()),
-        })
-        .unwrap_or(Ok(()))
+    if namidb_storage::cancel::deadline_exceeded() {
+        Err(ExecError::Timeout)
+    } else {
+        Ok(())
+    }
 }
 
-/// `Err(ExecError::RowCap)` when a row cap is in scope and `len` exceeds
-/// it, `Ok(())` otherwise. `len` is the row count an operator produced (or
-/// is about to produce). A no-op when no cap is scoped.
+/// `Err(ExecError::RowCap)` when a row cap is in scope and `len` exceeds it,
+/// `Ok(())` otherwise. `len` is the row count an operator produced (or is
+/// about to produce). A no-op when no cap is scoped.
 #[inline]
 pub(crate) fn check_row_cap(len: usize) -> Result<(), ExecError> {
-    LIMITS
-        .try_with(|l| match l.row_cap {
-            Some(cap) if len > cap => Err(ExecError::RowCap(cap)),
-            _ => Ok(()),
+    ROW_CAP
+        .try_with(|cap| {
+            if len > *cap {
+                Err(ExecError::RowCap(*cap))
+            } else {
+                Ok(())
+            }
         })
         .unwrap_or(Ok(()))
 }

--- a/crates/namidb-query/src/exec/walker.rs
+++ b/crates/namidb-query/src/exec/walker.rs
@@ -73,7 +73,13 @@ impl From<EvalError> for ExecError {
 
 impl From<namidb_storage::Error> for ExecError {
     fn from(e: namidb_storage::Error) -> Self {
-        ExecError::Storage(e)
+        match e {
+            // Storage raises its own Timeout when a query's deadline fires
+            // mid-decode (cooperative cancellation); surface it as the
+            // executor's Timeout, not a generic storage error.
+            namidb_storage::Error::Timeout => ExecError::Timeout,
+            other => ExecError::Storage(other),
+        }
     }
 }
 
@@ -1763,7 +1769,7 @@ pub(crate) async fn lookup_node_by_property_via_scan(
         return snapshot
             .lookup_node_by_property(label, property, s)
             .await
-            .map_err(ExecError::Storage);
+            .map_err(ExecError::from);
     }
 
     // Fallback for non-string keys.
@@ -1781,12 +1787,9 @@ pub(crate) async fn lookup_node_by_property_via_scan(
         snapshot
             .scan_label_with_predicates(label, &[pred])
             .await
-            .map_err(ExecError::Storage)?
+            .map_err(ExecError::from)?
     } else {
-        snapshot
-            .scan_label(label)
-            .await
-            .map_err(ExecError::Storage)?
+        snapshot.scan_label(label).await.map_err(ExecError::from)?
     };
     Ok(candidates.into_iter().next())
 }
@@ -1806,12 +1809,9 @@ pub(crate) async fn lookup_nodes_by_property_via_scan(
         return snapshot
             .lookup_nodes_by_property(label, property, s)
             .await
-            .map_err(ExecError::Storage);
+            .map_err(ExecError::from);
     }
-    let all = snapshot
-        .scan_label(label)
-        .await
-        .map_err(ExecError::Storage)?;
+    let all = snapshot.scan_label(label).await.map_err(ExecError::from)?;
     Ok(all
         .into_iter()
         .filter(|view| {

--- a/crates/namidb-storage/src/cancel.rs
+++ b/crates/namidb-storage/src/cancel.rs
@@ -1,0 +1,58 @@
+//! Cooperative cancellation for read queries (the query timeout).
+//!
+//! A read query's wall-clock deadline rides a tokio task-local scoped over
+//! the whole execution. Because the deadline lives in this crate, the
+//! CPU-bound SST decode and merge loops can probe it directly and abort a
+//! single long-running operator mid-flight, not only at the query operator
+//! boundaries above them (a giant single-SST decode used to run to
+//! completion regardless of the deadline). The query layer scopes the
+//! deadline through [`with_deadline`] and reads it through the same
+//! task-local.
+//!
+//! When no deadline is in scope (writes, tests, the no-timeout server
+//! config) every probe is a cheap task-local miss and the read path keeps
+//! its baseline cost.
+
+use std::future::Future;
+use std::time::Instant;
+
+use crate::error::{Error, Result};
+
+tokio::task_local! {
+    static DEADLINE: Instant;
+}
+
+/// Run `fut` with `deadline` scoped on the current task, so any read this
+/// task performs can probe it. `None` runs `fut` unguarded: no task-local is
+/// installed, so [`check`] and [`deadline_exceeded`] stay no-ops.
+pub async fn with_deadline<F: Future>(deadline: Option<Instant>, fut: F) -> F::Output {
+    match deadline {
+        Some(at) => DEADLINE.scope(at, fut).await,
+        None => fut.await,
+    }
+}
+
+/// `true` when a deadline is in scope and has passed.
+#[inline]
+pub fn deadline_exceeded() -> bool {
+    DEADLINE
+        .try_with(|at| Instant::now() >= *at)
+        .unwrap_or(false)
+}
+
+/// `Err(Error::Timeout)` when a deadline is in scope and has passed, else
+/// `Ok(())`. Call it periodically inside a long CPU-bound loop so the work
+/// aborts cooperatively instead of pinning a worker until it returns.
+#[inline]
+pub fn check() -> Result<()> {
+    if deadline_exceeded() {
+        Err(Error::Timeout)
+    } else {
+        Ok(())
+    }
+}
+
+/// How many rows a decode/merge loop processes between deadline probes.
+/// Probing every row would put an `Instant::now()` on the hot path; a power
+/// of two lets the compiler turn the modulus into a mask.
+pub const CHECK_STRIDE: usize = 1024;

--- a/crates/namidb-storage/src/error.rs
+++ b/crates/namidb-storage/src/error.rs
@@ -37,6 +37,13 @@ pub enum Error {
     #[error("precondition failed: {0}")]
     Precondition(String),
 
+    /// A read query ran past its wall-clock deadline while this crate was
+    /// decoding or merging SSTs (cooperative cancellation, see
+    /// [`crate::cancel`]). The query layer maps it to its own timeout error.
+    /// Only raised when a deadline is in scope.
+    #[error("read query exceeded its deadline")]
+    Timeout,
+
     /// The expected manifest version does not exist yet.
     #[error("manifest version {0} not found")]
     ManifestNotFound(u64),

--- a/crates/namidb-storage/src/lib.rs
+++ b/crates/namidb-storage/src/lib.rs
@@ -15,6 +15,7 @@
 
 pub mod adjacency;
 pub mod cache;
+pub mod cancel;
 pub mod compact;
 pub mod error;
 pub mod fence;

--- a/crates/namidb-storage/src/read.rs
+++ b/crates/namidb-storage/src/read.rs
@@ -1479,6 +1479,9 @@ impl<'mt> Snapshot<'mt> {
                 projection.map(|cols| cols.iter().map(|s| s.as_str()).collect());
 
             for batch in reader.scan_with_predicates_and_projection(predicates, projection)? {
+                // Cooperative cancellation (query timeout): one large SST can
+                // decode into many batches, so probe the deadline per batch.
+                crate::cancel::check()?;
                 let id_col = batch
                     .column_by_name(COL_NODE_ID)
                     .and_then(|c| c.as_any().downcast_ref::<FixedSizeBinaryArray>())
@@ -1644,6 +1647,11 @@ impl<'mt> Snapshot<'mt> {
             let overflows = reader.read_overflow_strings()?;
             let declared_streams = load_declared_streams(&reader, &declared_property_names)?;
             for (idx, row) in rows.iter().enumerate() {
+                // Cooperative cancellation (query timeout): a strided probe so
+                // a huge single edge SST aborts mid-decode, not just per SST.
+                if idx % crate::cancel::CHECK_STRIDE == 0 {
+                    crate::cancel::check()?;
+                }
                 let src = NodeId::from_uuid(Uuid::from_bytes(row.key_id));
                 let dst = NodeId::from_uuid(Uuid::from_bytes(row.partner_id));
                 let view = if row.tombstone {
@@ -1713,7 +1721,11 @@ impl<'mt> Snapshot<'mt> {
             let body = self.get_sst_body(desc).await?;
             let reader = EdgeSstReader::open(body)?;
             let rows = reader.scan_all_edges()?;
-            for row in &rows {
+            for (i, row) in rows.iter().enumerate() {
+                // Cooperative cancellation (query timeout): strided probe.
+                if i % crate::cancel::CHECK_STRIDE == 0 {
+                    crate::cancel::check()?;
+                }
                 let src = NodeId::from_uuid(Uuid::from_bytes(row.key_id));
                 let dst = NodeId::from_uuid(Uuid::from_bytes(row.partner_id));
                 update_edge_count_winner(&mut latest, (src, dst), row.lsn, !row.tombstone);
@@ -2199,6 +2211,12 @@ impl<'mt> Snapshot<'mt> {
     }
 
     async fn get_sst_body(&self, desc: &SstDescriptor) -> Result<Bytes> {
+        // Cooperative cancellation (query timeout): every read path fetches a
+        // candidate SST body through here once per SST, so this one probe
+        // bounds the "scan touches many SSTs" case across all of them. The
+        // per-row decode loops add their own strided probes for a single huge
+        // SST. A no-op when no deadline is in scope (writes, compaction).
+        crate::cancel::check()?;
         let absolute = format!("{}/{}", self.paths.namespace_prefix().as_ref(), desc.path);
         self.fetch_bytes(&absolute).await
     }
@@ -3176,6 +3194,50 @@ mod tests {
             Some(&Value::Str("Alice".into()))
         );
         assert_eq!(view.properties.get("age"), Some(&Value::I64(30)));
+    }
+
+    #[tokio::test]
+    async fn scan_aborts_on_a_passed_deadline() {
+        // Cooperative cancellation (query timeout): a scan run under an
+        // already-passed deadline aborts inside storage with `Error::Timeout`,
+        // at the per-SST body fetch, rather than decoding to completion first.
+        // No deadline in scope leaves the scan unguarded.
+        let store = make_store();
+        let paths = make_paths("read-deadline");
+        let ms = ManifestStore::new(store.clone(), paths.clone());
+        let mut base = ms.bootstrap(Uuid::now_v7()).await.unwrap();
+        base.manifest.label_dict.intern("Person");
+        let fence = WriterFence::new(base.manifest.epoch);
+        let schema = SchemaBuilder::new().label(person_label()).unwrap().build();
+
+        // Flush a node so the scan reaches an SST; the deadline probe lives in
+        // the per-SST body fetch and the per-batch decode loop.
+        let mut mt = Memtable::new();
+        mt.apply(
+            MemKey::Node {
+                id: sorted_node_id(1),
+            },
+            10,
+            MemOp::Upsert(node_payload("Alice", Some(30))),
+        );
+        let committed = flush(&ms, &fence, &base, &mt.freeze(), schema)
+            .await
+            .unwrap()
+            .committed;
+        let empty = Memtable::new();
+        let empty_view = empty.snapshot_view();
+        let snap = Snapshot::new(committed, &empty_view, store, paths);
+
+        // Unguarded: the scan succeeds.
+        assert_eq!(snap.scan_label("Person").await.unwrap().len(), 1);
+
+        // Under a deadline already in the past, the same scan aborts.
+        let past = std::time::Instant::now() - std::time::Duration::from_secs(1);
+        let result = crate::cancel::with_deadline(Some(past), snap.scan_label("Person")).await;
+        assert!(
+            matches!(result, Err(Error::Timeout)),
+            "expected Error::Timeout, got {result:?}"
+        );
     }
 
     // ── secondary equality index (non-unique `indexed` property) ──


### PR DESCRIPTION
The read-query timeout (0.13.0) checked the deadline at query operator boundaries and inside the scan / expand loops, but a single CPU-bound *storage* operator — a large SST decode or merge — ran to completion regardless. A pathological read (or, now, a big leveled-lite deep-level SST) could pin a worker well past its deadline.

## What changed

- **New `namidb-storage::cancel`** module: the read query's wall-clock deadline rides a tokio task-local scoped over the whole execution. Because it lives in the storage crate, the CPU-bound decode loops can probe it directly. `cancel::check()` returns `Error::Timeout` when the deadline has passed; it is a cheap no-op when none is in scope.
- **Storage probes** (`read.rs`):
  - `get_sst_body` — the per-SST chokepoint every read path funnels through — probes once per SST, bounding the "scan touches many SSTs" case across all paths.
  - Strided per-row / per-batch probes in `scan_label`, `scan_edge_type` and `count_edge_type` bound the "one huge SST decode" case (`CHECK_STRIDE = 1024`).
- **New `Error::Timeout`** in storage; the query layer's `From<namidb_storage::Error>` maps it to `ExecError::Timeout`, and the read-path `.map_err(ExecError::Storage)` sites become `.map_err(ExecError::from)` so it surfaces correctly.
- **Query `limits`** now installs the deadline through `storage::cancel` (shared with storage) and keeps the row cap on its own query-local task-local. The `with_limits` / `check_deadline` / `check_row_cap` API is unchanged for callers.

Writes and compaction are unaffected: they never scope a deadline, so every probe is a task-local miss.

## Test

`scan_aborts_on_a_passed_deadline` (storage): a `scan_label` run under an already-passed deadline returns `Error::Timeout` from inside the scan, while the same scan with no deadline succeeds.

Full workspace `cargo test` / `clippy` / `fmt` green (one unrelated pre-existing flaky test in `namidb-core::profile` — global-state under parallel execution — passes in isolation; not touched here).

## Not in scope

Interrupting a single atomic Arrow column decode that has no loop seam is out of scope; SST bodies are bounded by the flush threshold and, for deep leveled levels, by the per-level budget, and the strided probes cover the practical large-decode case.