### PR TITLE
feat(query): enforce NOT NULL constraints on writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,26 @@ below and in the release notes.
 
 ## [Unreleased]
 
+### Breaking
+
+- A property a label declares `nullable = false` is now enforced on write,
+  where before the flag was advisory. A `CREATE` that omits it or sets it to
+  `NULL`, a `SET p = NULL`, a `REMOVE p`, or adding the declaring label to a
+  node that lacks the value are all rejected with a constraint error. Schemas
+  that declared `nullable = false` without supplying the value on every write
+  will now see those writes fail; mark the property nullable, or supply a
+  value. Enforcement is node-only and pure (no extra read): edges still carry
+  no declared-property validation.
+
+### Added
+
+- NOT NULL constraint enforcement. Declaring a property `nullable = false`
+  now makes it a hard write-time invariant, alongside the existing unique
+  constraint, so a label's required properties cannot be left null through
+  `CREATE`, `SET`, `REMOVE`, `MERGE`, or a label addition. Violations surface
+  as `ExecError::Constraint` (HTTP 4xx / Bolt failure), the same path unique
+  violations take.
+
 ## [0.14.0] - 2026-06-07: vector search and embeddings, TLS, Prometheus metrics, leveled-lite compaction
 
 ### Added

--- a/crates/namidb-query/src/exec/writer.rs
+++ b/crates/namidb-query/src/exec/writer.rs
@@ -574,6 +574,64 @@ async fn enforce_unique_on_set(
     Ok(())
 }
 
