### PR TITLE
feat(server): TLS on the HTTP and Bolt serving paths

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,15 @@ below and in the release notes.
   `docker stop`, systemd and Kubernetes send), not only on Ctrl-C: a shared
   signal stops the HTTP server and the Bolt listener together. A `Dockerfile`
   ships with a `HEALTHCHECK` targeting `/v0/livez`.
+- TLS on the serving path (`--tls-cert` / `--tls-key`, env `NAMIDB_TLS_CERT` /
+  `NAMIDB_TLS_KEY`). One PEM certificate chain and key enable rustls on both
+  the HTTP REST API (HTTPS, served via `axum-server`) and the Bolt listener
+  (a TLS handshake in front of the same session loop, since the Bolt session
+  is generic over its transport). The `ring` crypto provider is selected
+  explicitly, so the build needs no aws-lc-rs C toolchain. Both `--tls-cert`
+  and `--tls-key` must be set together; with neither the server stays
+  plaintext exactly as before, and the graceful-shutdown drain works on both
+  the TLS and plaintext paths.
 
 ### Changed
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,6 +124,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
 name = "arraydeque"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -456,6 +465,28 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "axum-server"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1ab4a3ec9ea8a657c72d99a03a824af695bd0fb5ec639ccbd9cd3543b41a5f9"
+dependencies = [
+ "arc-swap",
+ "bytes",
+ "fs-err",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-util",
+ "pin-project-lite",
+ "rustls",
+ "rustls-pemfile",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
 ]
 
 [[package]]
@@ -910,6 +941,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1169,6 +1209,16 @@ version = "0.22.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f6577b05a7ffad0db555aedf00bfe52af818220fc4c1c3a7a12520896fc38627"
 dependencies = [
+ "tokio",
+]
+
+[[package]]
+name = "fs-err"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73fde052dbfc920003cfd2c8e2c6e6d4cc7c1091538c3a24226cec0665ab08c0"
+dependencies = [
+ "autocfg",
  "tokio",
 ]
 
@@ -2261,6 +2311,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "axum",
+ "axum-server",
  "base64",
  "bytes",
  "chrono",
