### PR TITLE
ci: gate namidb-py in clippy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,7 +42,7 @@ jobs:
       # `--all-targets` is intentionally NOT passed: it would pull
       # criterion and the other bench-only dev-deps into the lint gate.
       # Benches are exercised on demand via `cargo bench`, not in CI.
-      - run: cargo clippy --workspace --lib --tests --exclude namidb-py -- -D warnings -A clippy::doc_lazy_continuation
+      - run: cargo clippy --workspace --lib --tests -- -D warnings -A clippy::doc_lazy_continuation
 
   test:
     name: test (${{ matrix.os }})

--- a/crates/namidb-py/src/lib.rs
+++ b/crates/namidb-py/src/lib.rs
@@ -414,6 +414,9 @@ impl Client {
     /// `tags_loaded`, `tag_links`, `tags_pruned`, `tag_links_pruned`,
     /// `subtag_edges`, `subtag_edges_pruned`, `placeholders_created` and
     /// `commit_batches`.
+    // Wide arity is inherent to the Python keyword-argument surface; the
+    // `#[pyo3(signature = ...)]` above gives every extra parameter a default.
+    #[allow(clippy::too_many_arguments)]
     #[pyo3(signature = (path, label="Note", edge_type="LINKS_TO", commit_every=1000, prune=false, placeholders=false))]
     fn load_vault(
         &self,


### PR DESCRIPTION
Drops --exclude namidb-py from the clippy step (the binding is the main pip install channel but was ungated for lints). Adds #[allow(clippy::too_many_arguments)] to load_vault (pyo3 keyword-arg surface). namidb-py builds without libpython (extension-module+abi3) so no Python setup needed for clippy. test/check stay excluded (need maturin). Full-workspace clippy green locally.