### PR TITLE
feat(server): lock-free liveness, graceful SIGTERM, and a container healthcheck

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+# Keep the build context small and the build hermetic. Everything else
+# (source, Cargo manifests, README) is needed by `cargo build`.
+target/
+.git/
+.venv/
+**/.venv/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,15 @@ below and in the release notes.
   (a)-[:R]->(x)`) is still a follow-up: the staged edge is visible to a later
   statement or an in-transaction read, not to an expand stacked on the same
   statement's write.
+- Operability: a lock-free liveness probe, graceful `SIGTERM`, and a container
+  healthcheck. A new unauthenticated `GET /v0/livez` answers without taking any
+  lock or reading namespace state, so a long write or compaction (which holds
+  the writer lock) no longer makes a liveness probe hang and get the server
+  killed; `GET /v0/health` now reports the published snapshot's version and
+  epoch without the writer lock too. The server drains on `SIGTERM` (what
+  `docker stop`, systemd and Kubernetes send), not only on Ctrl-C: a shared
+  signal stops the HTTP server and the Bolt listener together. A `Dockerfile`
+  ships with a `HEALTHCHECK` targeting `/v0/livez`.
 
 ### Changed
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,28 @@
+# syntax=docker/dockerfile:1
+
+# ---- build ----
+FROM rust:1.85-slim AS build
+WORKDIR /src
+COPY . .
+RUN cargo build --release --bin namidb-server
+
+# ---- runtime ----
+FROM debian:bookworm-slim
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates curl \
+ && rm -rf /var/lib/apt/lists/*
+COPY --from=build /src/target/release/namidb-server /usr/local/bin/namidb-server
+
+# REST API on 8080. Set NAMIDB_BOLT_LISTEN=0.0.0.0:7687 to also expose Bolt.
+# NAMIDB_STORE is deployment-specific (e.g. s3://bucket/prefix or a path) and
+# must be supplied at run time.
+EXPOSE 8080
+ENV NAMIDB_LISTEN=0.0.0.0:8080
+
+# Liveness: /v0/livez takes no lock and reads no namespace state, so a busy
+# engine (a long write or compaction holding the writer lock) still answers,
+# and the server gets a SIGTERM-clean drain on `docker stop`.
+HEALTHCHECK --interval=15s --timeout=3s --start-period=10s --retries=3 \
+  CMD curl -fsS http://localhost:8080/v0/livez || exit 1
+
+ENTRYPOINT ["namidb-server"]

--- a/crates/namidb-server/src/bolt.rs
+++ b/crates/namidb-server/src/bolt.rs
@@ -341,6 +341,7 @@ pub async fn serve(
     listen: std::net::SocketAddr,
     auth_token: Option<Arc<str>>,
     tx_timeout: std::time::Duration,
+    mut shutdown: tokio::sync::watch::Receiver<bool>,
 ) -> anyhow::Result<()> {
     // `Duration::ZERO` disables the per-transaction idle timeout.
     let tx_idle_timeout = (!tx_timeout.is_zero()).then_some(tx_timeout);
@@ -358,11 +359,20 @@ pub async fn serve(
         std::env::var("NAMIDB_BOLT_SERVER_AGENT").unwrap_or_else(|_| "Neo4j/5.13.0".to_string());
     info!(server_agent = %agent, "bolt server agent");
     loop {
-        let (socket, peer) = match listener.accept().await {
-            Ok(p) => p,
-            Err(e) => {
-                error!(error = %e, "bolt accept failed");
-                continue;
+        let (socket, peer) = tokio::select! {
+            accepted = listener.accept() => match accepted {
+                Ok(p) => p,
+                Err(e) => {
+                    error!(error = %e, "bolt accept failed");
+                    continue;
+                }
+            },
+            // Stop accepting new connections on shutdown (SIGTERM/SIGINT). The
+            // HTTP server drains in parallel; in-flight Bolt sessions finish on
+            // their own tasks.
+            _ = shutdown.wait_for(|stop| *stop) => {
+                info!("shutdown signalled, bolt listener stopping");
+                break;
             }
         };
         if let Err(e) = socket.set_nodelay(true) {
@@ -389,6 +399,7 @@ pub async fn serve(
             }
         });
     }
+    Ok(())
 }
 
 // `ParseError` is included for callers that want a custom Bolt error

--- a/crates/namidb-server/src/lib.rs
+++ b/crates/namidb-server/src/lib.rs
@@ -195,10 +195,11 @@ impl AppState {
 }
 
 /// Assemble the `axum` router with every public route + auth
-/// middleware. `/v0/health` and `/v0/version` are intentionally
-/// excluded from the auth check.
+/// middleware. `/v0/livez`, `/v0/health` and `/v0/version` are intentionally
+/// excluded from the auth check (a healthcheck probe carries no token).
 pub fn build_router(state: AppState) -> Router {
     let public = Router::new()
+        .route("/v0/livez", get(livez))
         .route("/v0/health", get(health))
         .route("/v0/version", get(version));
 
@@ -354,12 +355,24 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
     // Optional Bolt listener (binds an extra TCP port for native
     // Neo4j drivers — see RFC-022). When not configured we stay
     // HTTP-only.
+    // A single shutdown signal, flipped to `true` on SIGINT or SIGTERM, that
+    // both the HTTP server and the Bolt listener observe, so a `docker stop`
+    // or a Kubernetes pod termination drains cleanly instead of being killed.
+    let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+    tokio::spawn(async move {
+        wait_for_shutdown_signal().await;
+        let _ = shutdown_tx.send(true);
+    });
+
     if let Some(bolt_addr) = config.bolt_listen {
         let bolt_state = state.clone();
         let bolt_auth = state.auth_token.clone();
         let tx_timeout = config.bolt_tx_timeout;
+        let bolt_shutdown = shutdown_rx.clone();
         tokio::spawn(async move {
-            if let Err(e) = bolt::serve(bolt_state, bolt_addr, bolt_auth, tx_timeout).await {
+            if let Err(e) =
+                bolt::serve(bolt_state, bolt_addr, bolt_auth, tx_timeout, bolt_shutdown).await
+            {
                 error!(error = %e, "bolt listener exited");
             }
         });
@@ -369,15 +382,39 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
 
     let listener = TcpListener::bind(config.listen).await?;
     info!(addr = %config.listen, "namidb-server listening");
+    let mut http_shutdown = shutdown_rx;
     axum::serve(listener, app)
-        .with_graceful_shutdown(shutdown_signal())
+        .with_graceful_shutdown(async move {
+            let _ = http_shutdown.wait_for(|stop| *stop).await;
+            info!("shutdown signalled, draining HTTP requests…");
+        })
         .await?;
     Ok(())
 }
 
-async fn shutdown_signal() {
-    let _ = tokio::signal::ctrl_c().await;
-    info!("ctrl-c received, draining requests…");
+/// Resolve when the process is asked to stop: Ctrl-C (SIGINT) on every
+/// platform, plus SIGTERM on Unix — what `docker stop`, systemd and
+/// Kubernetes send. Without the SIGTERM arm the server ignored the orderly
+/// stop signal and was hard-killed once the grace period elapsed.
+async fn wait_for_shutdown_signal() {
+    let ctrl_c = async {
+        let _ = tokio::signal::ctrl_c().await;
+    };
+    #[cfg(unix)]
+    let terminate = async {
+        match tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate()) {
+            Ok(mut sig) => {
+                sig.recv().await;
+            }
+            Err(_) => std::future::pending::<()>().await,
+        }
+    };
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+    tokio::select! {
+        _ = ctrl_c => info!("SIGINT received, draining…"),
+        _ = terminate => info!("SIGTERM received, draining…"),
+    }
 }
 
 // ── auth ──────────────────────────────────────────────────────────────
@@ -442,14 +479,27 @@ struct HealthResponse {
     epoch: u64,
 }
 
+/// Liveness: the process is up and its async runtime is responsive. Takes no
+/// lock and reads no namespace state, so a long write or compaction (which
+/// holds the writer lock) can never make it hang — a container liveness probe
+/// stays green while the engine is busy. This is the endpoint a Docker
+/// HEALTHCHECK or a Kubernetes livenessProbe should target.
+async fn livez() -> impl IntoResponse {
+    Json(serde_json::json!({ "status": "ok" }))
+}
+
+/// Readiness: report the latest published snapshot's manifest version and
+/// epoch WITHOUT taking the writer lock. The snapshot is republished after
+/// every commit, so it reflects committed state; a long write or compaction
+/// holding the writer lock does not stall the probe.
 async fn health(State(state): State<AppState>) -> impl IntoResponse {
-    let w = state.writer.lock().await;
-    let snap = w.snapshot();
+    let owned = state.snapshot.load();
+    let m = &owned.manifest().manifest;
     Json(HealthResponse {
         status: "ok",
         namespace: state.namespace.clone(),
-        manifest_version: snap.manifest().manifest.version,
-        epoch: snap.manifest().manifest.epoch.as_u64(),
+        manifest_version: m.version,
+        epoch: m.epoch.as_u64(),
     })
 }
 
@@ -871,6 +921,33 @@ mod tests {
         let v: serde_json::Value = serde_json::from_slice(&body).unwrap();
         assert_eq!(v["status"], "ok");
         assert_eq!(v["namespace"], "test");
+    }
+
+    #[tokio::test]
+    async fn livez_and_health_do_not_block_on_the_writer_lock() {
+        // A long write or compaction holds the writer lock; the liveness and
+        // readiness probes must still answer promptly, or an orchestrator
+        // kills a busy-but-healthy server. livez takes no lock; health reads
+        // the published snapshot, not the writer.
+        let (store, paths) = namidb_storage::parse_uri("memory://livez").unwrap();
+        let writer = WriterSession::open(store, paths).await.unwrap();
+        let state = AppState::new(writer, None, "test".into());
+        let app = build_router(state.clone());
+
+        // Hold the writer lock for the duration of both probes.
+        let _guard = state.writer.lock().await;
+
+        for uri in ["/v0/livez", "/v0/health"] {
+            let resp = tokio::time::timeout(
+                std::time::Duration::from_secs(2),
+                app.clone()
+                    .oneshot(Request::builder().uri(uri).body(Body::empty()).unwrap()),
+            )
+            .await
+            .unwrap_or_else(|_| panic!("{uri} blocked on the writer lock"))
+            .unwrap();
+            assert_eq!(resp.status(), StatusCode::OK, "{uri}");
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
First P1 (production-credibility) slice: operability. Three gaps that make the server hard to run under Docker / systemd / Kubernetes.

## Lock-free liveness
`GET /v0/health` took the **writer lock** (`state.writer.lock().await`) to read the manifest version. While a long write or compaction holds that lock, the probe hangs — so an orchestrator's liveness check times out and kills a server that is busy but perfectly healthy.

- New unauthenticated **`GET /v0/livez`**: pure liveness, takes no lock and reads no namespace state. This is what a `livenessProbe` / Docker `HEALTHCHECK` should target.
- **`GET /v0/health`** now reports the latest *published snapshot's* version and epoch (refreshed after every commit), lock-free, as a readiness signal.

## Graceful SIGTERM
`shutdown_signal()` only awaited `ctrl_c()` (SIGINT). `docker stop`, systemd and Kubernetes send **SIGTERM**, which the server ignored — so it was hard-killed once the grace period elapsed, dropping in-flight work.

- A shared `tokio::sync::watch` signal, flipped on SIGINT **or** SIGTERM (Unix), now drives a clean drain of both the HTTP server (`with_graceful_shutdown`) and the Bolt listener (the accept loop `select!`s on it and stops accepting). The Bolt server previously ran in a detached task with no shutdown path at all.

## Container healthcheck
- A multi-stage **`Dockerfile`** (+ `.dockerignore`) builds `namidb-server` and ships a `HEALTHCHECK` hitting `/v0/livez`.

## Test
`livez_and_health_do_not_block_on_the_writer_lock`: holds the writer lock, then asserts both `/v0/livez` and `/v0/health` answer within a 2s timeout. Full workspace `cargo test` / `clippy` / `fmt` green (8 server lib + 11 Bolt integration tests pass).

## Follow-up
Full Bolt session draining (tracking and awaiting in-flight sessions, not just halting new accepts) and TLS on the serving path are separate P1 items.