### PR TITLE
feat(server,query): wall-clock timeout on writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,30 @@ below and in the release notes.
 
 ## [Unreleased]
 
+### Breaking
+
+- Server-initiated writes are now bounded by a wall-clock timeout that
+  defaults to `--query-timeout` (30s). Before this, writes ran unbounded; a
+  bulk load or large `MERGE`/`DELETE` that takes longer than the budget now
+  aborts and rolls back. To keep the old unbounded behaviour set
+  `--write-timeout 0s` / `NAMIDB_WRITE_TIMEOUT=0s`, or raise the budget to a
+  value that fits the workload. Embedded callers are unaffected: the bare
+  `execute_write` / `execute_write_staged` stay unbounded.
+
+### Added
+
+- Write-query timeout. A write statement now honours a wall-clock deadline,
+  so a runaway `MERGE`/`DELETE` is aborted instead of pinning the single
+  writer of a namespace. The deadline rides the same cooperative
+  cancellation the read path uses, and a write that overruns has its pending
+  batch discarded, so nothing partial is committed. Configure it with
+  `--write-timeout` / `NAMIDB_WRITE_TIMEOUT`; it defaults to the read budget
+  (`--query-timeout`), and `0s` opts a write back into running unbounded. It
+  applies to HTTP and Bolt auto-commit statements and to each statement of a
+  Bolt explicit transaction. Embedded callers reach it through the new
+  `execute_write_with_deadline` / `execute_write_staged_with_deadline`; the
+  existing `execute_write` / `execute_write_staged` stay unbounded.
+
 ## [0.14.0] - 2026-06-07: vector search and embeddings, TLS, Prometheus metrics, leveled-lite compaction
 
 ### Added

--- a/crates/namidb-query/src/exec/limits.rs
+++ b/crates/namidb-query/src/exec/limits.rs
@@ -16,8 +16,12 @@
 //!   materialises.
 //!
 //! The server scopes both from its configuration (env `NAMIDB_QUERY_TIMEOUT`
-//! and `NAMIDB_QUERY_ROW_CAP`). Writes are not guarded here; an open Bolt
-//! transaction is bounded separately by its idle timeout.
+//! and `NAMIDB_QUERY_ROW_CAP`). Writes carry only a deadline (no row cap):
+//! the write executor scopes it through [`with_limits`] in
+//! `execute_write_with_deadline` and probes it in its per-row loops, so a
+//! runaway statement aborts before commit. The bare `execute_write` and an
+//! open Bolt transaction's own idle timeout remain separate, unrelated
+//! bounds.
 
 use std::future::Future;
 use std::time::Instant;