+/// Enforce declared NOT NULL constraints for a node that is being created or
+/// is gaining new labels. For each label in `labels`, every property the
+/// schema declares `nullable = false` must be present in `core_props` with a
+/// non-null value; a missing property and an explicit `NULL` are both
+/// violations. Returns [`ExecError::Constraint`] on the first one.
+///
+/// Pure schema lookup, no snapshot read: declared NOT NULL is a property of
+/// the row being staged, unlike the unique checks which must consult the
+/// read-your-own-writes overlay. Node-only, mirroring `enforce_unique_*`
+/// (edges carry no declared-property validation today).
+fn enforce_notnull_on_create(
+    writer: &WriterSession,
+    labels: &[String],
+    core_props: &BTreeMap<String, CoreValue>,
+) -> Result<(), ExecError> {
+    let schema = writer.schema();
+    for label in labels {
+        let Some(def) = schema.label(label) else {
+            continue;
+        };
+        for prop in &def.properties {
+            if prop.nullable {
+                continue;
+            }
+            match core_props.get(&prop.name) {
+                Some(v) if !matches!(v, CoreValue::Null) => {}
+                Some(_) => {
+                    return Err(ExecError::Constraint(format!(
+                        "{label}.{} is declared NOT NULL but was set to null (not-null constraint)",
+                        prop.name
+                    )));
+                }
+                None => {
+                    return Err(ExecError::Constraint(format!(
+                        "{label}.{} is declared NOT NULL but is missing (not-null constraint)",
+                        prop.name
+                    )));
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+/// The first of the node's `labels` that declares `key` as `nullable =
+/// false`, if any. Shared by the SET-to-null and REMOVE not-null guards.
+fn not_null_label(writer: &WriterSession, labels: &[String], key: &str) -> Option<String> {
+    let schema = writer.schema();
+    labels.iter().find_map(|label| {
+        schema.label(label).and_then(|def| {
+            def.properties
+                .iter()
+                .any(|p| p.name == key && !p.nullable)
+                .then(|| label.clone())
+        })
+    })
+}
+
 async fn apply_create(
     elements: &[CreateElement],
     mut row: Row,
@@ -633,6 +691,7 @@ async fn apply_create(
                 // node, so a duplicate staged earlier in the same uncommitted
                 // batch is caught as well as one already committed.
                 enforce_unique_on_create(writer, labels, &core_props).await?;
+                enforce_notnull_on_create(writer, labels, &core_props)?;
                 let record = NodeWriteRecord {
                     properties: core_props,
                     schema_version: 1,
@@ -755,6 +814,14 @@ async fn apply_set(
                     // the node's own value) is allowed.
                     let label_vec: Vec<String> = n.labels.iter().cloned().collect();
                     enforce_unique_on_set(writer, &label_vec, key, &core, n.id).await?;
+                    if matches!(core, CoreValue::Null) {
+                        if let Some(label) = not_null_label(writer, &label_vec, key) {
+                            return Err(ExecError::Constraint(format!(
+                                "{label}.{key} is declared NOT NULL and cannot be set to null \
+                                 (not-null constraint)"
+                            )));
+                        }
+                    }
                     let mut core_props = node_runtime_props_to_core(&n.properties)?;
                     core_props.insert(key.clone(), core);
                     let record = NodeWriteRecord {
@@ -814,19 +881,25 @@ async fn apply_set(
             Some(RuntimeValue::Node(mut n)) => {
                 // Union the new labels into the node's set, then re-upsert
                 // (keyed by id) so the row carries the full set.
-                let added = labels
+                let added_labels: Vec<String> = labels
                     .iter()
                     .filter(|l| n.labels.insert((*l).clone()))
-                    .count();
+                    .cloned()
+                    .collect();
+                let core_props = node_runtime_props_to_core(&n.properties)?;
+                // A newly-added label brings its own NOT NULL contract: the
+                // node must already carry a non-null value for every property
+                // that label declares non-null.
+                enforce_notnull_on_create(writer, &added_labels, &core_props)?;
                 let record = NodeWriteRecord {
-                    properties: node_runtime_props_to_core(&n.properties)?,
+                    properties: core_props,
                     schema_version: 1,
                     ..Default::default()
                 };
                 writer
                     .upsert_node_with_labels(n.labels.iter().cloned(), n.id, &record)
                     .map_err(ExecError::Storage)?;
-                outcome.labels_set += added as u64;
+                outcome.labels_set += added_labels.len() as u64;
                 row.set(target_alias.clone(), RuntimeValue::Node(n));
             }
             other => {
@@ -863,6 +936,13 @@ fn apply_remove(
     match op {
         RemoveOp::Property { target_alias, key } => match row.get(target_alias).cloned() {
             Some(RuntimeValue::Node(mut n)) => {
+                let labels: Vec<String> = n.labels.iter().cloned().collect();
+                if let Some(label) = not_null_label(writer, &labels, key) {
+                    return Err(ExecError::Constraint(format!(
+                        "{label}.{key} is declared NOT NULL and cannot be removed \
+                         (not-null constraint)"
+                    )));
+                }
                 let mut core_props = node_runtime_props_to_core(&n.properties)?;
                 core_props.remove(key);
                 let record = NodeWriteRecord {

--- a/crates/namidb-query/tests/exec_notnull.rs
+++ b/crates/namidb-query/tests/exec_notnull.rs
@@ -1,0 +1,209 @@
+//! Strict NOT NULL enforcement on the write path.
+//!
+//! A property a label declares `nullable = false` must carry a non-null value
+//! on every node bearing that label. The writer rejects the four ways a write
+//! could otherwise leave it null: creating a node that omits it or sets it to
+//! `NULL`, `SET`ting it to `NULL`, `REMOVE`ing it, and adding the declaring
+//! label to a node that lacks it. Mirrors the unique-constraint enforcement;
+//! both surface `ExecError::Constraint`. Edges are out of scope (they carry no
+//! declared-property validation today).
+
+use std::sync::Arc;
+
+use namidb_core::id::NamespaceId;
+use namidb_core::schema::{DataType, LabelDef, PropertyDef, Schema, SchemaBuilder};
+use namidb_storage::{NamespacePaths, WriterSession};
+use object_store::memory::InMemory;
+use object_store::ObjectStore;
+
+use namidb_query::{execute_write, lower, parse, ExecError, Params};
+
+fn store() -> Arc<dyn ObjectStore> {
+    Arc::new(InMemory::new())
+}
+
+fn paths(name: &str) -> NamespacePaths {
+    NamespacePaths::new("tenants", NamespaceId::new(name).unwrap())
+}
+
+/// `Person.name` is NOT NULL; `Person.nick` is nullable.
+fn person_schema() -> Schema {
+    SchemaBuilder::new()
+        .label(LabelDef {
+            name: "Person".into(),
+            properties: vec![
+                PropertyDef::new("name", DataType::Utf8, false).unwrap(),
+                PropertyDef::new("nick", DataType::Utf8, true).unwrap(),
+            ],
+        })
+        .unwrap()
+        .build()
+}
+
+async fn write_q(writer: &mut WriterSession, text: &str) -> namidb_query::WriteOutcome {
+    let plan = lower(&parse(text).unwrap()).unwrap();
+    execute_write(&plan, writer, &Params::new()).await.unwrap()
+}
+
+async fn write_err(writer: &mut WriterSession, text: &str) -> ExecError {
+    let plan = lower(&parse(text).unwrap()).unwrap();
+    execute_write(&plan, writer, &Params::new())
+        .await
+        .expect_err("expected the write to be rejected")
+}
+
+/// Open a writer with [`person_schema`] persisted into the manifest, so
+/// `writer.schema()` sees it and enforcement is live. A flush needs a
+/// non-empty memtable, so we seed one node under an unrelated, undeclared
+/// label (`Seed`) that the `Person` assertions ignore.
+async fn open_enforcing(ns: &str) -> WriterSession {
+    let mut writer = WriterSession::open(store(), paths(ns)).await.unwrap();
+    write_q(&mut writer, "CREATE (:Seed {x: 1})").await;
+    writer.flush(person_schema()).await.unwrap();
+    writer
+}
+
+fn is_notnull(err: &ExecError) -> bool {
+    matches!(err, ExecError::Constraint(msg) if msg.contains("not-null"))
+}
+
+async fn person_count(writer: &WriterSession) -> usize {
+    writer.snapshot().scan_label("Person").await.unwrap().len()
+}
+
+#[tokio::test]
+async fn create_rejects_missing_required_property() {
+    let mut writer = open_enforcing("nn-create-missing").await;
+    let err = write_err(&mut writer, "CREATE (:Person {nick: 'ada'})").await;
+    assert!(
+        is_notnull(&err),
+        "expected not-null constraint, got {err:?}"
+    );
+    assert_eq!(person_count(&writer).await, 0);
+}
+
+#[tokio::test]
+async fn create_rejects_explicit_null_required_property() {
+    let mut writer = open_enforcing("nn-create-null").await;
+    let err = write_err(&mut writer, "CREATE (:Person {name: null})").await;
+    assert!(
+        is_notnull(&err),
+        "expected not-null constraint, got {err:?}"
+    );
+    assert_eq!(person_count(&writer).await, 0);
+}
+
+#[tokio::test]
+async fn create_allows_required_property_with_value() {
+    let mut writer = open_enforcing("nn-create-ok").await;
+    // `nick` (nullable) may be omitted entirely.
+    let outcome = write_q(&mut writer, "CREATE (:Person {name: 'Ada'})").await;
+    assert_eq!(outcome.nodes_created, 1);
+    assert_eq!(person_count(&writer).await, 1);
+}
+
+#[tokio::test]
+async fn set_rejects_null_on_required_property() {
+    let mut writer = open_enforcing("nn-set-null").await;
+    write_q(&mut writer, "CREATE (:Person {name: 'Ada'})").await;
+    let err = write_err(&mut writer, "MATCH (p:Person) SET p.name = null").await;
+    assert!(
+        is_notnull(&err),
+        "expected not-null constraint, got {err:?}"
+    );
+    // The node keeps its original name; the rejected SET committed nothing.
+    let people = writer.snapshot().scan_label("Person").await.unwrap();
+    assert_eq!(people.len(), 1);
+    assert_eq!(
+        people[0].properties.get("name"),
+        Some(&namidb_core::value::Value::Str("Ada".into()))
+    );
+}
+
+#[tokio::test]
+async fn set_allows_value_on_required_and_null_on_nullable() {
+    let mut writer = open_enforcing("nn-set-ok").await;
+    write_q(&mut writer, "CREATE (:Person {name: 'Ada', nick: 'a'})").await;
+    // A real value on the required property is fine.
+    write_q(&mut writer, "MATCH (p:Person) SET p.name = 'Grace'").await;
+    // NULL on a nullable property is fine.
+    write_q(&mut writer, "MATCH (p:Person) SET p.nick = null").await;
+    let people = writer.snapshot().scan_label("Person").await.unwrap();
+    assert_eq!(
+        people[0].properties.get("name"),
+        Some(&namidb_core::value::Value::Str("Grace".into()))
+    );
+}
+
+#[tokio::test]
+async fn remove_rejects_required_property() {
+    let mut writer = open_enforcing("nn-remove-required").await;
+    write_q(&mut writer, "CREATE (:Person {name: 'Ada'})").await;
+    let err = write_err(&mut writer, "MATCH (p:Person) REMOVE p.name").await;
+    assert!(
+        is_notnull(&err),
+        "expected not-null constraint, got {err:?}"
+    );
+    let people = writer.snapshot().scan_label("Person").await.unwrap();
+    assert_eq!(
+        people[0].properties.get("name"),
+        Some(&namidb_core::value::Value::Str("Ada".into()))
+    );
+}
+
+#[tokio::test]
+async fn remove_allows_nullable_property() {
+    let mut writer = open_enforcing("nn-remove-nullable").await;
+    write_q(&mut writer, "CREATE (:Person {name: 'Ada', nick: 'a'})").await;
+    write_q(&mut writer, "MATCH (p:Person) REMOVE p.nick").await;
+    let people = writer.snapshot().scan_label("Person").await.unwrap();
+    assert_eq!(people[0].properties.get("nick"), None);
+    // The required property is untouched.
+    assert_eq!(
+        people[0].properties.get("name"),
+        Some(&namidb_core::value::Value::Str("Ada".into()))
+    );
+}
+
+#[tokio::test]
+async fn add_label_rejects_when_required_property_missing() {
+    let mut writer = open_enforcing("nn-addlabel-missing").await;
+    // A bare node with no `name`, created under an undeclared label.
+    write_q(&mut writer, "CREATE (:Ghost {x: 1})").await;
+    // Promoting it to :Person would leave Person.name null.
+    let err = write_err(&mut writer, "MATCH (g:Ghost) SET g:Person").await;
+    assert!(
+        is_notnull(&err),
+        "expected not-null constraint, got {err:?}"
+    );
+    assert_eq!(person_count(&writer).await, 0);
+}
+
+#[tokio::test]
+async fn add_label_allows_when_required_property_present() {
+    let mut writer = open_enforcing("nn-addlabel-ok").await;
+    write_q(&mut writer, "CREATE (:Ghost {name: 'Ada'})").await;
+    write_q(&mut writer, "MATCH (g:Ghost) SET g:Person").await;
+    assert_eq!(person_count(&writer).await, 1);
+}
+
+#[tokio::test]
+async fn merge_create_branch_enforces_required_property() {
+    let mut writer = open_enforcing("nn-merge").await;
+    // No Person matches, so MERGE takes the create branch — which must still
+    // reject a node missing the required property.
+    let err = write_err(&mut writer, "MERGE (:Person {nick: 'ada'})").await;
+    assert!(
+        is_notnull(&err),
+        "expected not-null constraint, got {err:?}"
+    );
+    assert_eq!(person_count(&writer).await, 0);
+}
+
+#[tokio::test]
+async fn undeclared_label_is_unconstrained() {
+    let mut writer = open_enforcing("nn-undeclared").await;
+    // `Robot` is not in the schema, so it has no NOT NULL contract.
+    let outcome = write_q(&mut writer, "CREATE (:Robot {serial: 7})").await;
+    assert_eq!(outcome.nodes_created, 1);
+}


### PR DESCRIPTION
P0: a property a label declares nullable=false is now a hard write-time invariant (was advisory). Rejects a CREATE that omits it or sets NULL, a SET p=NULL, a REMOVE p, and adding the declaring label to a node that lacks the value. MERGE covered via its CREATE/SET branches. Node-only, mirroring the unique-constraint path (ExecError::Constraint).