### PR TITLE
feat(query): read-your-own-writes for an Expand above a write (RFC-026 Q1)

### DIFF
--- a/crates/namidb-query/src/exec/walker.rs
+++ b/crates/namidb-query/src/exec/walker.rs
@@ -885,7 +885,7 @@ fn execute_capped<'a>(
 // ───────────────────────── Expand ────────────────────────────────────
 
 #[allow(clippy::too_many_arguments)]
-async fn execute_expand(
+pub(crate) async fn execute_expand(
     rows: Vec<Row>,
     source: &str,
     edge_type: Option<&[String]>,

--- a/crates/namidb-query/src/exec/writer.rs
+++ b/crates/namidb-query/src/exec/writer.rs
@@ -427,6 +427,55 @@ fn execute_write_inner<'a>(
                 Ok(out)
             }
 
+            // ─── An Expand whose input stages writes (RFC-026 Q1):
+            // `CREATE (a)-[:R]->(b) WITH a MATCH (a)-[:R]->(x) RETURN x`. The
+            // input subtree carries the CREATE, so it cannot go to the
+            // read-only walker (which rejects embedded writes). Recurse the
+            // input through the write executor to stage the mutations and
+            // materialise the source rows, then run the traversal step against
+            // the read-your-own-writes overlay so the just-staged edge is
+            // visible. A pure-read Expand still falls to the read-leaf arm
+            // below. `want_properties = true` / `skip_target_materialize =
+            // false`: the routing optimisation that prunes those is a read-only
+            // walker concern, so materialise fully here (correct, just not
+            // pruned).
+            LogicalPlan::Expand {
+                input,
+                source,
+                edge_type,
+                direction,
+                rel_alias,
+                target_alias,
+                target_labels,
+                length,
+                optional,
+                back_reference,
+                shortest,
+                path_binding,
+            } if input.contains_write() => {
+                let input_rows = execute_write_inner(input, writer, params, outcome).await?;
+                let snap = writer.overlay_snapshot();
+                crate::exec::walker::execute_expand(
+                    input_rows,
+                    source,
+                    edge_type.as_deref(),
+                    *direction,
+                    rel_alias.as_deref(),
+                    target_alias,
+                    target_labels,
+                    *length,
+                    *optional,
+                    *back_reference,
+                    *shortest,
+                    path_binding.as_deref(),
+                    &snap,
+                    true,
+                    false,
+                    None,
+                )
+                .await
+            }
+
             // ─── Pure read leaves and pattern-driven operators that do
             // NOT contain writes: delegate to the read-only walker on a
             // freshly pinned snapshot. v0: no read-your-own-writes.

--- a/crates/namidb-query/tests/exec_writes.rs
+++ b/crates/namidb-query/tests/exec_writes.rs
@@ -1265,3 +1265,51 @@ async fn nonstring_unique_set_rejects_collision_but_allows_self_update() {
     let rows = snap.scan_label("Account").await.unwrap();
     assert_eq!(rows.len(), 2, "no node was created or dropped by the SETs");
 }
+
+#[tokio::test]
+async fn expand_above_write_sees_staged_edge_in_one_statement() {
+    // RFC-026 Q1: a traversal (Expand) running directly above a write in the
+    // same statement must see the edge that write just staged. Before the fix
+    // this errored ("write operators require execute_write...") because the
+    // whole Expand-over-CREATE subtree was handed to the read-only walker; now
+    // the write executor stages the input, then expands over the overlay.
+    let mut writer = WriterSession::open(store(), paths("w-expand-above-write"))
+        .await
+        .unwrap();
+    let q = parse(
+        "CREATE (a:Person {name: 'A'})-[:R]->(b:Person {name: 'B'}) \
+         WITH a MATCH (a)-[:R]->(x) RETURN x",
+    )
+    .unwrap();
+    let plan = lower(&q).unwrap();
+    let outcome = execute_write(&plan, &mut writer, &Params::new())
+        .await
+        .unwrap();
+    assert_eq!(outcome.nodes_created, 2);
+    assert_eq!(outcome.edges_created, 1);
+    assert_eq!(
+        outcome.rows.len(),
+        1,
+        "the just-staged edge must be traversed by the following MATCH"
+    );
+    match outcome.rows[0].get("x") {
+        Some(RuntimeValue::Node(n)) => match n.properties.get("name") {
+            Some(RuntimeValue::String(s)) => {
+                assert_eq!(s.as_str(), "B", "x must bind to the created target b")
+            }
+            other => panic!("expected x.name = 'B', got {other:?}"),
+        },
+        other => panic!("expected node x, got {other:?}"),
+    }
+
+    // And it committed: a fresh snapshot sees the edge.
+    let snap = writer.snapshot();
+    let rows = execute(
+        &lower(&parse("MATCH (:Person)-[:R]->(x) RETURN x").unwrap()).unwrap(),
+        &snap,
+        &Params::new(),
+    )
+    .await
+    .unwrap();
+    assert_eq!(rows.len(), 1, "the edge must persist after commit");
+}

--- a/docs/rfc/026-read-your-own-writes.md
+++ b/docs/rfc/026-read-your-own-writes.md
@@ -221,13 +221,14 @@ insert hot path. Revisit only if overlay build cost shows up in a profile.
 - **Q1: Node-only v1, edges in a follow-up?** Resolved. Nodes landed first
   (CREATE-then-MATCH, MERGE, the intra-batch unique check); the edge overlay
   followed, so a traversal over an edge staged earlier in the same statement
-  or transaction now sees it. One capability is still a follow-up: running a
-  read pipeline (an `Expand`) directly above a write within a single
-  statement, `CREATE (a)-[:R]->(b) WITH a MATCH (a)-[:R]->(x)`. The write
-  executor delegates such a sub-plan to the read-only walker, which rejects
-  the embedded write; it is unsupported for nodes and edges alike. The staged
-  edge is visible through `overlay_snapshot` to a later statement or an
-  in-transaction read, which is the common case.
+  or transaction now sees it. The last residual, running a read pipeline (an
+  `Expand`) directly above a write within a single statement
+  (`CREATE (a)-[:R]->(b) WITH a MATCH (a)-[:R]->(x)`), is resolved too: the
+  write executor recurses the Expand's write-bearing input through
+  `execute_write_inner` to stage the mutations, then runs the traversal step
+  against `overlay_snapshot`, so the just-staged edge is visible. A pure-read
+  `Expand` still delegates wholesale to the read-only walker, and the walker's
+  write-operator guard stays as the backstop.
 
 - **Q2: Property index cache interaction.** The cross-snapshot property
   index cache (see the read path) must not serve a stale negative for a


### PR DESCRIPTION
## What

`CREATE (a)-[:R]->(b) WITH a MATCH (a)-[:R]->(x) RETURN x` previously **errored** with `"write operators require execute_write..."` and committed nothing. The write executor handed the whole `Expand`-over-`CREATE` subtree to the read-only walker, which rejects an embedded write. This was the last open residual of RFC-026 Q1 (read-your-own-writes); the node-only variant (`CREATE (a) WITH a MATCH (p:Person {...})`) already worked because it lowers to a `CrossProduct` whose sides dispatch independently.

Verified beforehand (adversarially) that this was a **clean error, not a wrong-answer bug** — so this is feature completion, not a correctness patch.

## Fix

In the write executor's read-leaf dispatch (`writer.rs`), add a guarded arm: when an `Expand`'s input `contains_write()`, recurse that input through `execute_write_inner` to stage the mutations and materialise the source rows, then run the traversal step via the existing `walker::execute_expand` against `overlay_snapshot()` — so the just-staged edge is visible. `execute_expand` is made `pub(crate)` for reuse.

- A pure-read `Expand` still falls through to the read-leaf arm and delegates wholesale to the walker (unchanged).
- `want_properties = true` / `skip_target_materialize = false`: the routing optimisation that prunes those is a read-only-walker concern, so the write path materialises fully (correct, just not pruned).
- The walker's write-operator guard stays as the backstop; scope is `Expand` only (the RFC-026 Q1 residual). `SemiApply`/`PatternList`/`MultiwayJoin` over writes are unchanged (they error cleanly as before — no regression).

RFC-026's Q1 open-question is updated to mark the residual resolved.

## Tests

- `expand_above_write_sees_staged_edge_in_one_statement`: the query returns 1 row with `x` bound to the just-created `b`, and the edge persists after commit. Before the fix this errored.

Full CI gate green locally (fmt, clippy `-D warnings`, `cargo test --workspace --exclude namidb-py` — 1207 passed).