### PR TITLE
perf(query): bounded top-k heap for ORDER BY ... LIMIT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ below and in the release notes.
 
 ## [Unreleased]
 
+### Changed
+
+- Bounded top-k for `ORDER BY ... LIMIT`. When a limit bounds the result to
+  `k = skip + limit` rows and `k` is smaller than the number of candidates,
+  the `TopN` operator now keeps only the `k` best in a max-heap instead of
+  materialising and sorting every candidate: O(n log k) time and O(k) memory
+  rather than O(n log n) and O(n). This is the hot path for K-nearest-neighbour
+  vector search (`ORDER BY cosine_similarity(n.embedding, $q) DESC LIMIT k`),
+  which previously sorted the whole scanned set. Results are identical to the
+  full sort, ties included. (The flat O(n) scan and uncompressed f32 vectors
+  remain; int8 quantization and an ANN index are the next steps.)
+
 ## [0.14.0] - 2026-06-07: vector search and embeddings, TLS, Prometheus metrics, leveled-lite compaction
 
 ### Added

--- a/crates/namidb-query/src/exec/walker.rs
+++ b/crates/namidb-query/src/exec/walker.rs
@@ -1454,6 +1454,43 @@ fn compare_keys(a: &[RuntimeValue], b: &[RuntimeValue], keys: &[OrderKey]) -> Or
     Ordering::Equal
 }
 
