### PR TITLE
feat(server): Prometheus metrics endpoint and slow-query log

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,21 @@ below and in the release notes.
   and `--tls-key` must be set together; with neither the server stays
   plaintext exactly as before, and the graceful-shutdown drain works on both
   the TLS and plaintext paths.
+- Prometheus metrics and a slow-query log. A new unauthenticated `GET
+  /v0/metrics` renders the process query metrics in the Prometheus text
+  exposition format: `namidb_queries_total` and `namidb_query_duration_seconds`
+  (a latency histogram), both split by protocol (`http` / `bolt`) and read vs
+  write, plus `namidb_queries_in_flight`, `namidb_slow_queries_total`,
+  `namidb_build_info` and `namidb_uptime_seconds`. The registry is a small
+  hand-rolled set of lock-free atomic counters, so the hot path stays
+  allocation-free and pulls in no new dependency. Both serving paths feed one
+  shared registry, and the stopwatch stops before the optional write-stall
+  sleep, so backpressure is not counted as query latency; Bolt schema
+  introspection probes are not counted as queries. Separately,
+  `--slow-query-threshold` (env `NAMIDB_SLOW_QUERY_THRESHOLD`, default `1s`,
+  `0s` disables) logs any query at or above that wall-clock at WARN with its
+  protocol, kind, status, elapsed and statement text. The statement text only,
+  never its parameters, which can carry sensitive values.
 
 ### Changed
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ The engine is the same whether you run it as a library inside your app, as a Rus
 
 It's the same engine across all three. Server and Embedded write to an identical bucket layout, so you can open an embedded notebook against the exact `s3://...` URI a `namidb-server` daemon is serving.
 
-NamiDB is pre-1.0 and alpha: the engine has run inside LESAI for about a year, but it has no external production users yet, several production concerns are still in progress (metrics, broad authz), and it is not yet a drop-in for critical data. Run it over a bucket you own, keep backups (`aws s3 sync`), and treat 0.x as the moving target it is.
+NamiDB is pre-1.0 and alpha: the engine has run inside LESAI for about a year, but it has no external production users yet, several production concerns are still in progress (broad authz, backup/restore), and it is not yet a drop-in for critical data. Run it over a bucket you own, keep backups (`aws s3 sync`), and treat 0.x as the moving target it is.
 
 <br />
 
@@ -95,7 +95,7 @@ NamiDB is pre-1.0 and alpha: the engine has run inside LESAI for about a year, b
 - **Six storage backends.** `memory://`, `file://` (with `flock`-based CAS), `s3://` (AWS S3, R2, MinIO, Tigris, LocalStack), `gs://`, `az://`.
 - **Python bindings.** `pip install namidb`. abi3 wheels for Linux (x86_64 and aarch64), macOS (arm64) and Windows (x86_64), with an sdist fallback everywhere else. Sync and async (`acypher`). Arrow, pandas and polars output.
 - **CLI.** `namidb parse`, `namidb explain --verbose`, `namidb run --store <uri>` for ad-hoc query work against any backend.
-- **HTTP server.** The `namidb-server` binary, with bearer-token auth, a periodic flush loop, a lock-free `/v0/livez` liveness probe, and a small REST API (`/v0/cypher`, `/v0/health`, `/v0/admin/flush`). Optional TLS on both the HTTP and Bolt listeners via `--tls-cert` / `--tls-key` (rustls).
+- **HTTP server.** The `namidb-server` binary, with bearer-token auth, a periodic flush loop, a lock-free `/v0/livez` liveness probe, Prometheus metrics at `/v0/metrics` plus a slow-query log, and a small REST API (`/v0/cypher`, `/v0/health`, `/v0/admin/flush`). Optional TLS on both the HTTP and Bolt listeners via `--tls-cert` / `--tls-key` (rustls).
 - **Bolt protocol.** Same `namidb-server` binary speaks Bolt 4.4 / 5.0 / 5.4 on an opt-in TCP listener (default 7687). Neo4j drivers connect over `bolt://host:7687` and run Cypher, verified end-to-end with the Python driver. The other language drivers (Java, JavaScript, .NET, Go, Rust) speak the same protocol but are not all exercised yet, and GUI clients that introspect the schema hit `CALL` / `SHOW` procedures the parser does not implement yet, so their schema panels come up empty. See [RFC-022](./docs/rfc/022-bolt-protocol.md).
 - **Bench harness.** A synthetic, deterministic LDBC SNB Interactive harness under [`bench/`](./bench/).
 
@@ -351,8 +351,9 @@ curl -X POST http://your-host:8080/v0/cypher \
 
 See [`crates/namidb-server/README.md`](./crates/namidb-server/README.md)
 for the full route reference (`/v0/cypher`, `/v0/health`,
-`/v0/version`, `/v0/admin/flush`), the JSON to Cypher type mapping, and
-the concurrency model.
+`/v0/version`, `/v0/metrics`, `/v0/admin/flush`), the metrics and
+slow-query log, the JSON to Cypher type mapping, and the concurrency
+model.
 
 ### Recipe: docker-compose with MinIO plus namidb-server
 
@@ -530,6 +531,7 @@ performance or memory problem.
 | `NAMIDB_LISTEN` | `0.0.0.0:8080` | TCP bind address. |
 | `NAMIDB_AUTH_TOKEN` | unset (open) | Bearer token. When it's unset the server warns and accepts every request. |
 | `NAMIDB_FLUSH_INTERVAL` | `30s` | Background memtable -> L0 flush cadence. `0s` disables it. |
+| `NAMIDB_SLOW_QUERY_THRESHOLD` | `1s` | Log any query at or above this wall-clock at WARN. `0s` disables the slow-query log. |
 
 <br />
 

--- a/crates/namidb-server/README.md
+++ b/crates/namidb-server/README.md
@@ -41,8 +41,10 @@ internet.
 
 | Method | Path | Auth | Description |
 |---|---|---|---|
-| `GET`  | `/v0/health`       | public  | Liveness + manifest version + epoch |
+| `GET`  | `/v0/livez`        | public  | Lock-free liveness (process is up) |
+| `GET`  | `/v0/health`       | public  | Readiness + manifest version + epoch |
 | `GET`  | `/v0/version`      | public  | Server build version |
+| `GET`  | `/v0/metrics`      | public  | Prometheus metrics (text exposition) |
 | `POST` | `/v0/cypher`       | bearer  | Run a Cypher query (read or write) |
 | `POST` | `/v0/admin/flush`  | bearer  | Force a memtable -> L0 SST flush |
 
@@ -144,6 +146,46 @@ fenced via epoch CAS).
 task turns the memtable into L0 SSTs. Set it to `0s` to disable the loop
 and call `POST /v0/admin/flush` from cron or a sidecar instead.
 
+## Metrics and the slow-query log
+
+`GET /v0/metrics` renders the process query metrics in the Prometheus
+text exposition format. It is unauthenticated, like `/v0/livez` and
+`/v0/health`, so a scraper needs no bearer token. When TLS is on it is
+served over HTTPS on the same listener.
+
+```bash
+curl -s http://127.0.0.1:8080/v0/metrics
+```
+
+| Metric | Type | Labels | What it is |
+|---|---|---|---|
+| `namidb_queries_total`          | counter   | `protocol`, `status` | Queries executed, by `http`/`bolt` and `ok`/`error` |
+| `namidb_query_duration_seconds` | histogram | `protocol`, `kind`   | Execution wall-clock, by `http`/`bolt` and `read`/`write` |
+| `namidb_queries_in_flight`      | gauge     |                      | Queries currently executing |
+| `namidb_slow_queries_total`     | counter   |                      | Queries that crossed the slow-query threshold |
+| `namidb_build_info`             | gauge     | `version`            | Always `1`; carries the build version |
+| `namidb_uptime_seconds`         | gauge     |                      | Seconds since the server started |
+
+Duration is measured per query and stops at the end of execution, so the
+optional write-stall backpressure sleep is not counted as query latency.
+Bolt schema-introspection probes (the `CALL` / `SHOW` calls GUIs issue)
+are not counted as queries.
+
+The **slow-query log** is separate from the metrics and controlled by
+`--slow-query-threshold` (env `NAMIDB_SLOW_QUERY_THRESHOLD`, default
+`1s`, set `0s` to disable). Any query at or above that wall-clock is
+logged at `WARN`:
+
+```
+WARN slow query protocol="http" kind="read" status="ok" elapsed_ms=1840 query="MATCH (a:Person)-[:KNOWS*2]-(b) RETURN count(b)"
+```
+
+The statement text is logged truncated; parameters are never logged,
+since they can carry sensitive values. The statement text itself is, so
+a value inlined as a literal in the Cypher source (rather than passed as
+a `$param`) does land in the log, the same as any SQL slow-query log.
+Parameterise sensitive values to keep them out of it.
+
 ## Bolt protocol
 
 Pass `--bolt-listen 0.0.0.0:7687` (or `NAMIDB_BOLT_LISTEN`) to expose