--- a/crates/namidb-query/src/exec/mod.rs
+++ b/crates/namidb-query/src/exec/mod.rs
@@ -23,4 +23,7 @@ pub use leapfrog::{LeapfrogIntersect, MergeSortedUnion, OrdIterator, SortedSlice
 pub use row::Row;
 pub use value::{NodeValue, RelValue, RuntimeValue};
 pub use walker::{execute, execute_factor_path, execute_flat_path, execute_with_limits, ExecError};
-pub use writer::{execute_write, execute_write_staged, WriteOutcome};
+pub use writer::{
+    execute_write, execute_write_staged, execute_write_staged_with_deadline,
+    execute_write_with_deadline, WriteOutcome,
+};

--- a/crates/namidb-query/src/exec/writer.rs
+++ b/crates/namidb-query/src/exec/writer.rs
@@ -23,6 +23,7 @@
 //! (List/Map/Node/Rel are rejected with an explicit error).
 
 use std::collections::BTreeMap;
+use std::time::Instant;
 
 use futures::future::BoxFuture;
 use futures::FutureExt;
@@ -63,8 +64,29 @@ pub async fn execute_write_staged(
     writer: &mut WriterSession,
     params: &Params,
 ) -> Result<WriteOutcome, ExecError> {
+    execute_write_staged_with_deadline(plan, writer, params, None).await
+}
+
+/// [`execute_write_staged`] with a wall-clock `deadline`. The deadline rides
+/// the shared [`namidb_storage::cancel`] task-local for the whole apply, so
+/// the storage decode loops a read sub-plan drives and the per-row / per-edge
+/// write loops here both probe it and abort a runaway statement mid-flight
+/// (cooperative cancellation) with [`ExecError::Timeout`]. `None` runs
+/// unguarded with the baseline cost — the server passes a deadline, embedded
+/// callers and tests do not.
+pub async fn execute_write_staged_with_deadline(
+    plan: &LogicalPlan,
+    writer: &mut WriterSession,
+    params: &Params,
+    deadline: Option<Instant>,
+) -> Result<WriteOutcome, ExecError> {
     let mut outcome = WriteOutcome::default();
-    let rows = execute_write_inner(plan, writer, params, &mut outcome).await?;
+    let rows = crate::exec::limits::with_limits(
+        deadline,
+        None,
+        execute_write_inner(plan, writer, params, &mut outcome),
+    )
+    .await?;
     outcome.rows = rows;
     Ok(outcome)
 }
@@ -79,13 +101,27 @@ pub async fn execute_write(
     writer: &mut WriterSession,
     params: &Params,
 ) -> Result<WriteOutcome, ExecError> {
-    let outcome = match execute_write_staged(plan, writer, params).await {
+    execute_write_with_deadline(plan, writer, params, None).await
+}
+
+/// [`execute_write`] with a wall-clock `deadline` bounding the apply. A write
+/// that overruns is aborted with [`ExecError::Timeout`] before
+/// `commit_batch`, so the pending batch is discarded and nothing partial is
+/// sealed — the writer is left clean for the next statement. `None` runs
+/// unbounded.
+pub async fn execute_write_with_deadline(
+    plan: &LogicalPlan,
+    writer: &mut WriterSession,
+    params: &Params,
+    deadline: Option<Instant>,
+) -> Result<WriteOutcome, ExecError> {
+    let outcome = match execute_write_staged_with_deadline(plan, writer, params, deadline).await {
         Ok(outcome) => outcome,
         Err(e) => {
-            // The statement failed after staging some mutations into the
-            // pending batch (writers are long-lived and shared, so the
-            // batch outlives this call). Drop them, or the next write on
-            // this writer would seal them with its own commit.
+            // The statement failed (a timeout counts) after staging some
+            // mutations into the pending batch (writers are long-lived and
+            // shared, so the batch outlives this call). Drop them, or the
+            // next write on this writer would seal them with its own commit.
             writer.discard_batch();
             return Err(e);
         }
@@ -107,6 +143,7 @@ fn execute_write_inner<'a>(
                 let rows = execute_write_inner(input, writer, params, outcome).await?;
                 let mut out = Vec::with_capacity(rows.len());
                 for row in rows {
+                    crate::exec::limits::check_deadline()?;
                     let new_row = apply_create(elements, row, writer, params, outcome).await?;
                     out.push(new_row);
                 }
@@ -117,6 +154,7 @@ fn execute_write_inner<'a>(
                 let rows = execute_write_inner(input, writer, params, outcome).await?;
                 let mut out = Vec::with_capacity(rows.len());
                 for row in rows {
+                    crate::exec::limits::check_deadline()?;
                     let new_row = apply_sets(items, row, writer, params, outcome).await?;
                     out.push(new_row);
                 }
@@ -127,6 +165,7 @@ fn execute_write_inner<'a>(
                 let rows = execute_write_inner(input, writer, params, outcome).await?;
                 let mut out = Vec::with_capacity(rows.len());
                 for row in rows {
+                    crate::exec::limits::check_deadline()?;
                     let new_row = apply_removes(items, row, writer, outcome)?;
                     out.push(new_row);
                 }
@@ -141,6 +180,7 @@ fn execute_write_inner<'a>(
                 let rows = execute_write_inner(input, writer, params, outcome).await?;
                 let mut out = Vec::with_capacity(rows.len());
                 for row in rows {
+                    crate::exec::limits::check_deadline()?;
                     apply_delete(targets, *detach, &row, writer, params, outcome).await?;
                     out.push(row);
                 }
@@ -156,6 +196,7 @@ fn execute_write_inner<'a>(
                 let rows = execute_write_inner(input, writer, params, outcome).await?;
                 let mut out = Vec::with_capacity(rows.len().max(1));
                 for row in rows {
+                    crate::exec::limits::check_deadline()?;
                     let merged = apply_merge(
                         pattern,
                         on_match_sets,
@@ -986,6 +1027,7 @@ async fn detach_incident_edges(
     // — acceptable for v0; see RFC-009 §Drawbacks.
     let edge_types: Vec<String> = writer.observed_edge_types();
     for et in edge_types {
+        crate::exec::limits::check_deadline()?;
         let mut to_delete: Vec<(NodeId, NodeId)> = Vec::new();
         {
             let snap = writer.overlay_snapshot();
@@ -1001,7 +1043,13 @@ async fn detach_incident_edges(
                 to_delete.push((e.src, e.dst));
             }
         }
-        for (src, dst) in to_delete {
+        for (i, (src, dst)) in to_delete.into_iter().enumerate() {
+            // Probe on a stride: tombstoning is a cheap memtable insert, so an
+            // `Instant::now()` per edge would show on a million-edge detach.
+            // The bounded read above already probes during edge decode.
+            if i % namidb_storage::cancel::CHECK_STRIDE == 0 {
+                crate::exec::limits::check_deadline()?;
+            }
             writer
                 .tombstone_edge(et.clone(), src, dst)
                 .map_err(ExecError::Storage)?;

--- a/crates/namidb-query/src/lib.rs
+++ b/crates/namidb-query/src/lib.rs
@@ -36,8 +36,8 @@ pub use cost::{
 };
 pub use exec::{
     evaluate, execute, execute_factor_path, execute_flat_path, execute_with_limits, execute_write,
-    execute_write_staged, factorize_enabled, EvalError, ExecError, Params, Row, RuntimeValue,
-    WriteOutcome,
+    execute_write_staged, execute_write_staged_with_deadline, execute_write_with_deadline,
+    factorize_enabled, EvalError, ExecError, Params, Row, RuntimeValue, WriteOutcome,
 };
 pub use optimize::{convert_cross_to_hash, normalize_filters, optimize, predicate_pushdown};
 pub use parser::{parse, ParseError, ParseResult, Query};

--- a/crates/namidb-query/tests/exec_write_timeout.rs
+++ b/crates/namidb-query/tests/exec_write_timeout.rs
@@ -1,0 +1,121 @@
+//! Write-query wall-clock timeout.
+//!
+//! A write that overruns its deadline is aborted cooperatively with
+//! [`ExecError::Timeout`] and its pending batch is discarded, so nothing
+//! partial is committed and the shared writer is left clean for the next
+//! statement. The write-side complement of the read-query timeout exercised
+//! through `execute_with_limits`.
+
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use namidb_core::id::NamespaceId;
+use namidb_storage::{NamespacePaths, WriterSession};
+use object_store::memory::InMemory;
+use object_store::ObjectStore;
+
+use namidb_query::{execute_write, execute_write_with_deadline, lower, parse, ExecError, Params};
+
+fn store() -> Arc<dyn ObjectStore> {
+    Arc::new(InMemory::new())
+}
+
+fn paths(name: &str) -> NamespacePaths {
+    NamespacePaths::new("tenants", NamespaceId::new(name).unwrap())
+}
+
+/// A deadline already in the past, so the first cooperative probe fires.
+fn expired() -> Option<Instant> {
+    Some(Instant::now() - Duration::from_secs(1))
+}
+
+async fn write(writer: &mut WriterSession, text: &str) {
+    let plan = lower(&parse(text).unwrap()).unwrap();
+    execute_write(&plan, writer, &Params::new()).await.unwrap();
+}
+
+async fn person_count(writer: &WriterSession) -> usize {
+    writer.snapshot().scan_label("Person").await.unwrap().len()
+}
+
+#[tokio::test]
+async fn create_past_deadline_times_out_and_commits_nothing() {
+    let mut writer = WriterSession::open(store(), paths("wt-create"))
+        .await
+        .unwrap();
+
+    let plan = lower(&parse("CREATE (a:Person {name: 'Ada'}) RETURN a").unwrap()).unwrap();
+    let err = execute_write_with_deadline(&plan, &mut writer, &Params::new(), expired())
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, ExecError::Timeout),
+        "expected timeout, got {err:?}"
+    );
+
+    // The node never reached a snapshot: the aborted batch was discarded.
+    assert_eq!(person_count(&writer).await, 0);
+
+    // The writer is clean — a later unbounded write succeeds and is the only
+    // thing committed, proving the discarded batch left no residue behind.
+    write(&mut writer, "CREATE (a:Person {name: 'Grace'}) RETURN a").await;
+    assert_eq!(person_count(&writer).await, 1);
+}
+
+#[tokio::test]
+async fn create_within_deadline_succeeds() {
+    let mut writer = WriterSession::open(store(), paths("wt-ok")).await.unwrap();
+
+    let plan = lower(&parse("CREATE (a:Person {name: 'Ada'}) RETURN a").unwrap()).unwrap();
+    let deadline = Some(Instant::now() + Duration::from_secs(30));
+    let outcome = execute_write_with_deadline(&plan, &mut writer, &Params::new(), deadline)
+        .await
+        .unwrap();
+
+    assert_eq!(outcome.nodes_created, 1);
+    assert_eq!(person_count(&writer).await, 1);
+}
+
+#[tokio::test]
+async fn detach_delete_past_deadline_preserves_data() {
+    let mut writer = WriterSession::open(store(), paths("wt-delete"))
+        .await
+        .unwrap();
+
+    // Seed two connected nodes with an unbounded, committed write.
+    write(
+        &mut writer,
+        "CREATE (a:Person {name: 'A'})-[:KNOWS]->(b:Person {name: 'B'})",
+    )
+    .await;
+    assert_eq!(person_count(&writer).await, 2);
+
+    // A delete that overruns its deadline must remove nothing.
+    let del = lower(&parse("MATCH (n:Person) DETACH DELETE n").unwrap()).unwrap();
+    let err = execute_write_with_deadline(&del, &mut writer, &Params::new(), expired())
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(err, ExecError::Timeout),
+        "expected timeout, got {err:?}"
+    );
+
+    // Both nodes survive the aborted delete.
+    assert_eq!(person_count(&writer).await, 2);
+}
+
+#[tokio::test]
+async fn no_deadline_leaves_writes_unbounded() {
+    let mut writer = WriterSession::open(store(), paths("wt-none"))
+        .await
+        .unwrap();
+
+    // `None` is the embedded / CLI / test path: no guard, baseline behaviour.
+    let plan = lower(&parse("CREATE (a:Person {name: 'Ada'}) RETURN a").unwrap()).unwrap();
+    let outcome = execute_write_with_deadline(&plan, &mut writer, &Params::new(), None)
+        .await
+        .unwrap();
+
+    assert_eq!(outcome.nodes_created, 1);
+    assert_eq!(person_count(&writer).await, 1);
+}

--- a/crates/namidb-server/src/bolt.rs
+++ b/crates/namidb-server/src/bolt.rs
@@ -14,8 +14,9 @@ use namidb_bolt::{
     AuthPolicy, Backend, BackendError, RunOutcome, ServerInfo, Session, StatementType,
 };
 use namidb_query::{
-    execute_with_limits, execute_write, execute_write_staged, parse as cypher_parse,
-    plan as build_plan, ExecError, LowerError, Params, ParseError, Row, WriteOutcome,
+    execute_with_limits, execute_write_staged_with_deadline, execute_write_with_deadline,
+    parse as cypher_parse, plan as build_plan, ExecError, LowerError, Params, ParseError, Row,
+    WriteOutcome,
 };
 use namidb_storage::WriterSession;
 use tokio::net::TcpListener;
@@ -105,7 +106,14 @@ impl ServerBackend {
             // On success we refresh the snapshot cell so subsequent reads
             // see the just-committed records (RFC-021).
             let mut writer = self.state.writer.lock().await;
-            match execute_write(&plan, &mut writer, &params).await {
+            match execute_write_with_deadline(
+                &plan,
+                &mut writer,
+                &params,
+                self.state.write_deadline(),
+            )
+            .await
+            {
                 Ok(outcome) => {
                     self.state.snapshot.store(writer.owned_snapshot());
                     // Soft write stall (RFC-027 P5): sample under the lock,
@@ -203,7 +211,14 @@ impl ServerBackend {
                     };
                 }
             };
-            let result = match execute_write_staged(&plan, &mut tx.writer, &params).await {
+            let result = match execute_write_staged_with_deadline(
+                &plan,
+                &mut tx.writer,
+                &params,
+                self.state.write_deadline(),
+            )
+            .await
+            {
                 Ok(outcome) => {
                     tx.staged = true;
                     Ok(write_run_outcome(outcome))

--- a/crates/namidb-server/src/lib.rs
+++ b/crates/namidb-server/src/lib.rs
@@ -26,8 +26,8 @@ use tokio::sync::Mutex;
 use tracing::{error, info, warn};
 
 use namidb_query::{
-    execute_with_limits, execute_write, parse as cypher_parse, plan as build_plan, Params,
-    RuntimeValue, StatsCatalog, WriteOutcome,
+    execute_with_limits, execute_write_with_deadline, parse as cypher_parse, plan as build_plan,
+    Params, RuntimeValue, StatsCatalog, WriteOutcome,
 };
 use namidb_storage::{sweep_orphans, Manifest, ManifestStore, SnapshotCell, WriterSession};
 
@@ -64,9 +64,16 @@ pub struct Config {
     pub bolt_tx_timeout: Duration,
     /// Wall-clock deadline for a single read query (HTTP and Bolt, including
     /// in-transaction reads). A runaway scan or expansion is aborted with a
-    /// timeout error rather than pinning a worker. Writes are bounded by the
-    /// transaction lifecycle, not this. `Duration::ZERO` disables it.
+    /// timeout error rather than pinning a worker. `Duration::ZERO` disables
+    /// it.
     pub query_timeout: Duration,
+    /// Wall-clock deadline for a single write query: an HTTP / Bolt
+    /// auto-commit statement, or each statement of a Bolt explicit
+    /// transaction. A runaway MERGE/DELETE is aborted cooperatively rather
+    /// than pinning the single writer, and its pending batch is discarded so
+    /// nothing partial is committed. `Duration::ZERO` disables it; the CLI
+    /// defaults it to `query_timeout`.
+    pub write_timeout: Duration,
     /// Maximum rows a single read-query operator may materialise. A query
     /// whose operator output would exceed this aborts with a row-cap error
     /// instead of risking an out-of-memory blow-up (e.g. a cross product).
@@ -118,6 +125,9 @@ pub struct AppState {
     /// Per-read-query wall-clock budget. `Duration::ZERO` disables it.
     /// Defaults to disabled; the server sets it from [`Config`] at boot.
     query_timeout: Duration,
+    /// Per-write-query wall-clock budget. `Duration::ZERO` disables it.
+    /// Defaults to disabled; the server sets it from [`Config`] at boot.
+    write_timeout: Duration,
     /// Per-read-query operator row cap. `0` disables it. Defaults to
     /// disabled; the server sets it from [`Config`] at boot.
     query_row_cap: usize,
@@ -145,6 +155,7 @@ impl AppState {
             auth_token: auth_token.map(Arc::from),
             namespace,
             query_timeout: Duration::ZERO,
+            write_timeout: Duration::ZERO,
             query_row_cap: 0,
             write_stall_l0: 0,
             write_stall_delay: Duration::ZERO,
@@ -186,6 +197,13 @@ impl AppState {
         self
     }
 
+    /// Set the per-write-query timeout (builder style). `Duration::ZERO`
+    /// leaves writes unbounded.
+    pub fn with_write_timeout(mut self, timeout: Duration) -> Self {
+        self.write_timeout = timeout;
+        self
+    }
+
     /// Set the per-read-query operator row cap (builder style). `0` leaves
     /// reads uncapped.
     pub fn with_query_row_cap(mut self, row_cap: usize) -> Self {
@@ -198,6 +216,13 @@ impl AppState {
     pub(crate) fn query_deadline(&self) -> Option<std::time::Instant> {
         (self.query_timeout > Duration::ZERO)
             .then(|| std::time::Instant::now() + self.query_timeout)
+    }
+
+    /// Deadline for a write query starting now, or `None` when the timeout
+    /// is disabled. Computed per statement so each write gets the full budget.
+    pub(crate) fn write_deadline(&self) -> Option<std::time::Instant> {
+        (self.write_timeout > Duration::ZERO)
+            .then(|| std::time::Instant::now() + self.write_timeout)
     }
 
     /// Operator row cap for a read query, or `None` when disabled.
@@ -271,6 +296,7 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
 
     let state = AppState::new(writer, config.auth_token.clone(), namespace)
         .with_query_timeout(config.query_timeout)
+        .with_write_timeout(config.write_timeout)
         .with_query_row_cap(config.query_row_cap)
         .with_write_stall(config.write_stall_l0, config.write_stall_delay)
         .with_slow_query_threshold(config.slow_query_threshold);
@@ -719,7 +745,8 @@ async fn run_cypher(state: &AppState, req: &CypherRequest) -> ObservedQuery {
 
     if plan.contains_write() {
         let mut writer = state.writer.lock().await;
-        let result = execute_write(&plan, &mut writer, &params).await;
+        let result =
+            execute_write_with_deadline(&plan, &mut writer, &params, state.write_deadline()).await;
         // Sample the soft write-stall decision while still holding the lock
         // (RFC-027 P5), then release it and sleep — backpressure applies to
         // this request, not to the writer mutex other connections need.

--- a/crates/namidb-server/src/main.rs
+++ b/crates/namidb-server/src/main.rs
@@ -110,6 +110,18 @@ struct Cli {
     )]
     query_timeout: Duration,
 
+    /// Wall-clock budget for a single write query: an HTTP / Bolt auto-commit
+    /// statement, or each statement of a Bolt explicit transaction. A runaway
+    /// MERGE/DELETE is aborted instead of pinning the single writer, and its
+    /// pending batch is discarded so nothing partial commits. Defaults to
+    /// `--query-timeout`; set to `0s` to allow writes to run unbounded.
+    #[arg(
+        long,
+        env = "NAMIDB_WRITE_TIMEOUT",
+        value_parser = humantime::parse_duration,
+    )]
+    write_timeout: Option<Duration>,
+
     /// Maximum rows a single read-query operator may materialise. A query
     /// whose operator output would exceed this aborts with a row-cap error
     /// instead of risking an out-of-memory blow-up. Set to `0` to allow read
@@ -182,6 +194,8 @@ fn main() -> anyhow::Result<()> {
         bolt_listen: cli.bolt_listen,
         bolt_tx_timeout: cli.bolt_tx_timeout,
         query_timeout: cli.query_timeout,
+        // Writes inherit the read budget unless given their own; `0s` opts out.
+        write_timeout: cli.write_timeout.unwrap_or(cli.query_timeout),
         query_row_cap: cli.query_row_cap,
         compaction_l0_trigger: cli.compaction_l0_trigger,
         write_stall_l0: cli.write_stall_l0,

--- a/crates/namidb-server/tests/bolt_integration.rs
+++ b/crates/namidb-server/tests/bolt_integration.rs
@@ -297,6 +297,7 @@ async fn boot_bolt_full(
         bolt_listen: Some(bolt_addr),
         bolt_tx_timeout: tx_timeout,
         query_timeout,
+        write_timeout: query_timeout,
         query_row_cap: 0,
         compaction_l0_trigger: 0,
         write_stall_l0: 0,
@@ -346,6 +347,7 @@ async fn bolt_create_then_match_roundtrip() {
         bolt_listen: Some(bolt_addr),
         bolt_tx_timeout: Duration::ZERO,
         query_timeout: Duration::ZERO,
+        write_timeout: Duration::ZERO,
         query_row_cap: 0,
         compaction_l0_trigger: 0,
         write_stall_l0: 0,
@@ -422,6 +424,7 @@ async fn bolt_bad_token_yields_failure() {
         bolt_listen: Some(bolt_addr),
         bolt_tx_timeout: Duration::ZERO,
         query_timeout: Duration::ZERO,
+        write_timeout: Duration::ZERO,
         query_row_cap: 0,
         compaction_l0_trigger: 0,
         write_stall_l0: 0,
@@ -562,6 +565,7 @@ async fn bolt_memgraph_introspection_populates_schema() {
         bolt_listen: Some(bolt_addr),
         bolt_tx_timeout: Duration::ZERO,
         query_timeout: Duration::ZERO,
+        write_timeout: Duration::ZERO,
         query_row_cap: 0,
         compaction_l0_trigger: 0,
         write_stall_l0: 0,
@@ -893,6 +897,38 @@ async fn bolt_read_query_times_out() {
     assert!(
         matches!(resp, Response::Failure(_)),
         "a read past its 1ns budget must fail, got {resp:?}"
+    );
+
+    // Session is FAILED after the error; just drop the connection.
+    stream.shutdown().await.ok();
+    task.abort();
+}
+
+#[tokio::test]
+async fn bolt_write_query_times_out() {
+    // A 1ns write budget: the deadline (now + 1ns) is already past by the
+    // time the write executor reaches its first per-row guard, so an
+    // auto-commit write RUN fails with a timeout and commits nothing.
+    // `boot_bolt_full` sets the write budget equal to the read budget.
+    let (bolt_addr, task) =
+        boot_bolt_full("bolt-wtimeout", Duration::ZERO, Duration::from_nanos(1)).await;
+    let mut stream = TcpStream::connect(bolt_addr).await.expect("connect bolt");
+    handshake(&mut stream).await;
+    hello_and_logon(&mut stream, "test-token").await;
+
+    let run = Value::Struct {
+        tag: struct_tag::RUN,
+        fields: vec![
+            Value::String("CREATE (p:Person {name: 'Ada'})".into()),
+            Value::Map(BTreeMap::new()),
+            Value::Map(BTreeMap::new()),
+        ],
+    };
+    send_msg(&mut stream, &pack(&run)).await;
+    let resp = recv_msg(&mut stream).await;
+    assert!(
+        matches!(resp, Response::Failure(_)),
+        "a write past its 1ns budget must fail, got {resp:?}"
     );
 
     // Session is FAILED after the error; just drop the connection.

--- a/crates/namidb-server/tests/tls_integration.rs
+++ b/crates/namidb-server/tests/tls_integration.rs
@@ -69,6 +69,7 @@ async fn serves_https_and_bolt_over_tls() {
         bolt_listen: Some(bolt),
         bolt_tx_timeout: Duration::ZERO,
         query_timeout: Duration::ZERO,
+        write_timeout: Duration::ZERO,
         query_row_cap: 0,
         compaction_l0_trigger: 0,
         write_stall_l0: 0,


### PR DESCRIPTION
P0: a runaway MERGE/DELETE no longer pins the single writer of a namespace. Writes honour a wall-clock deadline over the existing cooperative cancellation; a timeout returns before commit_batch so the pending batch is discarded (nothing partial). Config via --write-timeout / NAMIDB_WRITE_TIMEOUT (defaults to --query-timeout, 0s opts out). Covers HTTP + Bolt auto-commit and each statement of a Bolt explicit transaction.