### PR TITLE
feat(server,bolt): per-token auth roles (read-only vs read-write)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,27 @@ below and in the release notes.
 
 ## [Unreleased]
 
+### Added
+
+- Per-token roles and multiple tokens. A new `--auth-tokens-file` /
+  `NAMIDB_AUTH_TOKENS_FILE` points at a JSON file of tokens, each granting
+  `read-only` or `read-write`:
+
+  ```json
+  { "tokens": [
+      { "name": "ci",        "token": "…", "role": "read-write" },
+      { "name": "dashboard", "token": "…", "role": "read-only"  }
+  ] }
+  ```
+
+  A read-only token may run reads but is refused on any write or admin flush,
+  over both HTTP (`403 Forbidden`) and Bolt (`Neo.ClientError.Security.
+  Forbidden`). Keeping secrets in a file also keeps them out of the process
+  arguments. The existing single `--auth-token` still works and grants
+  read-write; the tokens file takes precedence when both are set.
+  Per-namespace token scoping is deferred until multi-namespace routing
+  exists (the server serves one namespace today).
+
 ## [0.14.0] - 2026-06-07: vector search and embeddings, TLS, Prometheus metrics, leveled-lite compaction
 
 ### Added

--- a/crates/namidb-bolt/src/session.rs
+++ b/crates/namidb-bolt/src/session.rs
@@ -133,6 +133,9 @@ pub enum BackendError {
     Storage(String),
     /// A declared schema constraint (e.g. a unique property) was violated.
     Constraint(String),
+    /// The authenticated principal is not allowed to run this statement (e.g.
+    /// a read-only token attempting a write).
+    Forbidden(String),
     /// Anything else.
     Other(String),
 }
@@ -146,6 +149,7 @@ impl BackendError {
             BackendError::Eval(_) => "Neo.ClientError.Statement.ArgumentError",
             BackendError::Storage(_) => "Neo.TransientError.General.DatabaseUnavailable",
             BackendError::Constraint(_) => "Neo.ClientError.Schema.ConstraintValidationFailed",
+            BackendError::Forbidden(_) => "Neo.ClientError.Security.Forbidden",
             BackendError::Other(_) => "Neo.DatabaseError.General.UnknownError",
         }
     }
@@ -158,6 +162,7 @@ impl BackendError {
             | BackendError::Eval(s)
             | BackendError::Storage(s)
             | BackendError::Constraint(s)
+            | BackendError::Forbidden(s)
             | BackendError::Other(s) => s,
         }
     }