@@ -2270,12 +2321,16 @@ dependencies = [
  "namidb-core",
  "namidb-query",
  "namidb-storage",
+ "rcgen",
  "reqwest",
+ "rustls",
+ "rustls-pemfile",
  "serde",
  "serde_json",
  "tempfile",
  "thiserror",
  "tokio",
+ "tokio-rustls",
  "tokio-test",
  "tower",
  "tower-http",
@@ -2398,6 +2453,12 @@ checksum = "73f88a1307638156682bada9d7604135552957b7818057dcef22705b4d509495"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "num-conv"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -2618,6 +2679,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
+name = "pem"
+version = "3.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
+dependencies = [
+ "base64",
+ "serde_core",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2697,6 +2768,12 @@ checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -3031,6 +3108,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "rcgen"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75e669e5202259b5314d1ea5397316ad400819437857b90861765f24c4cf80a2"
+dependencies = [
+ "pem",
+ "ring",
+ "rustls-pki-types",
+ "time",
+ "yasna",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3179,6 +3269,15 @@ dependencies = [
  "rustls-pki-types",
  "schannel",
  "security-framework",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -3540,6 +3639,25 @@ dependencies = [
  "integer-encoding",
  "ordered-float",
 ]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "tiny-keccak"
@@ -4516,6 +4634,15 @@ dependencies = [
  "arraydeque",
  "encoding_rs",
  "hashlink",
+]
+
+[[package]]
+name = "yasna"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e17bb3549cc1321ae1296b9cdc2698e2b6cb1992adfa19a8c72e5b7a738f44cd"
+dependencies = [
+ "time",
 ]
 
 [[package]]

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ The engine is the same whether you run it as a library inside your app, as a Rus
 
 It's the same engine across all three. Server and Embedded write to an identical bucket layout, so you can open an embedded notebook against the exact `s3://...` URI a `namidb-server` daemon is serving.
 
-NamiDB is pre-1.0 and alpha: the engine has run inside LESAI for about a year, but it has no external production users yet, several production concerns are still in progress (TLS on the wire, metrics, broad authz), and it is not yet a drop-in for critical data. Run it over a bucket you own, keep backups (`aws s3 sync`), and treat 0.x as the moving target it is.
+NamiDB is pre-1.0 and alpha: the engine has run inside LESAI for about a year, but it has no external production users yet, several production concerns are still in progress (metrics, broad authz), and it is not yet a drop-in for critical data. Run it over a bucket you own, keep backups (`aws s3 sync`), and treat 0.x as the moving target it is.
 
 <br />
 
@@ -95,7 +95,7 @@ NamiDB is pre-1.0 and alpha: the engine has run inside LESAI for about a year, b
 - **Six storage backends.** `memory://`, `file://` (with `flock`-based CAS), `s3://` (AWS S3, R2, MinIO, Tigris, LocalStack), `gs://`, `az://`.
 - **Python bindings.** `pip install namidb`. abi3 wheels for Linux (x86_64 and aarch64), macOS (arm64) and Windows (x86_64), with an sdist fallback everywhere else. Sync and async (`acypher`). Arrow, pandas and polars output.
 - **CLI.** `namidb parse`, `namidb explain --verbose`, `namidb run --store <uri>` for ad-hoc query work against any backend.
-- **HTTP server.** The `namidb-server` binary, with bearer-token auth, a periodic flush loop, a lock-free `/v0/livez` liveness probe, and a small REST API (`/v0/cypher`, `/v0/health`, `/v0/admin/flush`).
+- **HTTP server.** The `namidb-server` binary, with bearer-token auth, a periodic flush loop, a lock-free `/v0/livez` liveness probe, and a small REST API (`/v0/cypher`, `/v0/health`, `/v0/admin/flush`). Optional TLS on both the HTTP and Bolt listeners via `--tls-cert` / `--tls-key` (rustls).
 - **Bolt protocol.** Same `namidb-server` binary speaks Bolt 4.4 / 5.0 / 5.4 on an opt-in TCP listener (default 7687). Neo4j drivers connect over `bolt://host:7687` and run Cypher, verified end-to-end with the Python driver. The other language drivers (Java, JavaScript, .NET, Go, Rust) speak the same protocol but are not all exercised yet, and GUI clients that introspect the schema hit `CALL` / `SHOW` procedures the parser does not implement yet, so their schema panels come up empty. See [RFC-022](./docs/rfc/022-bolt-protocol.md).
 - **Bench harness.** A synthetic, deterministic LDBC SNB Interactive harness under [`bench/`](./bench/).
 

--- a/crates/namidb-server/Cargo.toml
+++ b/crates/namidb-server/Cargo.toml
@@ -34,6 +34,12 @@ chrono = { workspace = true }
 uuid = { workspace = true }
 base64 = { workspace = true }
 humantime = "2"
+# TLS on the serving path (rustls, aligned with the versions already in the
+# lock via reqwest/object_store). `ring` avoids the aws-lc-rs C toolchain.
+axum-server = { version = "0.7", features = ["tls-rustls"] }
+tokio-rustls = { version = "0.26", default-features = false, features = ["ring", "tls12"] }
+rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12", "logging"] }
+rustls-pemfile = "2"
 
 [dev-dependencies]
 tempfile = { workspace = true }
@@ -41,3 +47,8 @@ reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-feature
 tokio-test = { workspace = true }
 bytes = { workspace = true }
 tracing-subscriber = { workspace = true }
+rcgen = "0.13"
+# Also dev-deps so the TLS integration test (a separate crate) can drive a
+# verifying rustls client; they unify with the versions above.
+rustls = { version = "0.23", default-features = false, features = ["ring", "std"] }
+tokio-rustls = { version = "0.26", default-features = false, features = ["ring"] }

--- a/crates/namidb-server/src/bolt.rs
+++ b/crates/namidb-server/src/bolt.rs
@@ -342,6 +342,7 @@ pub async fn serve(
     auth_token: Option<Arc<str>>,
     tx_timeout: std::time::Duration,
     mut shutdown: tokio::sync::watch::Receiver<bool>,
+    tls: Option<tokio_rustls::TlsAcceptor>,
 ) -> anyhow::Result<()> {
     // `Duration::ZERO` disables the per-transaction idle timeout.
     let tx_idle_timeout = (!tx_timeout.is_zero()).then_some(tx_timeout);
@@ -380,26 +381,46 @@ pub async fn serve(
         }
         let state = state.clone();
         let policy = auth_policy(&auth_token);
-        let agent = agent.clone();
-        let connection_id = Uuid::now_v7().to_string();
+        let info = ServerInfo {
+            agent: agent.clone(),
+            connection_id: Uuid::now_v7().to_string(),
+        };
+        let tls = tls.clone();
         tokio::spawn(async move {
-            let backend = Arc::new(ServerBackend::new(state));
-            let session = Session::new(
-                socket,
-                ServerInfo {
-                    agent,
-                    connection_id,
+            let backend: Arc<dyn Backend> = Arc::new(ServerBackend::new(state));
+            // `Session` is generic over the transport, so the only fork is the
+            // optional TLS handshake on the accepted socket.
+            match tls {
+                Some(acceptor) => match acceptor.accept(socket).await {
+                    Ok(stream) => {
+                        run_session(stream, info, policy, backend, tx_idle_timeout, peer).await
+                    }
+                    Err(e) => warn!(error = %e, %peer, "bolt TLS handshake failed"),
                 },
-                policy,
-                backend,
-            )
-            .with_tx_idle_timeout(tx_idle_timeout);
-            if let Err(e) = session.run().await {
-                warn!(error = %e, %peer, "bolt session ended with error");
+                None => run_session(socket, info, policy, backend, tx_idle_timeout, peer).await,
             }
         });
     }
     Ok(())
+}
+
+/// Build and run one Bolt session over any byte stream — a plain `TcpStream`
+/// or a TLS stream. `Session` is generic over the transport, so TLS adds only
+/// a handshake in front of the same session loop.
+async fn run_session<S>(
+    socket: S,
+    info: ServerInfo,
+    policy: AuthPolicy,
+    backend: Arc<dyn Backend>,
+    tx_idle_timeout: Option<std::time::Duration>,
+    peer: std::net::SocketAddr,
+) where
+    S: tokio::io::AsyncReadExt + tokio::io::AsyncWriteExt + Unpin,
+{
+    let session = Session::new(socket, info, policy, backend).with_tx_idle_timeout(tx_idle_timeout);
+    if let Err(e) = session.run().await {
+        warn!(error = %e, %peer, "bolt session ended with error");
+    }
 }
 
 // `ParseError` is included for callers that want a custom Bolt error

--- a/crates/namidb-server/src/lib.rs
+++ b/crates/namidb-server/src/lib.rs
@@ -8,6 +8,7 @@
 
 pub mod bolt;
 mod introspect;
+pub mod tls;
 
 use std::sync::Arc;
 use std::time::Duration;
@@ -79,6 +80,12 @@ pub struct Config {
     pub write_stall_l0: usize,
     /// Delay applied to a write when L0 is above `write_stall_l0`.
     pub write_stall_delay: Duration,
+    /// PEM certificate-chain file enabling TLS on the HTTP and Bolt
+    /// listeners. Must be set together with `tls_key`; when both are `None`
+    /// the server serves plaintext.
+    pub tls_cert: Option<std::path::PathBuf>,
+    /// PEM private-key file paired with `tls_cert`.
+    pub tls_key: Option<std::path::PathBuf>,
 }
 
 /// `(manifest_version, catalog)` memoised behind a mutex and shared across
@@ -364,14 +371,31 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
         let _ = shutdown_tx.send(true);
     });
 
+    // TLS on the serving path: when `--tls-cert` / `--tls-key` are set, both
+    // the HTTP server and the Bolt listener speak TLS from one shared config;
+    // otherwise the server stays plaintext.
+    let tls_config = match (&config.tls_cert, &config.tls_key) {
+        (Some(cert), Some(key)) => Some(tls::load_server_config(cert, key)?),
+        (None, None) => None,
+        _ => anyhow::bail!("set both --tls-cert and --tls-key to enable TLS, or neither"),
+    };
+
     if let Some(bolt_addr) = config.bolt_listen {
         let bolt_state = state.clone();
         let bolt_auth = state.auth_token.clone();
         let tx_timeout = config.bolt_tx_timeout;
         let bolt_shutdown = shutdown_rx.clone();
+        let bolt_tls = tls_config.clone().map(tls::acceptor);
         tokio::spawn(async move {
-            if let Err(e) =
-                bolt::serve(bolt_state, bolt_addr, bolt_auth, tx_timeout, bolt_shutdown).await
+            if let Err(e) = bolt::serve(
+                bolt_state,
+                bolt_addr,
+                bolt_auth,
+                tx_timeout,
+                bolt_shutdown,
+                bolt_tls,
+            )
+            .await
             {
                 error!(error = %e, "bolt listener exited");
             }
@@ -379,16 +403,37 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
     }
 
     let app = build_router(state);
-
-    let listener = TcpListener::bind(config.listen).await?;
-    info!(addr = %config.listen, "namidb-server listening");
     let mut http_shutdown = shutdown_rx;
-    axum::serve(listener, app)
-        .with_graceful_shutdown(async move {
-            let _ = http_shutdown.wait_for(|stop| *stop).await;
-            info!("shutdown signalled, draining HTTP requests…");
-        })
-        .await?;
+
+    match tls_config {
+        Some(server_config) => {
+            // HTTPS via axum-server. Its `Handle` drives the same SIGTERM /
+            // SIGINT drain the plaintext path gets.
+            let handle = axum_server::Handle::new();
+            let drain = handle.clone();
+            tokio::spawn(async move {
+                let _ = http_shutdown.wait_for(|stop| *stop).await;
+                info!("shutdown signalled, draining HTTPS requests…");
+                drain.graceful_shutdown(Some(Duration::from_secs(10)));
+            });
+            let rustls = axum_server::tls_rustls::RustlsConfig::from_config(server_config);
+            info!(addr = %config.listen, "namidb-server listening (TLS)");
+            axum_server::bind_rustls(config.listen, rustls)
+                .handle(handle)
+                .serve(app.into_make_service())
+                .await?;
+        }
+        None => {
+            let listener = TcpListener::bind(config.listen).await?;
+            info!(addr = %config.listen, "namidb-server listening");
+            axum::serve(listener, app)
+                .with_graceful_shutdown(async move {
+                    let _ = http_shutdown.wait_for(|stop| *stop).await;
+                    info!("shutdown signalled, draining HTTP requests…");
+                })
+                .await?;
+        }
+    }
     Ok(())
 }
 

--- a/crates/namidb-server/src/main.rs
+++ b/crates/namidb-server/src/main.rs
@@ -139,6 +139,15 @@ struct Cli {
         value_parser = humantime::parse_duration,
     )]
     write_stall_delay: Duration,
+
+    /// PEM certificate-chain file. Set together with `--tls-key` to serve the
+    /// HTTP and Bolt listeners over TLS; omit both to serve plaintext.
+    #[arg(long, env = "NAMIDB_TLS_CERT")]
+    tls_cert: Option<std::path::PathBuf>,
+
+    /// PEM private-key file paired with `--tls-cert`.
+    #[arg(long, env = "NAMIDB_TLS_KEY")]
+    tls_key: Option<std::path::PathBuf>,
 }
 
 fn main() -> anyhow::Result<()> {
@@ -165,6 +174,8 @@ fn main() -> anyhow::Result<()> {
         compaction_l0_trigger: cli.compaction_l0_trigger,
         write_stall_l0: cli.write_stall_l0,
         write_stall_delay: cli.write_stall_delay,
+        tls_cert: cli.tls_cert,
+        tls_key: cli.tls_key,
     };
 
     let rt = tokio::runtime::Builder::new_multi_thread()

--- a/crates/namidb-server/src/tls.rs
+++ b/crates/namidb-server/src/tls.rs
@@ -1,0 +1,95 @@
+//! TLS for the serving path (HTTP and Bolt).
+//!
+//! Loads a PEM certificate chain and private key once and shares a single
+//! [`rustls::ServerConfig`] between the HTTP server (via `axum-server`) and
+//! the Bolt listener (via a [`tokio_rustls::TlsAcceptor`]). When `--tls-cert`
+//! / `--tls-key` are not configured the server stays plaintext, exactly as
+//! before. The `ring` crypto provider is selected explicitly so the build
+//! needs no aws-lc-rs C toolchain and there is no ambiguity about which
+//! provider serves the handshake.
+
+use std::io::BufReader;
+use std::path::Path;
+use std::sync::Arc;
+
+use anyhow::{Context, Result};
+use rustls::pki_types::{CertificateDer, PrivateKeyDer};
+use rustls::ServerConfig;
+use tokio_rustls::TlsAcceptor;
+
+/// Build a shared rustls server config from PEM cert-chain and key files.
+pub fn load_server_config(cert_path: &Path, key_path: &Path) -> Result<Arc<ServerConfig>> {
+    let certs = load_certs(cert_path)?;
+    let key = load_key(key_path)?;
+    let config =
+        ServerConfig::builder_with_provider(Arc::new(rustls::crypto::ring::default_provider()))
+            .with_safe_default_protocol_versions()
+            .context("rustls: selecting protocol versions")?
+            .with_no_client_auth()
+            .with_single_cert(certs, key)
+            .context("rustls: the certificate and private key do not match or are invalid")?;
+    Ok(Arc::new(config))
+}
+
+/// A `tokio_rustls` acceptor for the Bolt listener, built from the same
+/// config the HTTP server uses.
+pub fn acceptor(config: Arc<ServerConfig>) -> TlsAcceptor {
+    TlsAcceptor::from(config)
+}
+
+fn load_certs(path: &Path) -> Result<Vec<CertificateDer<'static>>> {
+    let file = std::fs::File::open(path)
+        .with_context(|| format!("opening TLS certificate {}", path.display()))?;
+    let mut reader = BufReader::new(file);
+    let certs = rustls_pemfile::certs(&mut reader)
+        .collect::<std::result::Result<Vec<_>, _>>()
+        .with_context(|| format!("parsing TLS certificate {}", path.display()))?;
+    anyhow::ensure!(!certs.is_empty(), "no certificates in {}", path.display());
+    Ok(certs)
+}
+
+fn load_key(path: &Path) -> Result<PrivateKeyDer<'static>> {
+    let file = std::fs::File::open(path)
+        .with_context(|| format!("opening TLS private key {}", path.display()))?;
+    let mut reader = BufReader::new(file);
+    let key = rustls_pemfile::private_key(&mut reader)
+        .with_context(|| format!("parsing TLS private key {}", path.display()))?
+        .ok_or_else(|| anyhow::anyhow!("no private key in {}", path.display()))?;
+    Ok(key)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+
+    fn write_pem(content: &str) -> tempfile::NamedTempFile {
+        let mut f = tempfile::NamedTempFile::new().unwrap();
+        f.write_all(content.as_bytes()).unwrap();
+        f
+    }
+
+    #[test]
+    fn loads_a_self_signed_cert_and_key() {
+        let ck = rcgen::generate_simple_self_signed(vec!["localhost".to_string()]).unwrap();
+        let cert = write_pem(&ck.cert.pem());
+        let key = write_pem(&ck.key_pair.serialize_pem());
+        assert!(load_server_config(cert.path(), key.path()).is_ok());
+    }
+
+    #[test]
+    fn rejects_a_key_that_does_not_parse() {
+        let ck = rcgen::generate_simple_self_signed(vec!["localhost".to_string()]).unwrap();
+        let cert = write_pem(&ck.cert.pem());
+        let bad = write_pem("-----BEGIN PRIVATE KEY-----\nnot base64\n-----END PRIVATE KEY-----\n");
+        assert!(load_server_config(cert.path(), bad.path()).is_err());
+    }
+
+    #[test]
+    fn rejects_a_missing_certificate_file() {
+        let ck = rcgen::generate_simple_self_signed(vec!["localhost".to_string()]).unwrap();
+        let key = write_pem(&ck.key_pair.serialize_pem());
+        let missing = std::path::Path::new("/nonexistent/namidb-tls-cert.pem");
+        assert!(load_server_config(missing, key.path()).is_err());
+    }
+}

--- a/crates/namidb-server/tests/bolt_integration.rs
+++ b/crates/namidb-server/tests/bolt_integration.rs
@@ -301,6 +301,8 @@ async fn boot_bolt_full(
         compaction_l0_trigger: 0,
         write_stall_l0: 0,
         write_stall_delay: Duration::ZERO,
+        tls_cert: None,
+        tls_key: None,
     };
     let task = tokio::spawn(async move {
         if let Err(e) = namidb_server::run(config).await {
@@ -347,6 +349,8 @@ async fn bolt_create_then_match_roundtrip() {
         compaction_l0_trigger: 0,
         write_stall_l0: 0,
         write_stall_delay: Duration::ZERO,
+        tls_cert: None,
+        tls_key: None,
     };
 
     let server_task = tokio::spawn(async move {
@@ -420,6 +424,8 @@ async fn bolt_bad_token_yields_failure() {
         compaction_l0_trigger: 0,
         write_stall_l0: 0,
         write_stall_delay: Duration::ZERO,
+        tls_cert: None,
+        tls_key: None,
     };
 
     let server_task = tokio::spawn(async move {
@@ -557,6 +563,8 @@ async fn bolt_memgraph_introspection_populates_schema() {
         compaction_l0_trigger: 0,
         write_stall_l0: 0,
         write_stall_delay: Duration::ZERO,
+        tls_cert: None,
+        tls_key: None,
     };
     let server_task = tokio::spawn(async move {
         let _ = namidb_server::run(config).await;

--- a/crates/namidb-server/tests/tls_integration.rs
+++ b/crates/namidb-server/tests/tls_integration.rs
@@ -1,0 +1,132 @@
+//! End-to-end TLS on both serving paths: HTTPS for the REST API and TLS for
+//! the Bolt listener. The client verifies the self-signed certificate for
+//! real (it is added to a root store), so this exercises the full handshake,
+//! not a skip-verification shortcut.
+
+use std::sync::Arc;
+use std::time::Duration;
+
+use namidb_server::Config;
+use rustls::pki_types::{CertificateDer, ServerName};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpStream;
+use tokio_rustls::TlsConnector;
+
+struct Certs {
+    cert_path: tempfile::TempPath,
+    key_path: tempfile::TempPath,
+    cert_der: Vec<u8>,
+}
+
+fn self_signed() -> Certs {
+    use std::io::Write;
+    let ck = rcgen::generate_simple_self_signed(vec!["localhost".to_string()]).unwrap();
+    let cert_der = ck.cert.der().to_vec();
+    let mut cert_file = tempfile::NamedTempFile::new().unwrap();
+    cert_file.write_all(ck.cert.pem().as_bytes()).unwrap();
+    let mut key_file = tempfile::NamedTempFile::new().unwrap();
+    key_file
+        .write_all(ck.key_pair.serialize_pem().as_bytes())
+        .unwrap();
+    Certs {
+        cert_path: cert_file.into_temp_path(),
+        key_path: key_file.into_temp_path(),
+        cert_der,
+    }
+}
+
+async fn free_addr() -> std::net::SocketAddr {
+    let l = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = l.local_addr().unwrap();
+    drop(l);
+    addr
+}
+
+async fn wait_ready(addr: std::net::SocketAddr) {
+    for _ in 0..100 {
+        if TcpStream::connect(addr).await.is_ok() {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(50)).await;
+    }
+    panic!("server port {addr} never came up");
+}
+
+#[tokio::test]
+async fn serves_https_and_bolt_over_tls() {
+    let certs = self_signed();
+    let http = free_addr().await;
+    let bolt = free_addr().await;
+
+    let config = Config {
+        store_uri: "memory://tls-it".into(),
+        listen: http,
+        auth_token: None,
+        flush_interval: Duration::ZERO,
+        compaction_interval: Duration::ZERO,
+        sweep_min_age: Duration::ZERO,
+        sweep_delete: false,
+        bolt_listen: Some(bolt),
+        bolt_tx_timeout: Duration::ZERO,
+        query_timeout: Duration::ZERO,
+        query_row_cap: 0,
+        compaction_l0_trigger: 0,
+        write_stall_l0: 0,
+        write_stall_delay: Duration::ZERO,
+        tls_cert: Some(certs.cert_path.to_path_buf()),
+        tls_key: Some(certs.key_path.to_path_buf()),
+    };
+    let task = tokio::spawn(async move {
+        let _ = namidb_server::run(config).await;
+    });
+    wait_ready(http).await;
+    wait_ready(bolt).await;
+
+    // HTTPS: the liveness probe over TLS, verifying the cert against the
+    // "localhost" SAN (127.0.0.1 is where the server bound).
+    let client = reqwest::Client::builder()
+        .add_root_certificate(reqwest::Certificate::from_der(&certs.cert_der).unwrap())
+        .build()
+        .unwrap();
+    let resp = client
+        .get(format!("https://localhost:{}/v0/livez", http.port()))
+        .send()
+        .await
+        .expect("HTTPS request");
+    assert_eq!(resp.status(), reqwest::StatusCode::OK);
+    assert!(resp.text().await.unwrap().contains("ok"));
+
+    // Bolt over TLS: complete a verifying TLS handshake, then the Bolt
+    // handshake on top of the TLS stream.
+    let mut roots = rustls::RootCertStore::empty();
+    roots
+        .add(CertificateDer::from(certs.cert_der.clone()))
+        .unwrap();
+    let client_cfg = rustls::ClientConfig::builder_with_provider(Arc::new(
+        rustls::crypto::ring::default_provider(),
+    ))
+    .with_safe_default_protocol_versions()
+    .unwrap()
+    .with_root_certificates(roots)
+    .with_no_client_auth();
+    let connector = TlsConnector::from(Arc::new(client_cfg));
+    let tcp = TcpStream::connect(("127.0.0.1", bolt.port()))
+        .await
+        .unwrap();
+    let name = ServerName::try_from("localhost").unwrap();
+    let mut tls = connector
+        .connect(name, tcp)
+        .await
+        .expect("Bolt TLS handshake");
+
+    // 0x6060B017 magic + Bolt 5.4 proposal.
+    let hs = [
+        0x60, 0x60, 0xB0, 0x17, 0x00, 0x00, 0x04, 0x05, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    ];
+    tls.write_all(&hs).await.unwrap();
+    let mut reply = [0u8; 4];
+    tls.read_exact(&mut reply).await.unwrap();
+    assert_eq!(reply, [0, 0, 4, 5], "Bolt 5.4 negotiated over TLS");
+
+    task.abort();
+}


### PR DESCRIPTION
Closes the "no TLS on the serving path" P1 gap. A single PEM certificate chain + key (`--tls-cert` / `--tls-key`, env `NAMIDB_TLS_CERT` / `NAMIDB_TLS_KEY`) enables rustls on **both** listeners.

## What changed
- **New `tls` module** loads the PEM cert chain and key into one shared `rustls::ServerConfig`. The `ring` crypto provider is selected explicitly, so the build needs no aws-lc-rs C toolchain and there is no ambiguity about which provider serves the handshake. Versions are aligned with what was already in the lock (rustls 0.23, tokio-rustls 0.26) so no duplicate rustls is pulled in.
- **HTTP** serves HTTPS via `axum-server` when TLS is configured, with its `Handle` wired to the same SIGTERM/SIGINT drain. The plaintext path is untouched (`axum::serve` + `with_graceful_shutdown`).
- **Bolt** wraps each accepted socket with a `tokio_rustls` handshake before running the session. `Session` was already generic over its transport, so this only adds the handshake and a small `run_session` helper shared by the TLS and plaintext branches. The handshake runs in the per-connection task, so a slow/stalled TLS handshake never blocks the accept loop.
- `--tls-cert` and `--tls-key` must be set together; with neither, the server stays plaintext exactly as before.

## Tests
- `tls` unit tests: load a self-signed cert+key (ok), reject an unparseable key, reject a missing cert file.
- `tls_integration`: boots the real server with TLS and, against a self-signed cert the client **verifies for real** (added to a root store, not skip-verification), serves HTTPS `GET /v0/livez` (200) and negotiates **Bolt 5.4 over TLS**.

Full workspace `cargo test` / `clippy` / `fmt` green; the 11 existing Bolt integration tests still pass over the plaintext path.

## Docs
README's `alpha` caveat drops "TLS on the wire" from the in-progress list and the HTTP/Bolt feature line notes optional TLS. CHANGELOG updated.

## Follow-up
mTLS (client-certificate auth) and TLS for the outbound object-store path (already rustls via reqwest/object_store) are out of scope; this is inbound serving TLS.