### PR TITLE
feat(server): enable write-stall backpressure by default (--write-stall-l0 24)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,12 @@ below and in the release notes.
   text) and the namespace's stored embedder id, so a query repeated in a RAG
   loop is embedded once — one API call instead of N for a remote embedder —
   and the embedder-mismatch guard no longer runs an extra lookup per search.
+- The server now applies soft write-stall backpressure by default
+  (`--write-stall-l0` defaults to `24`, three times the reactive-compaction
+  trigger). Before, backpressure was off, so a writer could outrun compaction
+  and let L0 grow unbounded, inflating read amplification. It is invisible
+  under normal load and only delays a committed write under sustained
+  overload; set `--write-stall-l0 0` to restore the old unbounded behaviour.
 
 ## [0.15.0] - 2026-06-10: production hardening — write timeouts, NOT NULL, backup/restore, token roles, bounded top-k
 

--- a/crates/namidb-server/src/main.rs
+++ b/crates/namidb-server/src/main.rs
@@ -144,10 +144,13 @@ struct Cli {
     #[arg(long, env = "NAMIDB_COMPACTION_L0_TRIGGER", default_value_t = 8)]
     compaction_l0_trigger: usize,
 
-    /// L0-count per bucket above which a committed write is softly stalled
-    /// by `--write-stall-delay`, so the writer cannot outrun compaction
-    /// without bound. Set to `0` (the default) to disable the stall.
-    #[arg(long, env = "NAMIDB_WRITE_STALL_L0", default_value_t = 0)]
+    /// L0-count per bucket above which a committed write is softly stalled by
+    /// `--write-stall-delay`, so the writer cannot outrun compaction without
+    /// bound (which would let L0 grow and inflate read amplification). Defaults
+    /// to `24` — three times the reactive-compaction trigger, so it is
+    /// invisible under normal load and only bites under sustained write
+    /// overload. Set to `0` to disable the stall entirely.
+    #[arg(long, env = "NAMIDB_WRITE_STALL_L0", default_value_t = 24)]
     write_stall_l0: usize,
 
     /// Delay applied to a committed write while L0 is above


### PR DESCRIPTION
Backpressure was off by default, letting a writer outrun compaction and grow L0 unbounded (read amplification, eventual read stalls). Default --write-stall-l0 to 24 (3x the reactive-compaction trigger): invisible under normal load, only bites under sustained overload. Opt out with --write-stall-l0 0. Behavior change, noted in CHANGELOG. Server tests green, fmt clean.