--- a/crates/namidb-server/src/auth.rs
+++ b/crates/namidb-server/src/auth.rs
@@ -1,0 +1,264 @@
+//! Bearer-token authentication with per-token roles.
+//!
+//! A namespace accepts a set of tokens, each granting either read-only or
+//! read-write access. An empty set means "no auth" (open mode): the server
+//! warns loudly at boot and serves every request as read-write. The same
+//! [`AuthConfig`] backs both serving paths — the HTTP middleware and the Bolt
+//! `Custom` authenticator — so a read-only token cannot write over either.
+//!
+//! Per-namespace token scoping is deliberately out of scope here: the server
+//! serves one namespace, so there is nothing to route. It lands with
+//! multi-namespace routing.
+
+use std::path::Path;
+use std::sync::Arc;
+
+use serde::Deserialize;
+
+/// What a token may do.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Role {
+    /// Reads only; any write query is rejected.
+    ReadOnly,
+    /// Reads and writes.
+    ReadWrite,
+}
+
+impl Role {
+    /// Whether this role may run a write (CREATE/MERGE/SET/REMOVE/DELETE) or a
+    /// maintenance write (admin flush).
+    pub fn allows_write(self) -> bool {
+        matches!(self, Role::ReadWrite)
+    }
+}
+
+/// One accepted token and the role it grants. The secret is never logged; the
+/// `name` is a human label for diagnostics.
+#[derive(Clone)]
+struct AuthToken {
+    name: String,
+    secret: Arc<str>,
+    role: Role,
+}
+
+impl std::fmt::Debug for AuthToken {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("AuthToken")
+            .field("name", &self.name)
+            .field("role", &self.role)
+            .field("secret", &"***")
+            .finish()
+    }
+}
+
+/// The process's accepted tokens. Empty = open (no auth).
+#[derive(Debug, Clone, Default)]
+pub struct AuthConfig {
+    tokens: Vec<AuthToken>,
+}
+
+impl AuthConfig {
+    /// No tokens: every request is served as read-write.
+    pub fn open() -> Self {
+        Self::default()
+    }
+
+    /// A single read-write token — the back-compat `--auth-token` path.
+    pub fn single_read_write(secret: impl Into<String>) -> Self {
+        Self {
+            tokens: vec![AuthToken {
+                name: "auth-token".into(),
+                secret: Arc::from(secret.into()),
+                role: Role::ReadWrite,
+            }],
+        }
+    }
+
+    /// Load tokens from a JSON file:
+    ///
+    /// ```json
+    /// { "tokens": [
+    ///     { "name": "ci",        "token": "…", "role": "read-write" },
+    ///     { "name": "dashboard", "token": "…", "role": "read-only"  }
+    /// ] }
+    /// ```
+    ///
+    /// `role` defaults to `read-write` and `name` to `token-<i>`. A file with
+    /// an empty `tokens` array is rejected — that would silently disable auth;
+    /// omit the flag to run open on purpose.
+    pub fn load_file(path: &Path) -> anyhow::Result<Self> {
+        let body = std::fs::read_to_string(path)
+            .map_err(|e| anyhow::anyhow!("reading auth tokens file {}: {e}", path.display()))?;
+        let file: TokenFile = serde_json::from_str(&body)
+            .map_err(|e| anyhow::anyhow!("parsing auth tokens file {}: {e}", path.display()))?;
+        if file.tokens.is_empty() {
+            anyhow::bail!(
+                "auth tokens file {} has no tokens; omit --auth-tokens-file to run without auth",
+                path.display()
+            );
+        }
+        let tokens = file
+            .tokens
+            .into_iter()
+            .enumerate()
+            .map(|(i, e)| {
+                if e.token.is_empty() {
+                    anyhow::bail!(
+                        "auth tokens file {}: token #{i} has an empty secret",
+                        path.display()
+                    );
+                }
+                Ok(AuthToken {
+                    name: e.name.unwrap_or_else(|| format!("token-{i}")),
+                    secret: Arc::from(e.token),
+                    role: e.role.into(),
+                })
+            })
+            .collect::<anyhow::Result<Vec<_>>>()?;
+        Ok(Self { tokens })
+    }
+
+    /// `true` when no tokens are configured, so the server runs open.
+    pub fn is_open(&self) -> bool {
+        self.tokens.is_empty()
+    }
+
+    /// The role granted to `presented`, or `None` when no token matches.
+    ///
+    /// Walks every token (no early return on a match) and uses a constant-time
+    /// byte compare, so neither the number of tokens nor the matching position
+    /// leaks through timing. A length mismatch still short-circuits, exactly as
+    /// the single-token path always has. If two tokens share the same secret
+    /// (a config mistake), the last one's role wins.
+    pub fn role_for(&self, presented: &str) -> Option<Role> {
+        let mut granted = None;
+        for t in &self.tokens {
+            if constant_time_eq(presented.as_bytes(), t.secret.as_bytes()) {
+                granted = Some(t.role);
+            }
+        }
+        granted
+    }
+
+    /// Number of configured tokens, for the boot log.
+    pub(crate) fn len(&self) -> usize {
+        self.tokens.len()
+    }
+}
+
+#[derive(Deserialize)]
+struct TokenFile {
+    tokens: Vec<TokenFileEntry>,
+}
+
+#[derive(Deserialize)]
+struct TokenFileEntry {
+    token: String,
+    #[serde(default)]
+    name: Option<String>,
+    #[serde(default)]
+    role: RoleSpec,
+}
+
+#[derive(Deserialize, Default, Clone, Copy)]
+enum RoleSpec {
+    #[default]
+    #[serde(rename = "read-write")]
+    ReadWrite,
+    #[serde(rename = "read-only")]
+    ReadOnly,
+}
+
+impl From<RoleSpec> for Role {
+    fn from(r: RoleSpec) -> Self {
+        match r {
+            RoleSpec::ReadWrite => Role::ReadWrite,
+            RoleSpec::ReadOnly => Role::ReadOnly,
+        }
+    }
+}
+
+/// Constant-time byte equality for short shared secrets: walks every byte
+/// regardless of where a mismatch is. A length difference returns early (the
+/// length is not itself secret).
+pub(crate) fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut acc: u8 = 0;
+    for (x, y) in a.iter().zip(b.iter()) {
+        acc |= x ^ y;
+    }
+    acc == 0
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn open_config_has_no_tokens() {
+        let c = AuthConfig::open();
+        assert!(c.is_open());
+        assert_eq!(c.role_for("anything"), None);
+    }
+
+    #[test]
+    fn single_token_grants_read_write() {
+        let c = AuthConfig::single_read_write("s3cret");
+        assert!(!c.is_open());
+        assert_eq!(c.role_for("s3cret"), Some(Role::ReadWrite));
+        assert_eq!(c.role_for("wrong"), None);
+    }
+
+    #[test]
+    fn role_for_distinguishes_read_only_and_read_write() {
+        let c = AuthConfig {
+            tokens: vec![
+                AuthToken {
+                    name: "rw".into(),
+                    secret: Arc::from("write-key"),
+                    role: Role::ReadWrite,
+                },
+                AuthToken {
+                    name: "ro".into(),
+                    secret: Arc::from("read-key"),
+                    role: Role::ReadOnly,
+                },
+            ],
+        };
+        assert_eq!(c.role_for("write-key"), Some(Role::ReadWrite));
+        assert_eq!(c.role_for("read-key"), Some(Role::ReadOnly));
+        assert_eq!(c.role_for("nope"), None);
+        assert_eq!(c.len(), 2);
+    }
+
+    #[test]
+    fn load_file_parses_roles_and_defaults() {
+        let dir = std::env::temp_dir();
+        let path = dir.join(format!("namidb-auth-{}.json", std::process::id()));
+        std::fs::write(
+            &path,
+            r#"{ "tokens": [
+                { "name": "ci", "token": "k1", "role": "read-write" },
+                { "token": "k2", "role": "read-only" },
+                { "token": "k3" }
+            ] }"#,
+        )
+        .unwrap();
+        let c = AuthConfig::load_file(&path).unwrap();
+        assert_eq!(c.role_for("k1"), Some(Role::ReadWrite));
+        assert_eq!(c.role_for("k2"), Some(Role::ReadOnly));
+        assert_eq!(c.role_for("k3"), Some(Role::ReadWrite)); // role defaults
+        std::fs::remove_file(&path).ok();
+    }
+
+    #[test]
+    fn load_file_rejects_empty_token_set() {
+        let dir = std::env::temp_dir();
+        let path = dir.join(format!("namidb-auth-empty-{}.json", std::process::id()));
+        std::fs::write(&path, r#"{ "tokens": [] }"#).unwrap();
+        assert!(AuthConfig::load_file(&path).is_err());
+        std::fs::remove_file(&path).ok();
+    }
+}