@@ -177,8 +219,7 @@ design.
 - `/v0/cypher/stream`: NDJSON streaming for large read result sets.
 - `/v0/cypher/arrow`: an Arrow IPC body for zero-copy DataFrame
   ingestion.
-- `/v0/metrics`: Prometheus exposition (counters, latency histogram,
-  cache hit rates).
+- Cache hit-rate gauges on `/v0/metrics` (adjacency, node, SST caches).
 
 See the project [`README`](../../README.md) and [`docs/rfc/`](../../docs/rfc/)
 for engine internals.

--- a/crates/namidb-server/src/bolt.rs
+++ b/crates/namidb-server/src/bolt.rs
@@ -23,7 +23,18 @@ use tokio::sync::{Mutex, OwnedMutexGuard};
 use tracing::{error, info, warn};
 use uuid::Uuid;
 
+use crate::metrics::{Protocol, QueryKind};
 use crate::AppState;
+
+/// One executed Bolt query, classified for metrics: read vs write (`None` if
+/// it failed before planning), the wall-clock it took (up to the end of
+/// execution, excluding any write-stall sleep), and the outcome the protocol
+/// returns to the driver.
+struct RunObservation {
+    kind: Option<QueryKind>,
+    elapsed: std::time::Duration,
+    result: std::result::Result<RunOutcome, BackendError>,
+}
 
 /// In-flight explicit transaction (BEGIN..COMMIT/ROLLBACK). Holds the
 /// global writer lock for the whole transaction so no other writer — nor
@@ -52,6 +63,195 @@ impl ServerBackend {
             tx: Mutex::new(None),
         }
     }
+
+    /// Auto-commit query: parse, plan, and execute against the published
+    /// snapshot (reads) or the writer lock (writes), timing the work for the
+    /// metrics. Mirrors the HTTP `run_cypher`. The stopwatch stops at the end
+    /// of execution, before the optional write-stall sleep, so backpressure is
+    /// not counted as query latency.
+    async fn run_query(&self, cypher: &str, params: Params) -> RunObservation {
+        let started = std::time::Instant::now();
+
+        let parsed = match cypher_parse(cypher) {
+            Ok(p) => p,
+            Err(errs) => {
+                let first = &errs[0];
+                return RunObservation {
+                    kind: None,
+                    elapsed: started.elapsed(),
+                    result: Err(BackendError::Syntax(format!(
+                        "{} at {}",
+                        first.message, first.span
+                    ))),
+                };
+            }
+        };
+        // Plan against the latest published snapshot — no writer lock.
+        let owned = self.state.snapshot.load();
+        let catalog = self.state.catalog_for(&owned.manifest().manifest);
+        let plan = match build_plan(&parsed, &catalog).map_err(map_lower_err) {
+            Ok(p) => p,
+            Err(e) => {
+                return RunObservation {
+                    kind: None,
+                    elapsed: started.elapsed(),
+                    result: Err(e),
+                };
+            }
+        };
+
+        if plan.contains_write() {
+            // Writes still take the writer lock (single-writer invariant).
+            // On success we refresh the snapshot cell so subsequent reads
+            // see the just-committed records (RFC-021).
+            let mut writer = self.state.writer.lock().await;
+            match execute_write(&plan, &mut writer, &params).await {
+                Ok(outcome) => {
+                    self.state.snapshot.store(writer.owned_snapshot());
+                    // Soft write stall (RFC-027 P5): sample under the lock,
+                    // release, then back off this request if L0 is piling up.
+                    let stall = self.state.write_stall_for(writer.max_l0_bucket_len());
+                    drop(writer);
+                    let elapsed = started.elapsed();
+                    if let Some(delay) = stall {
+                        tokio::time::sleep(delay).await;
+                    }
+                    RunObservation {
+                        kind: Some(QueryKind::Write),
+                        elapsed,
+                        result: Ok(write_run_outcome(outcome)),
+                    }
+                }
+                Err(e) => {
+                    drop(writer);
+                    RunObservation {
+                        kind: Some(QueryKind::Write),
+                        elapsed: started.elapsed(),
+                        result: Err(map_exec_err(e)),
+                    }
+                }
+            }
+        } else {
+            // Read path: borrow a short-lived `Snapshot` from the owned
+            // snapshot; the Arc keeps the underlying memtable alive for
+            // the duration of the query, no writer lock needed.
+            let snap = owned.borrow();
+            let rows = execute_with_limits(
+                &plan,
+                &snap,
+                &params,
+                self.state.query_deadline(),
+                self.state.query_row_cap(),
+            )
+            .await;
+            let elapsed = started.elapsed();
+            RunObservation {
+                kind: Some(QueryKind::Read),
+                elapsed,
+                result: rows.map(read_run_outcome).map_err(map_exec_err),
+            }
+        }
+    }
+
+    /// In-transaction query: stage writes into the held transaction's writer
+    /// (no commit) or read with the staged batch overlaid (RFC-026), timing the
+    /// work for the metrics. Mirrors the auto-commit `run_query`.
+    async fn run_query_in_tx(&self, cypher: &str, params: Params) -> RunObservation {
+        let started = std::time::Instant::now();
+
+        let parsed = match cypher_parse(cypher) {
+            Ok(p) => p,
+            Err(errs) => {
+                let first = &errs[0];
+                return RunObservation {
+                    kind: None,
+                    elapsed: started.elapsed(),
+                    result: Err(BackendError::Syntax(format!(
+                        "{} at {}",
+                        first.message, first.span
+                    ))),
+                };
+            }
+        };
+        let owned = self.state.snapshot.load();
+        let catalog = self.state.catalog_for(&owned.manifest().manifest);
+        let plan = match build_plan(&parsed, &catalog).map_err(map_lower_err) {
+            Ok(p) => p,
+            Err(e) => {
+                return RunObservation {
+                    kind: None,
+                    elapsed: started.elapsed(),
+                    result: Err(e),
+                };
+            }
+        };
+
+        if plan.contains_write() {
+            // Stage into the transaction's held writer; do NOT commit. The
+            // RETURN rows are computed during the apply, so they stream now.
+            let mut slot = self.tx.lock().await;
+            let tx = match slot.as_mut() {
+                Some(tx) => tx,
+                None => {
+                    return RunObservation {
+                        kind: Some(QueryKind::Write),
+                        elapsed: started.elapsed(),
+                        result: Err(BackendError::Other("no open transaction".into())),
+                    };
+                }
+            };
+            let result = match execute_write_staged(&plan, &mut tx.writer, &params).await {
+                Ok(outcome) => {
+                    tx.staged = true;
+                    Ok(write_run_outcome(outcome))
+                }
+                Err(e) => {
+                    // A failed statement aborts the transaction. Drop whatever
+                    // it (or an earlier statement) staged so a stray COMMIT
+                    // cannot seal a partial write; the session moves to FAILED
+                    // and the client must ROLLBACK / RESET.
+                    tx.writer.discard_batch();
+                    Err(map_exec_err(e))
+                }
+            };
+            RunObservation {
+                kind: Some(QueryKind::Write),
+                elapsed: started.elapsed(),
+                result,
+            }
+        } else {
+            // Read against the transaction's own writer so the staged batch
+            // is visible (RFC-026). The writer pins the committed state at
+            // tx-begin (no commit happens mid-tx while we hold the lock) and
+            // overlays everything statements 1..N-1 staged.
+            let mut slot = self.tx.lock().await;
+            let tx = match slot.as_mut() {
+                Some(tx) => tx,
+                None => {
+                    return RunObservation {
+                        kind: Some(QueryKind::Read),
+                        elapsed: started.elapsed(),
+                        result: Err(BackendError::Other("no open transaction".into())),
+                    };
+                }
+            };
+            let snap = tx.writer.overlay_snapshot();
+            let rows = execute_with_limits(
+                &plan,
+                &snap,
+                &params,
+                self.state.query_deadline(),
+                self.state.query_row_cap(),
+            )
+            .await;
+            let elapsed = started.elapsed();
+            RunObservation {
+                kind: Some(QueryKind::Read),
+                elapsed,
+                result: rows.map(read_run_outcome).map_err(map_exec_err),
+            }
+        }
+    }
 }
 
 #[async_trait]