+/// Heap element for the bounded top-k path of `TopN`. Orders by the same
+/// per-key direction `compare_keys` uses (`descs[i]` is true when ORDER BY key
+/// `i` is `DESC`), then breaks ties by `pos` — the element's position in the
+/// input — so a max-heap that keeps the `k` smallest reproduces the stable
+/// full-sort's first `k` exactly, ties and all. The heap's `peek` is the worst
+/// kept candidate, evicted when a better one arrives.
+struct TopNItem {
+    vals: Vec<RuntimeValue>,
+    leaf: crate::exec::FactorIdx,
+    pos: usize,
+    descs: std::sync::Arc<[bool]>,
+}
+
+impl Ord for TopNItem {
+    fn cmp(&self, other: &Self) -> Ordering {
+        for (i, &desc) in self.descs.iter().enumerate() {
+            let o = order_for_sort(&self.vals[i], &other.vals[i], desc);
+            if o != Ordering::Equal {
+                return o;
+            }
+        }
+        // Stable tiebreak: earlier input position sorts first.
+        self.pos.cmp(&other.pos)
+    }
+}
+impl PartialOrd for TopNItem {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+impl PartialEq for TopNItem {
+    fn eq(&self, other: &Self) -> bool {
+        self.cmp(other) == Ordering::Equal
+    }
+}
+impl Eq for TopNItem {}
+
 pub(crate) fn cross_product(left: Vec<Row>, right: Vec<Row>) -> Vec<Row> {
     if left.is_empty() || right.is_empty() {
         return Vec::new();
@@ -2166,6 +2203,62 @@ pub(crate) fn execute_factor_inner_with_routing<'a>(
                 let mut needed: BTreeSet<String> = BTreeSet::new();
                 for k in keys {
                     collect_referenced_variables(&k.expression, &mut needed);
+                }
+
+                // Bounded top-k fast path. When a `LIMIT` bounds the result to
+                // `k = skip + limit` rows and `k < n`, keep only the `k` best in
+                // a max-heap whose top is the worst kept candidate: O(n log k)
+                // time and O(k) memory instead of materialising and sorting all
+                // `n` keyed rows. This is the hot path for KNN
+                // (`ORDER BY cosine_similarity(...) DESC LIMIT k`). The position
+                // tiebreak makes the result identical to the full sort below.
+                if limit != u64::MAX {
+                    let k = (skip as usize).saturating_add(limit as usize);
+                    if k > 0 && k < input_set.cardinality() {
+                        let descs: std::sync::Arc<[bool]> = std::sync::Arc::from(
+                            keys.iter()
+                                .map(|key| {
+                                    matches!(key.direction, crate::parser::OrderDirection::Desc)
+                                })
+                                .collect::<Vec<bool>>(),
+                        );
+                        let mut heap: std::collections::BinaryHeap<TopNItem> =
+                            std::collections::BinaryHeap::with_capacity(k + 1);
+                        for (pos, &leaf) in input_set.leaves.iter().enumerate() {
+                            let mut thin_row = Row::new();
+                            for var_name in &needed {
+                                if let Some(v) = input_set.arena.lookup_binding(leaf, var_name) {
+                                    thin_row.set(var_name.clone(), v.clone());
+                                }
+                            }
+                            let mut key_vals = Vec::with_capacity(keys.len());
+                            for key in keys {
+                                key_vals.push(evaluate(&key.expression, &thin_row, params)?);
+                            }
+                            let item = TopNItem {
+                                vals: key_vals,
+                                leaf,
+                                pos,
+                                descs: descs.clone(),
+                            };
+                            if heap.len() < k {
+                                heap.push(item);
+                            } else if &item < heap.peek().expect("heap full so non-empty") {
+                                // `item` sorts before the current worst kept.
+                                heap.pop();
+                                heap.push(item);
+                            }
+                        }
+                        let mut kept = heap.into_vec();
+                        kept.sort_unstable();
+                        let rows: Vec<Row> = kept
+                            .into_iter()
+                            .skip(skip as usize)
+                            .take(limit as usize)
+                            .map(|it| input_set.arena.materialize(it.leaf, None))
+                            .collect();
+                        return Ok(FactorRowSet::from_flat(rows));
+                    }
                 }
 
                 let mut keyed: Vec<(Vec<RuntimeValue>, crate::exec::FactorIdx)> =

--- a/crates/namidb-query/tests/exec_topk.rs
+++ b/crates/namidb-query/tests/exec_topk.rs
@@ -1,0 +1,163 @@
+//! Bounded top-k: the `TopN` heap fast path.
+//!
+//! `ORDER BY ... LIMIT k` with `k < n` keeps only the `k` best rows in a
+//! max-heap (O(n log k) time, O(k) memory) instead of materialising and
+//! sorting all `n` keyed rows. This is the hot path for KNN
+//! (`ORDER BY cosine_similarity(...) DESC LIMIT k`). The result must be
+//! identical to the full sort: correct rows, correct order, correct window.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use namidb_core::id::{NamespaceId, NodeId};
+use namidb_core::value::Value as CoreValue;
+use namidb_storage::{NamespacePaths, NodeWriteRecord, WriterSession};
+use object_store::memory::InMemory;
+use object_store::ObjectStore;
+
+use namidb_query::{execute_with_limits, lower, parse, Params, RuntimeValue};
+
+fn store() -> Arc<dyn ObjectStore> {
+    Arc::new(InMemory::new())
+}
+
+fn paths(name: &str) -> NamespacePaths {
+    NamespacePaths::new("tenants", NamespaceId::new(name).unwrap())
+}
+
+/// Seed `n` `Person` nodes with distinct `rank` = `0..n`.
+async fn seed_ranks(name: &str, n: i64) -> WriterSession {
+    let mut w = WriterSession::open(store(), paths(name)).await.unwrap();
+    for r in 0..n {
+        let mut p = BTreeMap::new();
+        p.insert("rank".into(), CoreValue::I64(r));
+        w.upsert_node(
+            "Person",
+            NodeId::new(),
+            &NodeWriteRecord {
+                properties: p,
+                schema_version: 1,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+    }
+    w.commit_batch().await.unwrap();
+    w
+}
+
+/// Run `query` and collect the integer `r` column in result order.
+async fn ranks(writer: &WriterSession, query: &str) -> Vec<i64> {
+    let snap = writer.snapshot();
+    let plan = lower(&parse(query).unwrap()).unwrap();
+    let rows = execute_with_limits(&plan, &snap, &Params::new(), None, None)
+        .await
+        .unwrap();
+    rows.iter()
+        .map(|row| match row.get("r") {
+            Some(RuntimeValue::Integer(i)) => *i,
+            other => panic!("expected an integer `r`, got {other:?}"),
+        })
+        .collect()
+}
+
+#[tokio::test]
+async fn top_k_desc_returns_the_largest_in_order() {
+    let w = seed_ranks("topk-desc", 50).await;
+    // k = 5 << 50, so the bounded heap path runs.
+    let got = ranks(
+        &w,
+        "MATCH (p:Person) RETURN p.rank AS r ORDER BY p.rank DESC LIMIT 5",
+    )
+    .await;
+    assert_eq!(got, vec![49, 48, 47, 46, 45]);
+}
+
+#[tokio::test]
+async fn top_k_asc_returns_the_smallest_in_order() {
+    let w = seed_ranks("topk-asc", 50).await;
+    let got = ranks(
+        &w,
+        "MATCH (p:Person) RETURN p.rank AS r ORDER BY p.rank ASC LIMIT 5",
+    )
+    .await;
+    assert_eq!(got, vec![0, 1, 2, 3, 4]);
+}
+
+#[tokio::test]
+async fn top_k_with_skip_takes_the_right_window() {
+    let w = seed_ranks("topk-skip", 20).await;
+    // k = skip + limit = 5 < 20, heap path. Desc order is 19,18,17,...; SKIP 2
+    // LIMIT 3 yields 17,16,15.
+    let got = ranks(
+        &w,
+        "MATCH (p:Person) RETURN p.rank AS r ORDER BY p.rank DESC SKIP 2 LIMIT 3",
+    )
+    .await;
+    assert_eq!(got, vec![17, 16, 15]);
+}
+
+#[tokio::test]
+async fn limit_at_or_above_cardinality_falls_back_and_is_complete() {
+    let w = seed_ranks("topk-fallback", 6).await;
+    // k = 100 >= 6, so the full-sort path runs; still correct and complete.
+    let got = ranks(
+        &w,
+        "MATCH (p:Person) RETURN p.rank AS r ORDER BY p.rank DESC LIMIT 100",
+    )
+    .await;
+    assert_eq!(got, vec![5, 4, 3, 2, 1, 0]);
+}
+
+#[tokio::test]
+async fn limit_one_returns_the_single_extreme() {
+    let w = seed_ranks("topk-one", 30).await;
+    assert_eq!(
+        ranks(
+            &w,
+            "MATCH (p:Person) RETURN p.rank AS r ORDER BY p.rank DESC LIMIT 1"
+        )
+        .await,
+        vec![29]
+    );
+    assert_eq!(
+        ranks(
+            &w,
+            "MATCH (p:Person) RETURN p.rank AS r ORDER BY p.rank ASC LIMIT 1"
+        )
+        .await,
+        vec![0]
+    );
+}
+
+#[tokio::test]
+async fn ties_return_a_full_window_of_the_tied_value() {
+    // Five nodes share rank 7; ORDER BY rank LIMIT 3 returns three of them.
+    // Which three is unspecified under Cypher, but the heap's position
+    // tiebreak makes it the same set the full sort would pick.
+    let mut w = WriterSession::open(store(), paths("topk-ties"))
+        .await
+        .unwrap();
+    for _ in 0..5 {
+        let mut p = BTreeMap::new();
+        p.insert("rank".into(), CoreValue::I64(7));
+        w.upsert_node(
+            "Person",
+            NodeId::new(),
+            &NodeWriteRecord {
+                properties: p,
+                schema_version: 1,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+    }
+    w.commit_batch().await.unwrap();
+
+    let got = ranks(
+        &w,
+        "MATCH (p:Person) RETURN p.rank AS r ORDER BY p.rank ASC LIMIT 3",
+    )
+    .await;
+    assert_eq!(got, vec![7, 7, 7]);
+}


### PR DESCRIPTION
P0: KNN no longer sorts the whole scanned set. When LIMIT bounds the result to k = skip+limit < n, TopN keeps only the k best in a max-heap: O(n log k) time, O(k) memory (was O(n log n)/O(n)). Hot path for ORDER BY cosine_similarity(...) DESC LIMIT k. Output identical to the full sort, ties included. int8 quantization and ANN remain follow-ups.