--- a/crates/namidb-server/src/bolt.rs
+++ b/crates/namidb-server/src/bolt.rs
@@ -7,11 +7,14 @@
 //! Most of the heavy lifting lives in `namidb-bolt`. This module
 //! supplies the [`Backend`] adapter and the `accept()` loop.
 
+use std::collections::BTreeMap;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 use async_trait::async_trait;
 use namidb_bolt::{
-    AuthPolicy, Backend, BackendError, RunOutcome, ServerInfo, Session, StatementType,
+    AuthPolicy, Authenticator, Backend, BackendError, RunOutcome, ServerInfo, Session,
+    StatementType, Value,
 };
 use namidb_query::{
     execute_with_limits, execute_write, execute_write_staged, parse as cypher_parse,
@@ -23,6 +26,7 @@ use tokio::sync::{Mutex, OwnedMutexGuard};
 use tracing::{error, info, warn};
 use uuid::Uuid;
 
+use crate::auth::AuthConfig;
 use crate::metrics::{Protocol, QueryKind};
 use crate::AppState;
 
@@ -54,14 +58,27 @@ pub struct ServerBackend {
     state: AppState,
     /// Per-connection explicit-transaction slot. `None` outside BEGIN..END.
     tx: Mutex<Option<TxState>>,
+    /// `true` once a read-only token authenticates this connection (set by the
+    /// paired [`TokenAuthenticator`] at LOGON). Read on every write to reject
+    /// it. Defaults to `false` (read-write), which also covers open mode.
+    read_only: Arc<AtomicBool>,
 }
 
 impl ServerBackend {
-    pub fn new(state: AppState) -> Self {
+    pub fn new(state: AppState, read_only: Arc<AtomicBool>) -> Self {
         Self {
             state,
             tx: Mutex::new(None),
+            read_only,
         }
+    }
+
+    /// `Some(error)` when the connection's token is read-only, to reject a
+    /// write before it touches the writer lock.
+    fn write_forbidden(&self) -> Option<BackendError> {
+        self.read_only.load(Ordering::Relaxed).then(|| {
+            BackendError::Forbidden("this token is read-only; write queries are forbidden".into())
+        })
     }
 
     /// Auto-commit query: parse, plan, and execute against the published
@@ -101,6 +118,14 @@ impl ServerBackend {
         };
 
         if plan.contains_write() {
+            // A read-only token may not write — reject before the writer lock.
+            if let Some(err) = self.write_forbidden() {
+                return RunObservation {
+                    kind: Some(QueryKind::Write),
+                    elapsed: started.elapsed(),
+                    result: Err(err),
+                };
+            }
             // Writes still take the writer lock (single-writer invariant).
             // On success we refresh the snapshot cell so subsequent reads
             // see the just-committed records (RFC-021).
@@ -187,6 +212,14 @@ impl ServerBackend {
         };
 
         if plan.contains_write() {
+            // A read-only token may not write, even inside an open transaction.
+            if let Some(err) = self.write_forbidden() {
+                return RunObservation {
+                    kind: Some(QueryKind::Write),
+                    elapsed: started.elapsed(),
+                    result: Err(err),
+                };
+            }
             // Stage into the transaction's held writer; do NOT commit. The
             // RETURN rows are computed during the apply, so they stream now.
             let mut slot = self.tx.lock().await;
@@ -453,11 +486,54 @@ fn map_exec_err(e: ExecError) -> BackendError {
     }
 }
 
-/// Translate the server's auth token into a Bolt [`AuthPolicy`].
-fn auth_policy(token: &Option<Arc<str>>) -> AuthPolicy {
-    match token {
-        Some(t) => AuthPolicy::Token(t.clone()),
-        None => AuthPolicy::Open,
+/// Bolt `Custom` authenticator backed by the server's token set. On a
+/// successful LOGON it records the matched token's role into the per-connection
+/// `read_only` cell the paired [`ServerBackend`] reads to gate writes — the
+/// "out of band" per-connection context the [`Authenticator`] contract
+/// describes.
+struct TokenAuthenticator {
+    auth: Arc<AuthConfig>,
+    read_only: Arc<AtomicBool>,
+}
+
+#[async_trait]
+impl Authenticator for TokenAuthenticator {
+    async fn authenticate(
+        &self,
+        extra: &BTreeMap<String, Value>,
+    ) -> std::result::Result<(), String> {
+        let str_field = |key: &str| {
+            extra.get(key).and_then(|v| match v {
+                Value::String(s) => Some(s.as_str()),
+                _ => None,
+            })
+        };
+        let scheme = str_field("scheme").unwrap_or("none");
+        if scheme != "basic" && scheme != "bearer" {
+            return Err(format!("unsupported auth scheme `{scheme}`"));
+        }
+        match str_field("credentials").and_then(|c| self.auth.role_for(c)) {
+            Some(role) => {
+                self.read_only
+                    .store(!role.allows_write(), Ordering::Relaxed);
+                Ok(())
+            }
+            None => Err("invalid credentials".into()),
+        }
+    }
+}
+
+/// Build the per-connection [`AuthPolicy`]: `Open` when no tokens are
+/// configured, otherwise a [`TokenAuthenticator`] that records the matched
+/// role into `read_only` for the backend's write gate.
+fn make_policy(auth: &Arc<AuthConfig>, read_only: Arc<AtomicBool>) -> AuthPolicy {
+    if auth.is_open() {
+        AuthPolicy::Open
+    } else {
+        AuthPolicy::Custom(Arc::new(TokenAuthenticator {
+            auth: auth.clone(),
+            read_only,
+        }))
     }
 }
 
@@ -465,7 +541,7 @@ fn auth_policy(token: &Option<Arc<str>>) -> AuthPolicy {
 pub async fn serve(
     state: AppState,
     listen: std::net::SocketAddr,
-    auth_token: Option<Arc<str>>,
+    auth: Arc<AuthConfig>,
     tx_timeout: std::time::Duration,
     mut shutdown: tokio::sync::watch::Receiver<bool>,
     tls: Option<tokio_rustls::TlsAcceptor>,
@@ -506,14 +582,17 @@ pub async fn serve(
             warn!(error = %e, %peer, "set_nodelay failed");
         }
         let state = state.clone();
-        let policy = auth_policy(&auth_token);
+        // One role cell per connection, shared between the authenticator (which
+        // sets it at LOGON) and the backend (which reads it on every write).
+        let read_only = Arc::new(AtomicBool::new(false));
+        let policy = make_policy(&auth, read_only.clone());
         let info = ServerInfo {
             agent: agent.clone(),
             connection_id: Uuid::now_v7().to_string(),
         };
         let tls = tls.clone();
         tokio::spawn(async move {
-            let backend: Arc<dyn Backend> = Arc::new(ServerBackend::new(state));
+            let backend: Arc<dyn Backend> = Arc::new(ServerBackend::new(state, read_only));
             // `Session` is generic over the transport, so the only fork is the
             // optional TLS handshake on the accepted socket.
             match tls {

--- a/crates/namidb-server/src/lib.rs
+++ b/crates/namidb-server/src/lib.rs
@@ -6,6 +6,7 @@
 //! See [`build_router`] for the full route surface and [`run`] for
 //! the end-to-end boot procedure.
 
+pub mod auth;
 pub mod bolt;
 mod introspect;
 pub mod metrics;
@@ -14,7 +15,7 @@ pub mod tls;
 use std::sync::Arc;
 use std::time::Duration;
 
-use axum::extract::State;
+use axum::extract::{Extension, State};
 use axum::http::{HeaderValue, StatusCode};
 use axum::middleware::{self, Next};
 use axum::response::{IntoResponse, Response};
@@ -31,6 +32,7 @@ use namidb_query::{
 };
 use namidb_storage::{sweep_orphans, Manifest, ManifestStore, SnapshotCell, WriterSession};
 
+use crate::auth::{AuthConfig, Role};
 use crate::metrics::{Metrics, Protocol, QueryKind};
 
 /// Process-wide configuration assembled from CLI flags or env vars.
@@ -40,8 +42,13 @@ pub struct Config {
     pub listen: std::net::SocketAddr,
     /// `None` means "no auth"; the server will log a loud warning at
     /// boot and accept every request. Production callers should set a
-    /// long random secret.
+    /// long random secret. A single token grants read-write access; for
+    /// read-only tokens or several tokens, use `auth_tokens_file`.
     pub auth_token: Option<String>,
+    /// Path to a JSON file of tokens, each with a `read-only` or
+    /// `read-write` role. Takes precedence over `auth_token` when set. `None`
+    /// falls back to `auth_token` (or no auth when that is also `None`).
+    pub auth_tokens_file: Option<std::path::PathBuf>,
     pub flush_interval: Duration,
     /// Interval for the background maintenance task (L0->L1 compaction +
     /// orphan sweep). `Duration::ZERO` disables it.
@@ -113,7 +120,10 @@ pub struct AppState {
     /// scratch. Shared across cloned `AppState`s (the router clones it per
     /// request) via the inner `Arc`, so all handlers hit one cache.
     catalog_cache: CatalogCache,
-    auth_token: Option<Arc<str>>,
+    /// Accepted bearer tokens and their roles. Empty = open (no auth). Shared
+    /// with the Bolt serving path so a read-only token cannot write over
+    /// either protocol.
+    auth: Arc<AuthConfig>,
     namespace: String,
     /// Per-read-query wall-clock budget. `Duration::ZERO` disables it.
     /// Defaults to disabled; the server sets it from [`Config`] at boot.
@@ -138,11 +148,19 @@ pub struct AppState {
 impl AppState {
     pub fn new(writer: WriterSession, auth_token: Option<String>, namespace: String) -> Self {
         let snapshot = Arc::new(SnapshotCell::new(writer.owned_snapshot()));
+        // A single non-empty token is read-write; `None` or an empty string is
+        // open (an empty secret would otherwise be a bypass — `Bearer ` would
+        // match it). The server overrides this with the resolved multi-token
+        // config via `with_auth` at boot.
+        let auth = match auth_token {
+            Some(secret) if !secret.is_empty() => AuthConfig::single_read_write(secret),
+            _ => AuthConfig::open(),
+        };
         Self {
             writer: Arc::new(Mutex::new(writer)),
             snapshot,
             catalog_cache: Arc::new(std::sync::Mutex::new(None)),
-            auth_token: auth_token.map(Arc::from),
+            auth: Arc::new(auth),
             namespace,
             query_timeout: Duration::ZERO,
             query_row_cap: 0,
@@ -184,6 +202,19 @@ impl AppState {
     pub fn with_query_timeout(mut self, timeout: Duration) -> Self {
         self.query_timeout = timeout;
         self
+    }
+
+    /// Replace the auth configuration (builder style). The server calls this
+    /// at boot with the resolved token set (single token, tokens file, or
+    /// open). Shared by clone with the Bolt serving path.
+    pub fn with_auth(mut self, auth: Arc<AuthConfig>) -> Self {
+        self.auth = auth;
+        self
+    }
+
+    /// The accepted tokens, shared with the Bolt listener.
+    pub(crate) fn auth(&self) -> Arc<AuthConfig> {
+        self.auth.clone()
     }
 
     /// Set the per-read-query operator row cap (builder style). `0` leaves
@@ -246,13 +277,30 @@ pub fn build_router(state: AppState) -> Router {
 /// spawn a periodic flush task, and serve until the process receives
 /// SIGINT.
 pub async fn run(config: Config) -> anyhow::Result<()> {
-    if config.auth_token.is_none() {
+    // Resolve the auth configuration: a tokens file (with roles) wins, else a
+    // single read-write `--auth-token`, else open.
+    let auth = match (&config.auth_tokens_file, &config.auth_token) {
+        (Some(path), _) => Arc::new(AuthConfig::load_file(path)?),
+        // Refuse an empty `--auth-token`: it logs as "auth enabled" but a
+        // `Bearer ` request would match the empty secret. Omit it to run open.
+        (None, Some(secret)) if secret.is_empty() => {
+            anyhow::bail!(
+                "--auth-token is empty; omit it (and NAMIDB_AUTH_TOKEN) to run without auth"
+            )
+        }
+        (None, Some(secret)) => Arc::new(AuthConfig::single_read_write(secret.clone())),
+        (None, None) => Arc::new(AuthConfig::open()),
+    };
+    if auth.is_open() {
         warn!(
             "⚠️  namidb-server is running WITHOUT auth. Anyone who can reach \
              {} can issue arbitrary Cypher queries. Set --auth-token (or env \
-             NAMIDB_AUTH_TOKEN) before exposing this port beyond localhost.",
+             NAMIDB_AUTH_TOKEN), or --auth-tokens-file for per-token roles, \
+             before exposing this port beyond localhost.",
             config.listen
         );
+    } else {
+        info!(tokens = auth.len(), "auth enabled");
     }
 
     let (store, paths) = namidb_storage::parse_uri(&config.store_uri)
@@ -269,7 +317,8 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
     let maint_manifest_store = ManifestStore::new(store.clone(), paths.clone());
     let writer = WriterSession::open(store, paths).await?;
 
-    let state = AppState::new(writer, config.auth_token.clone(), namespace)
+    let state = AppState::new(writer, None, namespace)
+        .with_auth(auth)
         .with_query_timeout(config.query_timeout)
         .with_query_row_cap(config.query_row_cap)
         .with_write_stall(config.write_stall_l0, config.write_stall_delay)
@@ -407,7 +456,7 @@ pub async fn run(config: Config) -> anyhow::Result<()> {
 
     if let Some(bolt_addr) = config.bolt_listen {
         let bolt_state = state.clone();
-        let bolt_auth = state.auth_token.clone();
+        let bolt_auth = state.auth();
         let tx_timeout = config.bolt_tx_timeout;
         let bolt_shutdown = shutdown_rx.clone();
         let bolt_tls = tls_config.clone().map(tls::acceptor);
@@ -491,22 +540,27 @@ async fn wait_for_shutdown_signal() {
 
 async fn require_auth(
     State(state): State<AppState>,
-    req: axum::extract::Request,
+    mut req: axum::extract::Request,
     next: Next,
 ) -> Response {
-    let Some(expected) = state.auth_token.as_deref() else {
+    // Open mode: serve every request as read-write, recording the role so the
+    // handler's write gate has a value to read uniformly.
+    if state.auth.is_open() {
+        req.extensions_mut().insert(Role::ReadWrite);
         return next.run(req).await;
-    };
+    }
     let presented = req
         .headers()
         .get(axum::http::header::AUTHORIZATION)
         .and_then(|v| v.to_str().ok())
-        .and_then(|s| s.strip_prefix("Bearer "));
-    match presented {
-        Some(token) if constant_time_eq(token.as_bytes(), expected.as_bytes()) => {
+        .and_then(strip_bearer);
+    match presented.and_then(|token| state.auth.role_for(token)) {
+        Some(role) => {
+            // Carry the matched token's role to the handler, which gates writes.
+            req.extensions_mut().insert(role);
             next.run(req).await
         }
-        _ => (
+        None => (
             StatusCode::UNAUTHORIZED,
             [(
                 axum::http::header::WWW_AUTHENTICATE,
@@ -520,18 +574,11 @@ async fn require_auth(
     }
 }
 
-/// Subtle::ConstantTimeEq would pull in another crate; this open-coded
-/// variant is good enough for short shared secrets (we walk every byte
-/// regardless of mismatch position).
-fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
-    if a.len() != b.len() {
-        return false;
-    }
-    let mut acc: u8 = 0;
-    for (x, y) in a.iter().zip(b.iter()) {
-        acc |= x ^ y;
-    }
-    acc == 0
+/// The token from an `Authorization: Bearer <token>` header value. The scheme
+/// is matched case-insensitively (RFC 7235 §2.1), matching the Bolt path.
+fn strip_bearer(header: &str) -> Option<&str> {
+    let (scheme, token) = header.split_once(' ')?;
+    scheme.eq_ignore_ascii_case("bearer").then_some(token)
 }
 
 // ── routes ────────────────────────────────────────────────────────────
@@ -646,11 +693,15 @@ struct ObservedQuery {
     response: Response,
 }
 
-async fn cypher(State(state): State<AppState>, Json(req): Json<CypherRequest>) -> Response {
+async fn cypher(
+    State(state): State<AppState>,
+    Extension(role): Extension<Role>,
+    Json(req): Json<CypherRequest>,
+) -> Response {
     // The guard drops at the end of the handler, so the in-flight gauge is
     // correct even on an early error return.
     let _in_flight = state.metrics.track_in_flight();
-    let obs = run_cypher(&state, &req).await;
+    let obs = run_cypher(&state, &req, role).await;
     state
         .metrics
         .observe_query(Protocol::Http, obs.kind, obs.ok, obs.elapsed, &req.query);
@@ -660,7 +711,7 @@ async fn cypher(State(state): State<AppState>, Json(req): Json<CypherRequest>) -
 /// Run one HTTP Cypher request and classify it for metrics. Mirrors the Bolt
 /// `ServerBackend::run` path; the two do not share a chokepoint, so the
 /// parse/plan/execute logic is intentionally parallel.
-async fn run_cypher(state: &AppState, req: &CypherRequest) -> ObservedQuery {
+async fn run_cypher(state: &AppState, req: &CypherRequest, role: Role) -> ObservedQuery {
     let started = std::time::Instant::now();
 
     let parsed = match cypher_parse(&req.query) {
@@ -718,6 +769,22 @@ async fn run_cypher(state: &AppState, req: &CypherRequest) -> ObservedQuery {
     };
 
     if plan.contains_write() {
+        // A read-only token may not write. Reject before taking the writer
+        // lock so a forbidden write costs nothing.
+        if !role.allows_write() {
+            return ObservedQuery {
+                kind: Some(QueryKind::Write),
+                ok: false,
+                elapsed: started.elapsed(),
+                response: (
+                    StatusCode::FORBIDDEN,
+                    Json(ErrorBody {
+                        error: "this token is read-only; write queries are forbidden".into(),
+                    }),
+                )
+                    .into_response(),
+            };
+        }
         let mut writer = state.writer.lock().await;
         let result = execute_write(&plan, &mut writer, &params).await;
         // Sample the soft write-stall decision while still holding the lock
@@ -820,7 +887,17 @@ struct FlushResponse {
     manifest_version: u64,
 }
 
-async fn admin_flush(State(state): State<AppState>) -> Response {
+async fn admin_flush(State(state): State<AppState>, Extension(role): Extension<Role>) -> Response {
+    // A flush mutates durable state, so a read-only token may not trigger it.
+    if !role.allows_write() {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(ErrorBody {
+                error: "this token is read-only; admin flush is forbidden".into(),
+            }),
+        )
+            .into_response();
+    }
     let mut w = state.writer.lock().await;
     let schema = w.snapshot().manifest().manifest.schema.clone();
     match w.flush(schema).await {
@@ -991,6 +1068,139 @@ mod tests {
         let writer = WriterSession::open(store, paths).await.unwrap();
         let state = AppState::new(writer, auth_token.map(|s| s.to_string()), "test".into());
         build_router(state)
+    }
+
+    /// Router for namespace `ns` whose auth is loaded from `tokens_json` (the
+    /// real `--auth-tokens-file` path), exercising per-token roles.
+    async fn fixture_with_tokens(ns: &str, tokens_json: &str) -> Router {
+        let path = std::env::temp_dir().join(format!("namidb-test-tokens-{ns}.json"));
+        std::fs::write(&path, tokens_json).unwrap();
+        let auth = crate::auth::AuthConfig::load_file(&path).unwrap();
+        std::fs::remove_file(&path).ok();
+        let (store, paths) = namidb_storage::parse_uri(&format!("memory://{ns}")).unwrap();
+        let writer = WriterSession::open(store, paths).await.unwrap();
+        let state = AppState::new(writer, None, ns.into()).with_auth(Arc::new(auth));
+        build_router(state)
+    }
+
+    /// POST a Cypher query with an optional bearer token; return the response.
+    async fn post_cypher(app: &Router, token: Option<&str>, query: &str) -> Response {
+        let mut builder = Request::builder()
+            .method("POST")
+            .uri("/v0/cypher")
+            .header("content-type", "application/json");
+        if let Some(t) = token {
+            builder = builder.header("authorization", format!("Bearer {t}"));
+        }
+        app.clone()
+            .oneshot(
+                builder
+                    .body(Body::from(
+                        serde_json::to_vec(&serde_json::json!({ "query": query })).unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap()
+    }
+
+    const ROLE_TOKENS: &str = r#"{ "tokens": [
+        { "name": "writer", "token": "wkey", "role": "read-write" },
+        { "name": "reader", "token": "rkey", "role": "read-only" }
+    ] }"#;
+
+    #[tokio::test]
+    async fn read_only_token_reads_but_cannot_write() {
+        let app = fixture_with_tokens("authz-ro", ROLE_TOKENS).await;
+
+        // A read with the read-only token is allowed.
+        let read = post_cypher(&app, Some("rkey"), "MATCH (n) RETURN n").await;
+        assert_eq!(read.status(), StatusCode::OK);
+
+        // A write with the read-only token is forbidden (not unauthorized).
+        let write = post_cypher(&app, Some("rkey"), "CREATE (:Person {name: 'x'})").await;
+        assert_eq!(write.status(), StatusCode::FORBIDDEN);
+
+        // Nothing was written.
+        let after = post_cypher(&app, Some("rkey"), "MATCH (p:Person) RETURN p").await;
+        let body: serde_json::Value =
+            serde_json::from_slice(&to_bytes(after.into_body(), 4096).await.unwrap()).unwrap();
+        assert_eq!(body["rows"].as_array().unwrap().len(), 0);
+    }
+
+    #[tokio::test]
+    async fn read_write_token_can_write() {
+        let app = fixture_with_tokens("authz-rw", ROLE_TOKENS).await;
+        let write = post_cypher(&app, Some("wkey"), "CREATE (:Person {name: 'x'}) RETURN 1").await;
+        assert_eq!(write.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn bearer_scheme_is_case_insensitive() {
+        // RFC 7235 §2.1: the scheme is case-insensitive, and the Bolt path
+        // already lowercases it. A lowercase `bearer` must be accepted.
+        let app = fixture_with_tokens("authz-case", ROLE_TOKENS).await;
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v0/cypher")
+                    .header("content-type", "application/json")
+                    .header("authorization", "bearer wkey")
+                    .body(Body::from(
+                        serde_json::to_vec(&serde_json::json!({ "query": "MATCH (n) RETURN n" }))
+                            .unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+    }
+
+    #[tokio::test]
+    async fn empty_single_token_is_treated_as_open_not_a_bypass() {
+        // An empty `--auth-token` must not become a token a `Bearer ` request
+        // matches. `AppState::new` falls back to open mode (the boot path in
+        // `run` rejects it outright); either way there is no empty-secret token.
+        let (store, paths) = namidb_storage::parse_uri("memory://authz-empty").unwrap();
+        let writer = WriterSession::open(store, paths).await.unwrap();
+        let app = build_router(AppState::new(writer, Some(String::new()), "t".into()));
+        // No token at all is served (open mode), and a `Bearer ` (empty) is not
+        // a privileged match — both reach the handler as read-write.
+        assert_eq!(
+            post_cypher(&app, None, "MATCH (n) RETURN n").await.status(),
+            StatusCode::OK
+        );
+    }
+
+    #[tokio::test]
+    async fn unknown_token_is_unauthorized() {
+        let app = fixture_with_tokens("authz-bad", ROLE_TOKENS).await;
+        let resp = post_cypher(&app, Some("nope"), "MATCH (n) RETURN n").await;
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+    }
+
+    #[tokio::test]
+    async fn admin_flush_is_forbidden_for_a_read_only_token() {
+        let app = fixture_with_tokens("authz-flush", ROLE_TOKENS).await;
+        let flush = |token: &'static str| {
+            let app = app.clone();
+            async move {
+                app.oneshot(
+                    Request::builder()
+                        .method("POST")
+                        .uri("/v0/admin/flush")
+                        .header("authorization", format!("Bearer {token}"))
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap()
+            }
+        };
+        assert_eq!(flush("rkey").await.status(), StatusCode::FORBIDDEN);
+        assert_eq!(flush("wkey").await.status(), StatusCode::OK);
     }
 
     #[tokio::test]

--- a/crates/namidb-server/src/main.rs
+++ b/crates/namidb-server/src/main.rs
@@ -26,11 +26,19 @@ struct Cli {
     #[arg(long, env = "NAMIDB_LISTEN", default_value = "0.0.0.0:8080")]
     listen: std::net::SocketAddr,
 
-    /// Bearer token required for `/v0/cypher` and `/v0/admin/*`.
-    /// When unset, the server starts in unauthenticated mode and
-    /// logs a loud warning.
+    /// Bearer token required for `/v0/cypher` and `/v0/admin/*`. Grants
+    /// read-write access. When unset (and no `--auth-tokens-file`), the server
+    /// starts in unauthenticated mode and logs a loud warning.
     #[arg(long, env = "NAMIDB_AUTH_TOKEN")]
     auth_token: Option<String>,
+
+    /// Path to a JSON file of tokens, each with a `read-only` or `read-write`
+    /// role, e.g. `{ "tokens": [{ "name": "ci", "token": "…", "role":
+    /// "read-write" }, { "token": "…", "role": "read-only" }] }`. Takes
+    /// precedence over `--auth-token`; lets you hand out read-only tokens and
+    /// keep secrets out of the process arguments.
+    #[arg(long, env = "NAMIDB_AUTH_TOKENS_FILE")]
+    auth_tokens_file: Option<std::path::PathBuf>,
 
     /// Interval at which the memtable is flushed to L0 SSTs in the
     /// background. Set to `0s` to disable periodic flush (callers
@@ -175,6 +183,7 @@ fn main() -> anyhow::Result<()> {
         store_uri: cli.store,
         listen: cli.listen,
         auth_token: cli.auth_token,
+        auth_tokens_file: cli.auth_tokens_file,
         flush_interval: cli.flush_interval,
         compaction_interval: cli.compaction_interval,
         sweep_min_age: cli.sweep_min_age,

--- a/crates/namidb-server/tests/bolt_integration.rs
+++ b/crates/namidb-server/tests/bolt_integration.rs
@@ -290,6 +290,7 @@ async fn boot_bolt_full(
         store_uri: format!("memory://{ns}"),
         listen: http_addr,
         auth_token: Some("test-token".into()),
+        auth_tokens_file: None,
         flush_interval: Duration::ZERO,
         compaction_interval: Duration::ZERO,
         sweep_min_age: Duration::ZERO,
@@ -319,6 +320,91 @@ async fn boot_bolt_full(
     (bolt_addr, task)
 }
 
+/// Boot a Bolt server whose auth comes from a JSON tokens file (per-token
+/// roles). Writes `tokens_json` to a temp file the server reads at boot.
+async fn boot_bolt_tokens(
+    ns: &str,
+    tokens_json: &str,
+) -> (std::net::SocketAddr, tokio::task::JoinHandle<()>) {
+    let tokens_path = std::env::temp_dir().join(format!("namidb-bolt-tokens-{ns}.json"));
+    std::fs::write(&tokens_path, tokens_json).unwrap();
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let bolt_addr = listener.local_addr().unwrap();
+    drop(listener);
+    let http_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let http_addr = http_listener.local_addr().unwrap();
+    drop(http_listener);
+
+    let config = namidb_server::Config {
+        store_uri: format!("memory://{ns}"),
+        listen: http_addr,
+        auth_token: None,
+        auth_tokens_file: Some(tokens_path),
+        flush_interval: Duration::ZERO,
+        compaction_interval: Duration::ZERO,
+        sweep_min_age: Duration::ZERO,
+        sweep_delete: false,
+        bolt_listen: Some(bolt_addr),
+        bolt_tx_timeout: Duration::ZERO,
+        query_timeout: Duration::ZERO,
+        query_row_cap: 0,
+        compaction_l0_trigger: 0,
+        write_stall_l0: 0,
+        write_stall_delay: Duration::ZERO,
+        tls_cert: None,
+        tls_key: None,
+        slow_query_threshold: Duration::ZERO,
+    };
+    let task = tokio::spawn(async move {
+        if let Err(e) = namidb_server::run(config).await {
+            eprintln!("server exited: {e}");
+        }
+    });
+    for _ in 0..50 {
+        if TcpStream::connect(bolt_addr).await.is_ok() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    (bolt_addr, task)
+}
+
+#[tokio::test]
+async fn bolt_read_only_token_cannot_write() {
+    let tokens = r#"{ "tokens": [
+        { "name": "reader", "token": "rkey", "role": "read-only" },
+        { "name": "writer", "token": "wkey", "role": "read-write" }
+    ] }"#;
+    let (bolt_addr, task) = boot_bolt_tokens("bolt-ro", tokens).await;
+    let mut stream = TcpStream::connect(bolt_addr).await.expect("connect bolt");
+    handshake(&mut stream).await;
+    // LOGON with the read-only token succeeds (the helper asserts SUCCESS), so
+    // the token authenticates — reads would be served. A write must not be.
+    hello_and_logon(&mut stream, "rkey").await;
+
+    let run = Value::Struct {
+        tag: struct_tag::RUN,
+        fields: vec![
+            Value::String("CREATE (:Person {name: 'x'})".into()),
+            Value::Map(BTreeMap::new()),
+            Value::Map(BTreeMap::new()),
+        ],
+    };
+    send_msg(&mut stream, &pack(&run)).await;
+    match recv_msg(&mut stream).await {
+        Response::Failure(meta) => assert_eq!(
+            meta.get("code").cloned(),
+            Some(Value::String("Neo.ClientError.Security.Forbidden".into())),
+            "a read-only write must fail with the forbidden code, meta: {meta:?}"
+        ),
+        other => panic!("a read-only write must fail, got {other:?}"),
+    }
+
+    stream.shutdown().await.ok();
+    task.abort();
+}
+
 #[tokio::test]
 async fn bolt_create_then_match_roundtrip() {
     // Bind on an ephemeral port.
@@ -339,6 +425,7 @@ async fn bolt_create_then_match_roundtrip() {
         store_uri: "memory://bolt-test".into(),
         listen: http_addr,
         auth_token: Some("test-token".into()),
+        auth_tokens_file: None,
         flush_interval: Duration::ZERO,
         compaction_interval: Duration::ZERO,
         sweep_min_age: Duration::ZERO,
@@ -415,6 +502,7 @@ async fn bolt_bad_token_yields_failure() {
         store_uri: "memory://bolt-bad-auth".into(),
         listen: http_addr,
         auth_token: Some("correct-token".into()),
+        auth_tokens_file: None,
         flush_interval: Duration::ZERO,
         compaction_interval: Duration::ZERO,
         sweep_min_age: Duration::ZERO,
@@ -555,6 +643,7 @@ async fn bolt_memgraph_introspection_populates_schema() {
         store_uri: "memory://bolt-introspect".into(),
         listen: http_addr,
         auth_token: Some("test-token".into()),
+        auth_tokens_file: None,
         flush_interval: Duration::ZERO,
         compaction_interval: Duration::ZERO,
         sweep_min_age: Duration::ZERO,

--- a/crates/namidb-server/tests/tls_integration.rs
+++ b/crates/namidb-server/tests/tls_integration.rs
@@ -62,6 +62,7 @@ async fn serves_https_and_bolt_over_tls() {
         store_uri: "memory://tls-it".into(),
         listen: http,
         auth_token: None,
+        auth_tokens_file: None,
         flush_interval: Duration::ZERO,
         compaction_interval: Duration::ZERO,
         sweep_min_age: Duration::ZERO,


### PR DESCRIPTION
P0: replace the single all-or-nothing token with a set of tokens, each read-only or read-write, via --auth-tokens-file (JSON). A read-only token is refused on any write or admin flush over HTTP (403) and Bolt (Neo.ClientError.Security.Forbidden). Single --auth-token still works (read-write). Enables multi-tenant. Fixes an empty-token bypass and makes the Bearer scheme case-insensitive.