@@ -65,6 +265,8 @@ impl Backend for ServerBackend {
         // GUIs) hits procedures the Cypher parser has no `CALL` clause
         // for. Answer them from the live snapshot before the parser
         // would reject them as a syntax error. See `crate::introspect`.
+        // These are schema metadata probes, not user queries, so they are
+        // intentionally not counted toward the query metrics.
         {
             let owned = self.state.snapshot.load();
             let snap = owned.borrow();
@@ -73,54 +275,16 @@ impl Backend for ServerBackend {
             }
         }
 
-        let parsed = match cypher_parse(cypher) {
-            Ok(p) => p,
-            Err(errs) => {
-                let first = &errs[0];
-                return Err(BackendError::Syntax(format!(
-                    "{} at {}",
-                    first.message, first.span
-                )));
-            }
-        };
-        // Plan against the latest published snapshot — no writer lock.
-        let owned = self.state.snapshot.load();
-        let catalog = self.state.catalog_for(&owned.manifest().manifest);
-        let plan = build_plan(&parsed, &catalog).map_err(map_lower_err)?;
-
-        if plan.contains_write() {
-            // Writes still take the writer lock (single-writer invariant).
-            // On success we refresh the snapshot cell so subsequent reads
-            // see the just-committed records (RFC-021).
-            let mut writer = self.state.writer.lock().await;
-            let outcome = execute_write(&plan, &mut writer, &params)
-                .await
-                .map_err(map_exec_err)?;
-            self.state.snapshot.store(writer.owned_snapshot());
-            // Soft write stall (RFC-027 P5): sample under the lock, release,
-            // then back off this request if L0 is piling up.
-            let stall = self.state.write_stall_for(writer.max_l0_bucket_len());
-            drop(writer);
-            if let Some(delay) = stall {
-                tokio::time::sleep(delay).await;
-            }
-            Ok(write_run_outcome(outcome))
-        } else {
-            // Read path: borrow a short-lived `Snapshot` from the owned
-            // snapshot; the Arc keeps the underlying memtable alive for
-            // the duration of the query, no writer lock needed.
-            let snap = owned.borrow();
-            let rows = execute_with_limits(
-                &plan,
-                &snap,
-                &params,
-                self.state.query_deadline(),
-                self.state.query_row_cap(),
-            )
-            .await
-            .map_err(map_exec_err)?;
-            Ok(read_run_outcome(rows))
-        }
+        let _in_flight = self.state.metrics.track_in_flight();
+        let obs = self.run_query(cypher, params).await;
+        self.state.metrics.observe_query(
+            Protocol::Bolt,
+            obs.kind,
+            obs.result.is_ok(),
+            obs.elapsed,
+            cypher,
+        );
+        obs.result
     }
 
     async fn begin_tx(&self) -> std::result::Result<(), BackendError> {
@@ -146,7 +310,8 @@ impl Backend for ServerBackend {
         // Introspection runs against the published snapshot (schema only).
         // Data reads, below, run against the transaction's own writer with
         // its staged batch overlaid, so an in-tx read sees the tx's own
-        // staged writes (read-your-own-writes, RFC-026).
+        // staged writes (read-your-own-writes, RFC-026). Introspection is a
+        // schema probe, not a user query, so it is not counted in the metrics.
         {
             let owned = self.state.snapshot.load();
             let snap = owned.borrow();
@@ -154,61 +319,17 @@ impl Backend for ServerBackend {
                 return result;
             }
         }
-        let parsed = match cypher_parse(cypher) {
-            Ok(p) => p,
-            Err(errs) => {
-                let first = &errs[0];
-                return Err(BackendError::Syntax(format!(
-                    "{} at {}",
-                    first.message, first.span
-                )));
-            }
-        };
-        let owned = self.state.snapshot.load();
-        let catalog = self.state.catalog_for(&owned.manifest().manifest);
-        let plan = build_plan(&parsed, &catalog).map_err(map_lower_err)?;
 
-        if plan.contains_write() {
-            // Stage into the transaction's held writer; do NOT commit. The
-            // RETURN rows are computed during the apply, so they stream now.
-            let mut slot = self.tx.lock().await;
-            let tx = slot
-                .as_mut()
-                .ok_or_else(|| BackendError::Other("no open transaction".into()))?;
-            let outcome = match execute_write_staged(&plan, &mut tx.writer, &params).await {
-                Ok(outcome) => outcome,
-                Err(e) => {
-                    // A failed statement aborts the transaction. Drop whatever
-                    // it (or an earlier statement) staged so a stray COMMIT
-                    // cannot seal a partial write; the session moves to FAILED
-                    // and the client must ROLLBACK / RESET.
-                    tx.writer.discard_batch();
-                    return Err(map_exec_err(e));
-                }
-            };
-            tx.staged = true;
-            Ok(write_run_outcome(outcome))
-        } else {
-            // Read against the transaction's own writer so the staged batch
-            // is visible (RFC-026). The writer pins the committed state at
-            // tx-begin (no commit happens mid-tx while we hold the lock) and
-            // overlays everything statements 1..N-1 staged.
-            let mut slot = self.tx.lock().await;
-            let tx = slot
-                .as_mut()
-                .ok_or_else(|| BackendError::Other("no open transaction".into()))?;
-            let snap = tx.writer.overlay_snapshot();
-            let rows = execute_with_limits(
-                &plan,
-                &snap,
-                &params,
-                self.state.query_deadline(),
-                self.state.query_row_cap(),
-            )
-            .await
-            .map_err(map_exec_err)?;
-            Ok(read_run_outcome(rows))
-        }
+        let _in_flight = self.state.metrics.track_in_flight();
+        let obs = self.run_query_in_tx(cypher, params).await;
+        self.state.metrics.observe_query(
+            Protocol::Bolt,
+            obs.kind,
+            obs.result.is_ok(),
+            obs.elapsed,
+            cypher,
+        );
+        obs.result
     }
 
     async fn commit_tx(&self) -> std::result::Result<(), BackendError> {

--- a/crates/namidb-server/src/bolt.rs
+++ b/crates/namidb-server/src/bolt.rs
@@ -193,8 +193,11 @@ impl ServerBackend {
             let tx = match slot.as_mut() {
                 Some(tx) => tx,
                 None => {
+                    // A protocol-state error, not an executed query: keep it out
+                    // of the latency histogram (kind None) like a parse/plan
+                    // error. It still counts toward queries_total status=error.
                     return RunObservation {
-                        kind: Some(QueryKind::Write),
+                        kind: None,
                         elapsed: started.elapsed(),
                         result: Err(BackendError::Other("no open transaction".into())),
                     };
@@ -228,8 +231,10 @@ impl ServerBackend {
             let tx = match slot.as_mut() {
                 Some(tx) => tx,
                 None => {
+                    // See the write branch: a no-open-transaction error is a
+                    // protocol-state error, not an executed query.
                     return RunObservation {
-                        kind: Some(QueryKind::Read),
+                        kind: None,
                         elapsed: started.elapsed(),
                         result: Err(BackendError::Other("no open transaction".into())),
                     };

--- a/crates/namidb-server/src/lib.rs
+++ b/crates/namidb-server/src/lib.rs
@@ -8,6 +8,7 @@
 
 pub mod bolt;
 mod introspect;
+pub mod metrics;
 pub mod tls;
 
 use std::sync::Arc;
@@ -29,6 +30,8 @@ use namidb_query::{
     RuntimeValue, StatsCatalog, WriteOutcome,
 };
 use namidb_storage::{sweep_orphans, Manifest, ManifestStore, SnapshotCell, WriterSession};
+
+use crate::metrics::{Metrics, Protocol, QueryKind};
 
 /// Process-wide configuration assembled from CLI flags or env vars.
 #[derive(Debug, Clone)]
@@ -86,6 +89,11 @@ pub struct Config {
     pub tls_cert: Option<std::path::PathBuf>,
     /// PEM private-key file paired with `tls_cert`.
     pub tls_key: Option<std::path::PathBuf>,
+    /// Wall-clock at or above which a query is logged at `warn!` as a slow
+    /// query (the statement text, never its parameters). The Prometheus
+    /// counters and latency histograms at `/v0/metrics` are always on
+    /// regardless of this. `Duration::ZERO` disables the slow-query log.
+    pub slow_query_threshold: Duration,
 }
 
 /// `(manifest_version, catalog)` memoised behind a mutex and shared across
@@ -120,6 +128,11 @@ pub struct AppState {
     /// disabled; the server sets them from [`Config`] at boot.
     write_stall_l0: usize,
     write_stall_delay: Duration,
+    /// Process-wide query metrics, shared across every connection on both
+    /// serving paths. Rendered at `/v0/metrics` and the home of the
+    /// slow-query log. Defaults to a registry with the slow-query log
+    /// disabled; the server sets the threshold from [`Config`] at boot.
+    pub metrics: Arc<Metrics>,
 }
 
 impl AppState {
@@ -135,7 +148,16 @@ impl AppState {
             query_row_cap: 0,
             write_stall_l0: 0,
             write_stall_delay: Duration::ZERO,
+            metrics: Metrics::new(env!("CARGO_PKG_VERSION"), Duration::ZERO),
         }
+    }
+
+    /// Set the slow-query threshold (builder style). `Duration::ZERO` leaves
+    /// the slow-query log off. Replaces the metrics registry, so call this at
+    /// boot before any query is served.
+    pub fn with_slow_query_threshold(mut self, threshold: Duration) -> Self {
+        self.metrics = Metrics::new(env!("CARGO_PKG_VERSION"), threshold);
+        self
     }
 
     /// Set the soft write-stall threshold and delay (builder style). A
@@ -202,13 +224,15 @@ impl AppState {
 }
 
 /// Assemble the `axum` router with every public route + auth
-/// middleware. `/v0/livez`, `/v0/health` and `/v0/version` are intentionally
-/// excluded from the auth check (a healthcheck probe carries no token).
+/// middleware. `/v0/livez`, `/v0/health`, `/v0/version` and `/v0/metrics` are
+/// intentionally excluded from the auth check (a healthcheck probe or a
+/// Prometheus scraper carries no token).
 pub fn build_router(state: AppState) -> Router {
     let public = Router::new()
         .route("/v0/livez", get(livez))
         .route("/v0/health", get(health))
-        .route("/v0/version", get(version));
+        .route("/v0/version", get(version))
+        .route("/v0/metrics", get(metrics_handler));
 
     let private = Router::new()
         .route("/v0/cypher", post(cypher))
@@ -248,7 +272,8 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
     let state = AppState::new(writer, config.auth_token.clone(), namespace)
         .with_query_timeout(config.query_timeout)
         .with_query_row_cap(config.query_row_cap)
-        .with_write_stall(config.write_stall_l0, config.write_stall_delay);
+        .with_write_stall(config.write_stall_l0, config.write_stall_delay)
+        .with_slow_query_threshold(config.slow_query_threshold);
 
     // Periodic flush task — keeps the WAL bounded and L0 SSTs current.
     if config.flush_interval > Duration::ZERO {
@@ -561,6 +586,19 @@ async fn version() -> impl IntoResponse {
     })
 }
 
+/// Prometheus scrape endpoint. Renders the process query metrics in the text
+/// exposition format. Unauthenticated, like the health probes, so a scraper
+/// needs no bearer token.
+async fn metrics_handler(State(state): State<AppState>) -> impl IntoResponse {
+    (
+        [(
+            axum::http::header::CONTENT_TYPE,
+            HeaderValue::from_static("text/plain; version=0.0.4; charset=utf-8"),
+        )],
+        state.metrics.render(),
+    )
+}
+
 #[derive(Deserialize)]
 struct CypherRequest {
     query: String,
@@ -597,25 +635,62 @@ impl From<&WriteOutcome> for WriteSummary {
     }
 }
 
+/// One executed query, classified for metrics: read vs write (`None` if it
+/// failed before planning), whether it succeeded, the wall-clock it took
+/// (measured up to the end of execution, excluding any write-stall sleep), and
+/// the HTTP response to return.
+struct ObservedQuery {
+    kind: Option<QueryKind>,
+    ok: bool,
+    elapsed: Duration,
+    response: Response,
+}
+
 async fn cypher(State(state): State<AppState>, Json(req): Json<CypherRequest>) -> Response {
+    // The guard drops at the end of the handler, so the in-flight gauge is
+    // correct even on an early error return.
+    let _in_flight = state.metrics.track_in_flight();
+    let obs = run_cypher(&state, &req).await;
+    state
+        .metrics
+        .observe_query(Protocol::Http, obs.kind, obs.ok, obs.elapsed, &req.query);
+    obs.response
+}
+
+/// Run one HTTP Cypher request and classify it for metrics. Mirrors the Bolt
+/// `ServerBackend::run` path; the two do not share a chokepoint, so the
+/// parse/plan/execute logic is intentionally parallel.
+async fn run_cypher(state: &AppState, req: &CypherRequest) -> ObservedQuery {
+    let started = std::time::Instant::now();
+
     let parsed = match cypher_parse(&req.query) {
         Ok(p) => p,
         Err(errs) => {
             let first = &errs[0];
-            return (
-                StatusCode::BAD_REQUEST,
-                Json(ErrorBody {
-                    error: format!("parse error: {} at {}", first.message, first.span),
-                }),
-            )
-                .into_response();
+            return ObservedQuery {
+                kind: None,
+                ok: false,
+                elapsed: started.elapsed(),
+                response: (
+                    StatusCode::BAD_REQUEST,
+                    Json(ErrorBody {
+                        error: format!("parse error: {} at {}", first.message, first.span),
+                    }),
+                )
+                    .into_response(),
+            };
         }
     };
 
     let params = match params_from_json(&req.params) {
         Ok(p) => p,
         Err(e) => {
-            return (StatusCode::BAD_REQUEST, Json(ErrorBody { error: e })).into_response();
+            return ObservedQuery {
+                kind: None,
+                ok: false,
+                elapsed: started.elapsed(),
+                response: (StatusCode::BAD_REQUEST, Json(ErrorBody { error: e })).into_response(),
+            };
         }
     };
 
@@ -626,13 +701,18 @@ async fn cypher(State(state): State<AppState>, Json(req): Json<CypherRequest>) -
         match build_plan(&parsed, &catalog) {
             Ok(p) => p,
             Err(e) => {
-                return (
-                    StatusCode::BAD_REQUEST,
-                    Json(ErrorBody {
-                        error: format!("plan error: {e}"),
-                    }),
-                )
-                    .into_response();
+                return ObservedQuery {
+                    kind: None,
+                    ok: false,
+                    elapsed: started.elapsed(),
+                    response: (
+                        StatusCode::BAD_REQUEST,
+                        Json(ErrorBody {
+                            error: format!("plan error: {e}"),
+                        }),
+                    )
+                        .into_response(),
+                };
             }
         }
     };
@@ -652,6 +732,10 @@ async fn cypher(State(state): State<AppState>, Json(req): Json<CypherRequest>) -
             None
         };
         drop(writer);
+        // Stop the clock before the backpressure sleep: the stall is
+        // intentional throttling, not query cost, so it must not inflate the
+        // latency histogram or trip the slow-query log.
+        let elapsed = started.elapsed();
         if let Some(delay) = stall {
             tokio::time::sleep(delay).await;
         }
@@ -659,51 +743,72 @@ async fn cypher(State(state): State<AppState>, Json(req): Json<CypherRequest>) -
             Ok(outcome) => {
                 let summary = WriteSummary::from(&outcome);
                 let (columns, rows) = rows_to_json(&outcome.rows);
-                Json(CypherResponse {
-                    columns,
-                    rows,
-                    write_outcome: Some(summary),
-                })
-                .into_response()
+                ObservedQuery {
+                    kind: Some(QueryKind::Write),
+                    ok: true,
+                    elapsed,
+                    response: Json(CypherResponse {
+                        columns,
+                        rows,
+                        write_outcome: Some(summary),
+                    })
+                    .into_response(),
+                }
             }
-            Err(e) => (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorBody {
-                    error: format!("write execution failed: {e}"),
-                }),
-            )
-                .into_response(),
+            Err(e) => ObservedQuery {
+                kind: Some(QueryKind::Write),
+                ok: false,
+                elapsed,
+                response: (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorBody {
+                        error: format!("write execution failed: {e}"),
+                    }),
+                )
+                    .into_response(),
+            },
         }
     } else {
         // Read path: no writer lock. Borrow a short-lived `Snapshot`
         // from the owned one; the `OwnedSnapshot` Arc keeps the
         // underlying memtable alive for the duration of the query.
         let snap = owned.borrow();
-        match execute_with_limits(
+        let result = execute_with_limits(
             &plan,
             &snap,
             &params,
             state.query_deadline(),
             state.query_row_cap(),
         )
-        .await
-        {
+        .await;
+        let elapsed = started.elapsed();
+        match result {
             Ok(rows) => {
                 let (columns, rows) = rows_to_json(&rows);
-                Json(CypherResponse {
-                    columns,
-                    rows,
-                    write_outcome: None,
-                })
-                .into_response()
+                ObservedQuery {
+                    kind: Some(QueryKind::Read),
+                    ok: true,
+                    elapsed,
+                    response: Json(CypherResponse {
+                        columns,
+                        rows,
+                        write_outcome: None,
+                    })
+                    .into_response(),
+                }
             }
-            Err(e) => (
-                StatusCode::INTERNAL_SERVER_ERROR,
-                Json(ErrorBody {
-                    error: format!("read execution failed: {e}"),
-                }),
-            )
-                .into_response(),
+            Err(e) => ObservedQuery {
+                kind: Some(QueryKind::Read),
+                ok: false,
+                elapsed,
+                response: (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    Json(ErrorBody {
+                        error: format!("read execution failed: {e}"),
+                    }),
+                )
+                    .into_response(),
+            },
         }
     }
 }
@@ -1083,6 +1188,79 @@ mod tests {
         assert_eq!(rows.len(), 1);
         assert_eq!(rows[0]["name"], "Alice");
         assert_eq!(rows[0]["age"], 30);
+    }
+
+    #[tokio::test]
+    async fn metrics_endpoint_is_public_and_renders_prometheus() {
+        // Even with auth set, the scrape carries no bearer token and must
+        // still be served, like the health probes.
+        let app = fixture(Some("secret")).await;
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/v0/metrics")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let ct = resp
+            .headers()
+            .get(axum::http::header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or_default()
+            .to_string();
+        assert!(ct.starts_with("text/plain"), "content-type was {ct}");
+        let body = to_bytes(resp.into_body(), 64 * 1024).await.unwrap();
+        let text = String::from_utf8(body.to_vec()).unwrap();
+        assert!(text.contains("namidb_build_info{version="));
+        assert!(text.contains("namidb_queries_total{protocol=\"http\",status=\"ok\"}"));
+        assert!(text.contains("namidb_query_duration_seconds_bucket"));
+    }
+
+    #[tokio::test]
+    async fn cypher_request_increments_query_metrics() {
+        let app = fixture(None).await;
+
+        // One successful read query.
+        let read = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v0/cypher")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::to_vec(&serde_json::json!({"query": "MATCH (n) RETURN n"}))
+                            .unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(read.status(), StatusCode::OK);
+
+        // The shared metrics registry (Arc on the cloned state) reflects it.
+        let scrape = app
+            .oneshot(
+                Request::builder()
+                    .uri("/v0/metrics")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let body = to_bytes(scrape.into_body(), 64 * 1024).await.unwrap();
+        let text = String::from_utf8(body.to_vec()).unwrap();
+        assert!(
+            text.contains("namidb_queries_total{protocol=\"http\",status=\"ok\"} 1"),
+            "metrics did not count the read query:\n{text}"
+        );
+        assert!(
+            text.contains("namidb_query_duration_seconds_count{protocol=\"http\",kind=\"read\"} 1"),
+            "read histogram did not record the query:\n{text}"
+        );
     }
 
     #[tokio::test]

--- a/crates/namidb-server/src/main.rs
+++ b/crates/namidb-server/src/main.rs
@@ -148,6 +148,18 @@ struct Cli {
     /// PEM private-key file paired with `--tls-cert`.
     #[arg(long, env = "NAMIDB_TLS_KEY")]
     tls_key: Option<std::path::PathBuf>,
+
+    /// Wall-clock at or above which a query is logged at WARN as a slow query
+    /// (the statement text, never its parameters). The Prometheus counters and
+    /// latency histograms at `/v0/metrics` are always on regardless of this.
+    /// Set to `0s` to turn the slow-query log off.
+    #[arg(
+        long,
+        env = "NAMIDB_SLOW_QUERY_THRESHOLD",
+        default_value = "1s",
+        value_parser = humantime::parse_duration,
+    )]
+    slow_query_threshold: Duration,
 }
 
 fn main() -> anyhow::Result<()> {
@@ -176,6 +188,7 @@ fn main() -> anyhow::Result<()> {
         write_stall_delay: cli.write_stall_delay,
         tls_cert: cli.tls_cert,
         tls_key: cli.tls_key,
+        slow_query_threshold: cli.slow_query_threshold,
     };
 
     let rt = tokio::runtime::Builder::new_multi_thread()

--- a/crates/namidb-server/src/metrics.rs
+++ b/crates/namidb-server/src/metrics.rs
@@ -12,8 +12,10 @@
 //! [`Metrics::observe_query`] exactly once per query with the protocol, the
 //! read/write kind, whether it succeeded, and the wall-clock it took. When a
 //! query crosses the configured slow-query threshold the same call emits a
-//! structured `warn!` line (the query text, never its parameters, which may
-//! carry sensitive values).
+//! structured `warn!` line. Query parameters are never logged, since they
+//! routinely carry sensitive values. Note the statement text itself is, so a
+//! value inlined as a literal in the Cypher source (rather than passed as a
+//! parameter) does land in the log, the same as every SQL slow-query log.
 
 use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
 use std::sync::Arc;
@@ -100,22 +102,33 @@ impl Histogram {
 
     /// Render the `_bucket`/`_sum`/`_count` lines for one label set. `labels`
     /// is the inner label list without braces, e.g. `protocol="http",kind="read"`.
+    ///
+    /// The fields are independent atomics read without a lock, so a scrape that
+    /// races a live `observe` would otherwise risk `+Inf < _count`, which the
+    /// Prometheus exposition format forbids. We anchor on a single `count`
+    /// read: every bounded bucket's cumulative value is clamped to it and the
+    /// `+Inf` bucket is set equal to it, so the output always satisfies
+    /// `bucket[i] <= bucket[i+1] <= +Inf == _count`. The worst a race can do is
+    /// momentarily under-report a bounded bucket, which the next scrape heals.
     fn render_into(&self, out: &mut String, name: &str, labels: &str) {
         use std::fmt::Write as _;
+        let total = self.count.load(Ordering::Relaxed);
         let mut cumulative: u64 = 0;
         for (i, &bound) in BUCKET_BOUNDS_S.iter().enumerate() {
             cumulative += self.counts[i].load(Ordering::Relaxed);
-            let _ = writeln!(out, "{name}_bucket{{{labels},le=\"{bound}\"}} {cumulative}");
+            // `{bound:?}` keeps the canonical float form (`1.0`, `10.0`), which
+            // is the `le` label every Prometheus client library emits; plain
+            // Display would drop the decimal (`1`, `10`).
+            let _ = writeln!(
+                out,
+                "{name}_bucket{{{labels},le=\"{bound:?}\"}} {}",
+                cumulative.min(total)
+            );
         }
-        cumulative += self.counts[BUCKET_BOUNDS_S.len()].load(Ordering::Relaxed);
-        let _ = writeln!(out, "{name}_bucket{{{labels},le=\"+Inf\"}} {cumulative}");
+        let _ = writeln!(out, "{name}_bucket{{{labels},le=\"+Inf\"}} {total}");
         let sum_s = self.sum_micros.load(Ordering::Relaxed) as f64 / 1_000_000.0;
         let _ = writeln!(out, "{name}_sum{{{labels}}} {sum_s}");
-        let _ = writeln!(
-            out,
-            "{name}_count{{{labels}}} {}",
-            self.count.load(Ordering::Relaxed)
-        );
+        let _ = writeln!(out, "{name}_count{{{labels}}} {total}");
     }
 }
 
@@ -348,7 +361,7 @@ mod tests {
         // The 2ms observation makes le=0.005 cumulative count 2.
         assert!(out.contains("q_bucket{protocol=\"http\",kind=\"read\",le=\"0.005\"} 2"));
         // The 20s observation only shows up in +Inf: 3 total.
-        assert!(out.contains("q_bucket{protocol=\"http\",kind=\"read\",le=\"10\"} 2"));
+        assert!(out.contains("q_bucket{protocol=\"http\",kind=\"read\",le=\"10.0\"} 2"));
         assert!(out.contains("q_bucket{protocol=\"http\",kind=\"read\",le=\"+Inf\"} 3"));
         assert!(out.contains("q_count{protocol=\"http\",kind=\"read\"} 3"));
     }

--- a/crates/namidb-server/src/metrics.rs
+++ b/crates/namidb-server/src/metrics.rs
@@ -1,0 +1,440 @@
+//! Process-level query metrics and the slow-query log.
+//!
+//! A hand-rolled registry of lock-free atomic counters and fixed-bucket
+//! histograms, rendered on demand in the Prometheus text exposition format
+//! at `GET /v0/metrics`. There is no metrics-crate dependency: the surface we
+//! need (a handful of counters, a gauge, and four latency histograms) is small
+//! enough that hand-rolling keeps the hot path allocation-free and the
+//! dependency tree honest, matching the style of [`namidb_core::profile`].
+//!
+//! Both serving paths feed the same registry. HTTP queries are recorded by the
+//! `cypher` handler and Bolt queries by the `ServerBackend`, each calling
+//! [`Metrics::observe_query`] exactly once per query with the protocol, the
+//! read/write kind, whether it succeeded, and the wall-clock it took. When a
+//! query crosses the configured slow-query threshold the same call emits a
+//! structured `warn!` line (the query text, never its parameters, which may
+//! carry sensitive values).
+
+use std::sync::atomic::{AtomicI64, AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use tracing::warn;
+
+/// Which serving path a query arrived on. Used as the `protocol` label.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Protocol {
+    Http,
+    Bolt,
+}
+
+impl Protocol {
+    fn as_str(self) -> &'static str {
+        match self {
+            Protocol::Http => "http",
+            Protocol::Bolt => "bolt",
+        }
+    }
+}
+
+/// Read vs write, decided by `plan.contains_write()`. `None` is used for a
+/// query that failed before planning (a parse or plan error), where the kind
+/// is genuinely unknown; such a query still counts toward the error total but
+/// is not placed in a latency histogram.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum QueryKind {
+    Read,
+    Write,
+}
+
+impl QueryKind {
+    fn as_str(self) -> &'static str {
+        match self {
+            QueryKind::Read => "read",
+            QueryKind::Write => "write",
+        }
+    }
+}
+
+/// Upper bounds (seconds) for the latency histogram buckets. A query is placed
+/// in the first bucket whose bound is `>= elapsed`; anything slower lands in an
+/// implicit `+Inf` overflow bucket. The range spans a sub-millisecond point
+/// read up to the 30s default query timeout and beyond.
+const BUCKET_BOUNDS_S: [f64; 10] = [0.0005, 0.001, 0.005, 0.01, 0.05, 0.1, 0.5, 1.0, 5.0, 10.0];
+
+/// A cumulative-renderable latency histogram: a per-bucket count, the running
+/// sum, and the observation count. Counts are stored per bucket (not yet
+/// cumulative) and accumulated at render time, so a single observation is one
+/// atomic increment rather than one per bucket.
+#[derive(Debug)]
+struct Histogram {
+    /// `BUCKET_BOUNDS_S.len()` bounded buckets plus one `+Inf` overflow slot.
+    counts: [AtomicU64; BUCKET_BOUNDS_S.len() + 1],
+    sum_micros: AtomicU64,
+    count: AtomicU64,
+}
+
+impl Histogram {
+    fn new() -> Self {
+        Self {
+            counts: std::array::from_fn(|_| AtomicU64::new(0)),
+            sum_micros: AtomicU64::new(0),
+            count: AtomicU64::new(0),
+        }
+    }
+
+    fn observe(&self, elapsed: Duration) {
+        let secs = elapsed.as_secs_f64();
+        let mut idx = BUCKET_BOUNDS_S.len(); // default to the +Inf overflow bucket
+        for (i, &bound) in BUCKET_BOUNDS_S.iter().enumerate() {
+            if secs <= bound {
+                idx = i;
+                break;
+            }
+        }
+        self.counts[idx].fetch_add(1, Ordering::Relaxed);
+        self.sum_micros
+            .fetch_add(elapsed.as_micros() as u64, Ordering::Relaxed);
+        self.count.fetch_add(1, Ordering::Relaxed);
+    }
+
+    /// Render the `_bucket`/`_sum`/`_count` lines for one label set. `labels`
+    /// is the inner label list without braces, e.g. `protocol="http",kind="read"`.
+    fn render_into(&self, out: &mut String, name: &str, labels: &str) {
+        use std::fmt::Write as _;
+        let mut cumulative: u64 = 0;
+        for (i, &bound) in BUCKET_BOUNDS_S.iter().enumerate() {
+            cumulative += self.counts[i].load(Ordering::Relaxed);
+            let _ = writeln!(out, "{name}_bucket{{{labels},le=\"{bound}\"}} {cumulative}");
+        }
+        cumulative += self.counts[BUCKET_BOUNDS_S.len()].load(Ordering::Relaxed);
+        let _ = writeln!(out, "{name}_bucket{{{labels},le=\"+Inf\"}} {cumulative}");
+        let sum_s = self.sum_micros.load(Ordering::Relaxed) as f64 / 1_000_000.0;
+        let _ = writeln!(out, "{name}_sum{{{labels}}} {sum_s}");
+        let _ = writeln!(
+            out,
+            "{name}_count{{{labels}}} {}",
+            self.count.load(Ordering::Relaxed)
+        );
+    }
+}
+
+/// Per-protocol counters and latency histograms.
+#[derive(Debug)]
+struct ProtoMetrics {
+    ok: AtomicU64,
+    err: AtomicU64,
+    read: Histogram,
+    write: Histogram,
+}
+
+impl ProtoMetrics {
+    fn new() -> Self {
+        Self {
+            ok: AtomicU64::new(0),
+            err: AtomicU64::new(0),
+            read: Histogram::new(),
+            write: Histogram::new(),
+        }
+    }
+}
+
+/// The process-wide query metrics registry. One per server, shared across all
+/// connections via the `Arc` held on `AppState`.
+#[derive(Debug)]
+pub struct Metrics {
+    started: Instant,
+    version: &'static str,
+    /// Queries at or above this wall-clock are logged at `warn!`. `ZERO`
+    /// disables the slow-query log (the counters and histograms stay on).
+    slow_threshold: Duration,
+    in_flight: AtomicI64,
+    slow_queries: AtomicU64,
+    http: ProtoMetrics,
+    bolt: ProtoMetrics,
+}
+
+impl Metrics {
+    /// Build a registry. `version` labels `namidb_build_info`; `slow_threshold`
+    /// of `ZERO` turns the slow-query log off.
+    pub fn new(version: &'static str, slow_threshold: Duration) -> Arc<Self> {
+        Arc::new(Self {
+            started: Instant::now(),
+            version,
+            slow_threshold,
+            in_flight: AtomicI64::new(0),
+            slow_queries: AtomicU64::new(0),
+            http: ProtoMetrics::new(),
+            bolt: ProtoMetrics::new(),
+        })
+    }
+
+    fn proto(&self, protocol: Protocol) -> &ProtoMetrics {
+        match protocol {
+            Protocol::Http => &self.http,
+            Protocol::Bolt => &self.bolt,
+        }
+    }
+
+    /// Increment the in-flight gauge and return a guard that decrements it on
+    /// drop, so the count is correct even if the query errors or panics.
+    pub fn track_in_flight(self: &Arc<Self>) -> InFlightGuard {
+        self.in_flight.fetch_add(1, Ordering::Relaxed);
+        InFlightGuard(Arc::clone(self))
+    }
+
+    /// Record one completed query. Called exactly once per query from each
+    /// serving path. `kind` is `None` for a query that failed before planning.
+    /// Emits the slow-query `warn!` when enabled and `elapsed` crosses the
+    /// threshold; `query` is the source text, logged truncated and without
+    /// parameters.
+    pub fn observe_query(
+        &self,
+        protocol: Protocol,
+        kind: Option<QueryKind>,
+        ok: bool,
+        elapsed: Duration,
+        query: &str,
+    ) {
+        let p = self.proto(protocol);
+        if ok {
+            p.ok.fetch_add(1, Ordering::Relaxed);
+        } else {
+            p.err.fetch_add(1, Ordering::Relaxed);
+        }
+        match kind {
+            Some(QueryKind::Read) => p.read.observe(elapsed),
+            Some(QueryKind::Write) => p.write.observe(elapsed),
+            None => {}
+        }
+
+        if !self.slow_threshold.is_zero() && elapsed >= self.slow_threshold {
+            self.slow_queries.fetch_add(1, Ordering::Relaxed);
+            warn!(
+                protocol = protocol.as_str(),
+                kind = kind.map(QueryKind::as_str).unwrap_or("unknown"),
+                status = if ok { "ok" } else { "error" },
+                elapsed_ms = elapsed.as_millis() as u64,
+                query = %sanitize_query(query),
+                "slow query",
+            );
+        }
+    }
+
+    /// Render the whole registry in the Prometheus text exposition format
+    /// (`text/plain; version=0.0.4`).
+    pub fn render(&self) -> String {
+        use std::fmt::Write as _;
+        let mut out = String::with_capacity(2048);
+
+        let _ = writeln!(out, "# HELP namidb_build_info Build information.");
+        let _ = writeln!(out, "# TYPE namidb_build_info gauge");
+        let _ = writeln!(out, "namidb_build_info{{version=\"{}\"}} 1", self.version);
+
+        let _ = writeln!(
+            out,
+            "# HELP namidb_uptime_seconds Seconds since the server started."
+        );
+        let _ = writeln!(out, "# TYPE namidb_uptime_seconds gauge");
+        let _ = writeln!(
+            out,
+            "namidb_uptime_seconds {}",
+            self.started.elapsed().as_secs_f64()
+        );
+
+        let _ = writeln!(
+            out,
+            "# HELP namidb_queries_in_flight Cypher queries currently executing."
+        );
+        let _ = writeln!(out, "# TYPE namidb_queries_in_flight gauge");
+        let _ = writeln!(
+            out,
+            "namidb_queries_in_flight {}",
+            self.in_flight.load(Ordering::Relaxed)
+        );
+
+        let _ = writeln!(
+            out,
+            "# HELP namidb_queries_total Cypher queries executed, by protocol and status."
+        );
+        let _ = writeln!(out, "# TYPE namidb_queries_total counter");
+        for (proto, pm) in [("http", &self.http), ("bolt", &self.bolt)] {
+            let _ = writeln!(
+                out,
+                "namidb_queries_total{{protocol=\"{proto}\",status=\"ok\"}} {}",
+                pm.ok.load(Ordering::Relaxed)
+            );
+            let _ = writeln!(
+                out,
+                "namidb_queries_total{{protocol=\"{proto}\",status=\"error\"}} {}",
+                pm.err.load(Ordering::Relaxed)
+            );
+        }
+
+        let _ = writeln!(
+            out,
+            "# HELP namidb_slow_queries_total Queries that crossed the slow-query threshold."
+        );
+        let _ = writeln!(out, "# TYPE namidb_slow_queries_total counter");
+        let _ = writeln!(
+            out,
+            "namidb_slow_queries_total {}",
+            self.slow_queries.load(Ordering::Relaxed)
+        );
+
+        let _ = writeln!(
+            out,
+            "# HELP namidb_query_duration_seconds Query execution wall-clock, by protocol and kind."
+        );
+        let _ = writeln!(out, "# TYPE namidb_query_duration_seconds histogram");
+        for (proto, pm) in [("http", &self.http), ("bolt", &self.bolt)] {
+            pm.read.render_into(
+                &mut out,
+                "namidb_query_duration_seconds",
+                &format!("protocol=\"{proto}\",kind=\"read\""),
+            );
+            pm.write.render_into(
+                &mut out,
+                "namidb_query_duration_seconds",
+                &format!("protocol=\"{proto}\",kind=\"write\""),
+            );
+        }
+
+        out
+    }
+}
+
+/// RAII guard returned by [`Metrics::track_in_flight`]; decrements the
+/// in-flight gauge on drop.
+pub struct InFlightGuard(Arc<Metrics>);
+
+impl Drop for InFlightGuard {
+    fn drop(&mut self) {
+        self.0.in_flight.fetch_sub(1, Ordering::Relaxed);
+    }
+}
+
+/// Collapse whitespace and cap a query string so the slow-query log stays one
+/// readable line. Parameters are never included; only the statement text is.
+fn sanitize_query(query: &str) -> String {
+    const MAX: usize = 300;
+    let collapsed = query.split_whitespace().collect::<Vec<_>>().join(" ");
+    if collapsed.len() <= MAX {
+        return collapsed;
+    }
+    let mut end = MAX;
+    while !collapsed.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{}...", &collapsed[..end])
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn histogram_buckets_are_cumulative_with_sum_and_count() {
+        let h = Histogram::new();
+        h.observe(Duration::from_micros(200)); // <= 0.0005
+        h.observe(Duration::from_millis(2)); // <= 0.005
+        h.observe(Duration::from_secs(20)); // overflow (+Inf only)
+
+        let mut out = String::new();
+        h.render_into(&mut out, "q", "protocol=\"http\",kind=\"read\"");
+
+        // Smallest bucket holds the 200us observation.
+        assert!(out.contains("q_bucket{protocol=\"http\",kind=\"read\",le=\"0.0005\"} 1"));
+        // The 2ms observation makes le=0.005 cumulative count 2.
+        assert!(out.contains("q_bucket{protocol=\"http\",kind=\"read\",le=\"0.005\"} 2"));
+        // The 20s observation only shows up in +Inf: 3 total.
+        assert!(out.contains("q_bucket{protocol=\"http\",kind=\"read\",le=\"10\"} 2"));
+        assert!(out.contains("q_bucket{protocol=\"http\",kind=\"read\",le=\"+Inf\"} 3"));
+        assert!(out.contains("q_count{protocol=\"http\",kind=\"read\"} 3"));
+    }
+
+    #[test]
+    fn observe_query_splits_counters_by_status_and_kind() {
+        let m = Metrics::new("0.0.0-test", Duration::ZERO);
+        m.observe_query(
+            Protocol::Http,
+            Some(QueryKind::Read),
+            true,
+            Duration::from_millis(1),
+            "MATCH (n) RETURN n",
+        );
+        m.observe_query(
+            Protocol::Http,
+            Some(QueryKind::Write),
+            true,
+            Duration::from_millis(2),
+            "CREATE (n)",
+        );
+        m.observe_query(
+            Protocol::Bolt,
+            None,
+            false,
+            Duration::from_millis(1),
+            "NOT CYPHER",
+        );
+
+        let text = m.render();
+        assert!(text.contains("namidb_queries_total{protocol=\"http\",status=\"ok\"} 2"));
+        assert!(text.contains("namidb_queries_total{protocol=\"bolt\",status=\"error\"} 1"));
+        // The parse failure (kind None) never enters a histogram.
+        assert!(
+            text.contains("namidb_query_duration_seconds_count{protocol=\"http\",kind=\"read\"} 1")
+        );
+        assert!(text
+            .contains("namidb_query_duration_seconds_count{protocol=\"http\",kind=\"write\"} 1"));
+        assert!(
+            text.contains("namidb_query_duration_seconds_count{protocol=\"bolt\",kind=\"read\"} 0")
+        );
+        // Slow log disabled (threshold ZERO): never counts a slow query.
+        assert!(text.contains("namidb_slow_queries_total 0"));
+        assert!(text.contains("namidb_build_info{version=\"0.0.0-test\"} 1"));
+    }
+
+    #[test]
+    fn slow_threshold_counts_queries_at_or_above_it() {
+        let m = Metrics::new("0.0.0-test", Duration::from_millis(10));
+        m.observe_query(
+            Protocol::Http,
+            Some(QueryKind::Read),
+            true,
+            Duration::from_millis(1),
+            "fast",
+        );
+        m.observe_query(
+            Protocol::Http,
+            Some(QueryKind::Read),
+            true,
+            Duration::from_millis(50),
+            "slow",
+        );
+        assert!(m.render().contains("namidb_slow_queries_total 1"));
+    }
+
+    #[test]
+    fn in_flight_guard_increments_then_decrements() {
+        let m = Metrics::new("0.0.0-test", Duration::ZERO);
+        {
+            let _g1 = m.track_in_flight();
+            let _g2 = m.track_in_flight();
+            assert!(m.render().contains("namidb_queries_in_flight 2"));
+        }
+        assert!(m.render().contains("namidb_queries_in_flight 0"));
+    }
+
+    #[test]
+    fn sanitize_collapses_whitespace_and_truncates() {
+        assert_eq!(
+            sanitize_query("MATCH (n)\n  RETURN   n"),
+            "MATCH (n) RETURN n"
+        );
+        let long = "X".repeat(400);
+        let s = sanitize_query(&long);
+        assert!(s.ends_with("..."));
+        assert!(s.len() <= 303);
+    }
+}

--- a/crates/namidb-server/tests/bolt_integration.rs
+++ b/crates/namidb-server/tests/bolt_integration.rs
@@ -303,6 +303,7 @@ async fn boot_bolt_full(
         write_stall_delay: Duration::ZERO,
         tls_cert: None,
         tls_key: None,
+        slow_query_threshold: Duration::ZERO,
     };
     let task = tokio::spawn(async move {
         if let Err(e) = namidb_server::run(config).await {
@@ -351,6 +352,7 @@ async fn bolt_create_then_match_roundtrip() {
         write_stall_delay: Duration::ZERO,
         tls_cert: None,
         tls_key: None,
+        slow_query_threshold: Duration::ZERO,
     };
 
     let server_task = tokio::spawn(async move {
@@ -426,6 +428,7 @@ async fn bolt_bad_token_yields_failure() {
         write_stall_delay: Duration::ZERO,
         tls_cert: None,
         tls_key: None,
+        slow_query_threshold: Duration::ZERO,
     };
 
     let server_task = tokio::spawn(async move {
@@ -565,6 +568,7 @@ async fn bolt_memgraph_introspection_populates_schema() {
         write_stall_delay: Duration::ZERO,
         tls_cert: None,
         tls_key: None,
+        slow_query_threshold: Duration::ZERO,
     };
     let server_task = tokio::spawn(async move {
         let _ = namidb_server::run(config).await;

--- a/crates/namidb-server/tests/tls_integration.rs
+++ b/crates/namidb-server/tests/tls_integration.rs
@@ -75,6 +75,7 @@ async fn serves_https_and_bolt_over_tls() {
         write_stall_delay: Duration::ZERO,
         tls_cert: Some(certs.cert_path.to_path_buf()),
         tls_key: Some(certs.key_path.to_path_buf()),
+        slow_query_threshold: Duration::ZERO,
     };
     let task = tokio::spawn(async move {
         let _ = namidb_server::run(config).await;


### PR DESCRIPTION
Next P1 observability item: a Prometheus `/v0/metrics` endpoint and a slow-query log.

## What

- **`GET /v0/metrics`** renders process query metrics in the Prometheus text exposition format (`text/plain; version=0.0.4`). Unauthenticated, like `/v0/livez` / `/v0/health` / `/v0/version`, so a scraper needs no bearer token.
  - `namidb_queries_total{protocol,status}` (counter)
  - `namidb_query_duration_seconds{protocol,kind}` (histogram, read vs write)
  - `namidb_queries_in_flight` (gauge)
  - `namidb_slow_queries_total` (counter)
  - `namidb_build_info{version}`, `namidb_uptime_seconds` (gauges)
- **Slow-query log** gated by `--slow-query-threshold` (env `NAMIDB_SLOW_QUERY_THRESHOLD`, default `1s`, `0s` disables). A query at or above the threshold logs a `WARN` line with protocol, kind, status, elapsed and the statement text. Parameters are never logged.

## How

- A hand-rolled registry of lock-free atomic counters and fixed-bucket histograms (`crates/namidb-server/src/metrics.rs`), no new dependency, matching the style of `namidb_core::profile`. Held as `Arc<Metrics>` on `AppState`, shared across every connection.
- Both serving paths feed one registry: the HTTP `cypher` handler and the Bolt `ServerBackend` each record exactly one observation per query. The HTTP `cypher` handler was split into `cypher` + `run_cypher`, and Bolt `run`/`run_in_tx` into `run_query`/`run_query_in_tx`, so timing/classification happens once per path with no behavior change.
- The stopwatch stops at the end of execution, **before** the optional write-stall backpressure sleep, so throttling is not counted as query latency. Bolt schema-introspection probes are not counted as queries.

## Review

Ran an adversarial multi-lens review (parity, concurrency, Prometheus format, security/PII). No critical/high findings. Hardening applied from it:
- Histogram render anchors on a single `count` read (buckets clamped, `+Inf == _count`) so a scrape racing a live observe can never violate `+Inf < _count`.
- `le` labels render in canonical float form (`1.0`/`10.0`).
- A Bolt RUN with no open transaction is classified `kind=None` (counts as an error, stays out of the latency histogram).
- Docs are explicit that inline literals in the statement text are logged (parameterise sensitive values).

## Test

- Unit tests for the histogram (cumulative buckets, sum/count), counter splits, slow threshold, in-flight guard, query sanitisation.
- HTTP integration tests: `/v0/metrics` is public and renders Prometheus; a cypher request increments the counters/histogram.
- Full `cargo test --workspace --exclude namidb-py` green; `cargo clippy ... -D warnings` clean; `cargo fmt --all --check` clean.
- Smoke-tested a running server: content-type, `le` formatting, `+Inf == _count`, parse-error counted as `http error` without entering the histogram, and the slow-query WARN lines (no params).

Docs updated: root README, `crates/namidb-server/README.md` (endpoints table + a Metrics section), CHANGELOG.