### PR TITLE
feat(core,bench): int8 vector quantizer + recall harness

### DIFF
--- a/crates/namidb-bench/src/main.rs
+++ b/crates/namidb-bench/src/main.rs
@@ -17,6 +17,7 @@ mod dataset;
 mod loader;
 mod queries;
 mod runner;
+mod vector_recall;
 
 use dataset::{DatasetConfig, DatasetSizes};
 use queries::Query;
@@ -104,6 +105,35 @@ enum Cmd {
         /// Object-store root prefix; must match the worker's `storage.root_prefix`.
         #[arg(long, default_value = "tenants")]
         root_prefix: String,
+    },
+    /// Measure int8 quantization recall@k + latency vs exact f32 on synthetic
+    /// unit-norm vectors. The gate for the int8 storage work: run at the
+    /// embedder dimensions (e.g. 256 and 1536) and confirm recall@10 stays high
+    /// before committing to int8 on disk.
+    VectorRecall {
+        /// Vector dimension (e.g. 256 local, 1536 OpenAI).
+        #[arg(long, default_value_t = 256)]
+        dim: usize,
+        /// Number of stored vectors to search over.
+        #[arg(long, default_value_t = 10_000)]
+        num: usize,
+        /// Number of query vectors to average recall/latency over.
+        #[arg(long, default_value_t = 100)]
+        queries: usize,
+        /// Top-k.
+        #[arg(short, long, default_value_t = 10)]
+        k: usize,
+        /// Number of cluster centroids. `0` = uniform random (pessimistic
+        /// floor); `>0` draws vectors/queries around centroids, like real
+        /// embeddings with meaningful neighbours.
+        #[arg(long, default_value_t = 64)]
+        clusters: usize,
+        /// Cluster tightness (Gaussian noise stddev added to a centroid before
+        /// renormalizing). Smaller = tighter clusters.
+        #[arg(long, default_value_t = 0.35)]
+        spread: f32,
+        #[arg(short = 'S', long, default_value_t = 42)]
+        seed: u64,
     },
 }
 
@@ -331,6 +361,28 @@ async fn main() -> Result<()> {
                     + sizes.likes
                     + sizes.reply_of) as f64
                     / load_time_secs,
+            );
+            println!("{}", serde_json::to_string_pretty(&report)?);
+        }
+        Cmd::VectorRecall {
+            dim,
+            num,
+            queries,
+            k,
+            clusters,
+            spread,
+            seed,
+        } => {
+            let report = vector_recall::run(dim, num, queries, k, clusters, spread, seed);
+            eprintln!(
+                "vector-recall dim={dim} num={num} queries={queries} k={k} clusters={clusters}: \
+                 recall@{k}={:.4} (fixed-scale {:.4}) compression={:.2}x  \
+                 exact p50={}µs  int8 p50={}µs",
+                report.recall_at_k,
+                report.recall_at_k_fixed_scale,
+                report.compression_ratio,
+                report.exact_p50_us,
+                report.int8_p50_us,
             );
             println!("{}", serde_json::to_string_pretty(&report)?);
         }

--- a/crates/namidb-bench/src/vector_recall.rs
+++ b/crates/namidb-bench/src/vector_recall.rs
@@ -1,0 +1,241 @@
+//! `vector-recall` — measure int8 quantization recall@k + latency vs exact
+//! f32 on synthetic unit-norm vectors that mimic embeddings.
+//!
+//! int8 quantization is lossy, so before the storage layer commits to it we
+//! measure the recall it costs. The harness quantizes the stored vectors, runs
+//! brute-force top-k with the asymmetric scorer (f32 query × int8 stored, the
+//! exact arithmetic the engine will use), and reports recall@k against the
+//! exact f32 ranking plus the latency and bytes/vector change. It reports BOTH
+//! the per-vector max-abs scale (what the engine ships) and a naive fixed-127
+//! scale, so the data justifies the choice.
+//!
+//! Two workloads: `--clusters 0` is pure uniform-on-sphere (a pessimistic
+//! floor — random vectors have no meaningful neighbours, so any noise reshuffles
+//! near-tied ranks); `--clusters N` draws vectors around N centroids so the true
+//! top-k are well separated, like real embeddings. Generation is deterministic
+//! from `--seed`.
+
+use std::collections::HashSet;
+use std::time::Instant;
+
+use namidb_core::quantize::quantize_i8;
+use rand::{Rng, SeedableRng};
+use rand_chacha::ChaCha8Rng;
+use serde::Serialize;
+
+/// JSON report emitted to stdout.
+#[derive(Debug, Serialize)]
+pub struct VectorRecallReport {
+    pub dim: usize,
+    pub num_vectors: usize,
+    pub num_queries: usize,
+    pub k: usize,
+    pub clusters: usize,
+    /// Recall@k with per-vector max-abs scale (the scheme the engine ships).
+    pub recall_at_k: f64,
+    /// Recall@k with a naive fixed-127 scale, for comparison.
+    pub recall_at_k_fixed_scale: f64,
+    pub exact_p50_us: u128,
+    pub exact_p99_us: u128,
+    pub int8_p50_us: u128,
+    pub int8_p99_us: u128,
+    pub bytes_per_vector_f32: usize,
+    /// int8 codes (dim) + the per-vector f32 scale (4 bytes).
+    pub bytes_per_vector_int8: usize,
+    pub compression_ratio: f64,
+}
+
+/// Fill `dim` Gaussian components via Box-Muller (uniform direction on the
+/// sphere once normalized).
+fn gaussian(rng: &mut ChaCha8Rng, dim: usize) -> Vec<f32> {
+    let mut v = Vec::with_capacity(dim);
+    while v.len() < dim {
+        let u1: f32 = rng.gen::<f32>().max(1e-12);
+        let u2: f32 = rng.gen::<f32>();
+        let r = (-2.0 * u1.ln()).sqrt();
+        let (s, c) = (std::f32::consts::TAU * u2).sin_cos();
+        v.push(r * c);
+        if v.len() < dim {
+            v.push(r * s);
+        }
+    }
+    v
+}
+
+fn normalize(v: &mut [f32]) {
+    let norm = v.iter().map(|x| x * x).sum::<f32>().sqrt();
+    if norm > 0.0 {
+        for x in v {
+            *x /= norm;
+        }
+    }
+}
+
+fn random_unit_vector(rng: &mut ChaCha8Rng, dim: usize) -> Vec<f32> {
+    let mut v = gaussian(rng, dim);
+    normalize(&mut v);
+    v
+}
+
+/// `base + spread * gaussian`, normalized — a vector near `base`'s direction.
+fn perturbed_unit_vector(rng: &mut ChaCha8Rng, base: &[f32], spread: f32) -> Vec<f32> {
+    let noise = gaussian(rng, base.len());
+    let mut v: Vec<f32> = base
+        .iter()
+        .zip(&noise)
+        .map(|(b, n)| b + spread * n)
+        .collect();
+    normalize(&mut v);
+    v
+}
+
+fn dot_f32(a: &[f32], b: &[f32]) -> f32 {
+    a.iter().zip(b).map(|(x, y)| x * y).sum()
+}
+
+/// Asymmetric score, per-vector scale: `scale * Σ query_i * code_i`. The
+/// stored side is never expanded to f32.
+fn dot_f32_i8_scaled(q: &[f32], codes: &[i8], scale: f32) -> f32 {
+    scale * q.iter().zip(codes).map(|(x, &c)| x * c as f32).sum::<f32>()
+}
+
+/// Naive fixed-127 quantize + score, for the comparison column.
+fn quantize_fixed(v: &[f32]) -> Vec<i8> {
+    v.iter()
+        .map(|&x| (x * 127.0).round().clamp(-127.0, 127.0) as i8)
+        .collect()
+}
+fn dot_f32_i8_fixed(q: &[f32], codes: &[i8]) -> f32 {
+    q.iter()
+        .zip(codes)
+        .map(|(x, &c)| x * (c as f32 / 127.0))
+        .sum()
+}
+
+fn top_k(scores: &[f32], k: usize) -> Vec<usize> {
+    let mut idx: Vec<usize> = (0..scores.len()).collect();
+    idx.sort_by(|&a, &b| {
+        scores[b]
+            .partial_cmp(&scores[a])
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    idx.truncate(k);
+    idx
+}
+
+fn percentile(sorted_us: &[u128], p: f64) -> u128 {
+    if sorted_us.is_empty() {
+        return 0;
+    }
+    let rank = ((p / 100.0) * (sorted_us.len() as f64 - 1.0)).round() as usize;
+    sorted_us[rank.min(sorted_us.len() - 1)]
+}
+
+fn recall(int8_top: &[usize], exact_set: &HashSet<usize>) -> usize {
+    int8_top.iter().filter(|i| exact_set.contains(i)).count()
+}
+
+/// Run the harness. `clusters == 0` is uniform random; `clusters > 0` draws
+/// stored vectors and queries around that many centroids (`spread` controls
+/// cluster tightness).
+pub fn run(
+    dim: usize,
+    num_vectors: usize,
+    num_queries: usize,
+    k: usize,
+    clusters: usize,
+    spread: f32,
+    seed: u64,
+) -> VectorRecallReport {
+    let mut rng = ChaCha8Rng::seed_from_u64(seed);
+
+    let centroids: Vec<Vec<f32>> = (0..clusters)
+        .map(|_| random_unit_vector(&mut rng, dim))
+        .collect();
+
+    let stored_f32: Vec<Vec<f32>> = (0..num_vectors)
+        .map(|i| {
+            if clusters == 0 {
+                random_unit_vector(&mut rng, dim)
+            } else {
+                let base = &centroids[i % clusters];
+                perturbed_unit_vector(&mut rng, base, spread)
+            }
+        })
+        .collect();
+
+    let stored_scaled: Vec<(Vec<i8>, f32)> = stored_f32.iter().map(|v| quantize_i8(v)).collect();
+    let stored_fixed: Vec<Vec<i8>> = stored_f32.iter().map(|v| quantize_fixed(v)).collect();
+
+    let queries: Vec<Vec<f32>> = (0..num_queries)
+        .map(|i| {
+            if clusters == 0 {
+                random_unit_vector(&mut rng, dim)
+            } else {
+                // A query near a centroid: its true neighbours are that
+                // cluster's members, so the top-k are well separated.
+                let base = &centroids[i % clusters];
+                perturbed_unit_vector(&mut rng, base, spread * 0.5)
+            }
+        })
+        .collect();
+
+    let mut hits_scaled = 0usize;
+    let mut hits_fixed = 0usize;
+    let mut total = 0usize;
+    let mut exact_us: Vec<u128> = Vec::with_capacity(num_queries);
+    let mut int8_us: Vec<u128> = Vec::with_capacity(num_queries);
+
+    for q in &queries {
+        let t = Instant::now();
+        let exact_scores: Vec<f32> = stored_f32.iter().map(|s| dot_f32(q, s)).collect();
+        let exact_top = top_k(&exact_scores, k);
+        exact_us.push(t.elapsed().as_micros());
+
+        let t = Instant::now();
+        let scaled_scores: Vec<f32> = stored_scaled
+            .iter()
+            .map(|(codes, scale)| dot_f32_i8_scaled(q, codes, *scale))
+            .collect();
+        let scaled_top = top_k(&scaled_scores, k);
+        int8_us.push(t.elapsed().as_micros());
+
+        let fixed_scores: Vec<f32> = stored_fixed
+            .iter()
+            .map(|c| dot_f32_i8_fixed(q, c))
+            .collect();
+        let fixed_top = top_k(&fixed_scores, k);
+
+        let exact_set: HashSet<usize> = exact_top.iter().copied().collect();
+        hits_scaled += recall(&scaled_top, &exact_set);
+        hits_fixed += recall(&fixed_top, &exact_set);
+        total += exact_top.len();
+    }
+
+    exact_us.sort_unstable();
+    int8_us.sort_unstable();
+    let div = |h: usize| {
+        if total > 0 {
+            h as f64 / total as f64
+        } else {
+            0.0
+        }
+    };
+
+    VectorRecallReport {
+        dim,
+        num_vectors,
+        num_queries,
+        k,
+        clusters,
+        recall_at_k: div(hits_scaled),
+        recall_at_k_fixed_scale: div(hits_fixed),
+        exact_p50_us: percentile(&exact_us, 50.0),
+        exact_p99_us: percentile(&exact_us, 99.0),
+        int8_p50_us: percentile(&int8_us, 50.0),
+        int8_p99_us: percentile(&int8_us, 99.0),
+        bytes_per_vector_f32: dim * 4,
+        bytes_per_vector_int8: dim + 4,
+        compression_ratio: (dim * 4) as f64 / (dim + 4) as f64,
+    }
+}

--- a/crates/namidb-core/src/lib.rs
+++ b/crates/namidb-core/src/lib.rs
@@ -12,11 +12,13 @@
 pub mod error;
 pub mod id;
 pub mod profile;
+pub mod quantize;
 pub mod schema;
 pub mod value;
 
 pub use error::{Error, Result};
 pub use id::{EdgeId, LabelId, NamespaceId, NodeId};
+pub use quantize::{dequantize_i8, quantize_i8};
 pub use schema::{
     DataType, EdgeTypeDef, LabelDef, LabelDictionary, PropertyDef, Schema, SchemaBuilder,
 };

--- a/crates/namidb-core/src/quantize.rs
+++ b/crates/namidb-core/src/quantize.rs
@@ -1,0 +1,96 @@
+//! Symmetric per-vector int8 quantization for embedding vectors.
+//!
+//! Each vector is quantized with its own max-abs scale, so the full int8 range
+//! [-127, 127] is used no matter the dimension. A single fixed scale wastes
+//! almost all of the range for high-dimensional unit vectors — their
+//! components are ~1/sqrt(dim) and tiny, so `x * 127` lands in single digits
+//! and recall collapses (the `namidb-bench vector-recall` harness measures
+//! exactly this: fixed-scale recall@10 falls to ~0.87 at dim 1536, per-vector
+//! scaling restores it). Quantization is lossy; the harness reports recall@k.
+//!
+//! Stored form is `(codes: Vec<i8>, scale: f32)`, with `x_i ≈ codes_i * scale`.
+//! The asymmetric scorer keeps the query in f32 and folds the scale into the
+//! dot product: `dot(query, stored) = scale * Σ query_i * codes_i` — so the
+//! stored side is never expanded back into an f32 vector. There is exactly one
+//! definition of this mapping, shared by the write path, the scorer, and the
+//! harness.
+
+/// Quantize a vector with a per-vector symmetric max-abs scale. Returns the
+/// int8 codes and the scale `s` such that `x_i ≈ codes_i * s`. A zero vector
+/// (or empty) yields all-zero codes and `scale = 0.0`, which dequantizes back
+/// to zeros.
+pub fn quantize_i8(v: &[f32]) -> (Vec<i8>, f32) {
+    let max_abs = v.iter().fold(0.0f32, |m, &x| m.max(x.abs()));
+    if max_abs == 0.0 {
+        return (vec![0i8; v.len()], 0.0);
+    }
+    let scale = max_abs / 127.0;
+    let codes = v
+        .iter()
+        .map(|&x| (x / scale).round().clamp(-127.0, 127.0) as i8)
+        .collect();
+    (codes, scale)
+}
+
+/// Recover the f32 vector from its int8 codes and scale (`codes_i * scale`).
+pub fn dequantize_i8(codes: &[i8], scale: f32) -> Vec<f32> {
+    codes.iter().map(|&c| c as f32 * scale).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trip_bounds_the_error_per_vector() {
+        // Per-vector error is at most half a step = 0.5 * scale, where
+        // scale = max|x| / 127. So the bound scales with the vector's range.
+        let v: Vec<f32> = (0..256).map(|i| (i as f32 / 255.0) * 0.2 - 0.1).collect();
+        let (codes, scale) = quantize_i8(&v);
+        let back = dequantize_i8(&codes, scale);
+        for (x, y) in v.iter().zip(&back) {
+            assert!(
+                (x - y).abs() <= 0.5 * scale + 1e-6,
+                "component {x} round-tripped to {y} (scale {scale})"
+            );
+        }
+    }
+
+    #[test]
+    fn max_abs_component_is_exact() {
+        // The component equal to max|x| maps to ±127 and dequantizes exactly.
+        let (codes, scale) = quantize_i8(&[0.5, -0.25, 0.0]);
+        assert_eq!(codes[0], 127);
+        let back = dequantize_i8(&codes, scale);
+        assert!((back[0] - 0.5).abs() < 1e-6);
+        assert_eq!(codes[2], 0);
+    }
+
+    #[test]
+    fn full_range_used_regardless_of_magnitude() {
+        // Tiny components (high-dim unit vector) still span the int8 range,
+        // which is the whole point of per-vector scaling.
+        let (codes, _scale) = quantize_i8(&[0.02, -0.02, 0.01]);
+        assert_eq!(codes[0], 127);
+        assert_eq!(codes[1], -127);
+    }
+
+    #[test]
+    fn zero_vector_is_all_zero() {
+        let (codes, scale) = quantize_i8(&[0.0, 0.0, 0.0]);
+        assert_eq!(codes, vec![0, 0, 0]);
+        assert_eq!(scale, 0.0);
+        assert_eq!(dequantize_i8(&codes, scale), vec![0.0, 0.0, 0.0]);
+    }
+
+    #[test]
+    fn negation_is_symmetric() {
+        let v: Vec<f32> = [0.1, -0.37, 0.9, -0.04, 0.5].to_vec();
+        let neg: Vec<f32> = v.iter().map(|x| -x).collect();
+        let (qv, _) = quantize_i8(&v);
+        let (qn, _) = quantize_i8(&neg);
+        for (a, b) in qv.iter().zip(&qn) {
+            assert_eq!(*a, -*b);
+        }
+    }
+}

--- a/crates/namidb-core/src/quantize.rs
+++ b/crates/namidb-core/src/quantize.rs
@@ -19,15 +19,29 @@
 /// int8 codes and the scale `s` such that `x_i ≈ codes_i * s`. A zero vector
 /// (or empty) yields all-zero codes and `scale = 0.0`, which dequantizes back
 /// to zeros.
+///
+/// Non-finite components (`NaN`/`±Inf`) are excluded from the scale and coded
+/// as `0`, so the returned scale is always finite. Otherwise a single `Inf`
+/// would make `max_abs` (and the scale) `Inf`, persisting a poisoned vector
+/// that dequantizes to `NaN` — the storage layer relies on a finite scale.
 pub fn quantize_i8(v: &[f32]) -> (Vec<i8>, f32) {
-    let max_abs = v.iter().fold(0.0f32, |m, &x| m.max(x.abs()));
+    let max_abs = v
+        .iter()
+        .filter(|x| x.is_finite())
+        .fold(0.0f32, |m, &x| m.max(x.abs()));
     if max_abs == 0.0 {
         return (vec![0i8; v.len()], 0.0);
     }
     let scale = max_abs / 127.0;
     let codes = v
         .iter()
-        .map(|&x| (x / scale).round().clamp(-127.0, 127.0) as i8)
+        .map(|&x| {
+            if x.is_finite() {
+                (x / scale).round().clamp(-127.0, 127.0) as i8
+            } else {
+                0
+            }
+        })
         .collect();
     (codes, scale)
 }
@@ -92,5 +106,24 @@ mod tests {
         for (a, b) in qv.iter().zip(&qn) {
             assert_eq!(*a, -*b);
         }
+    }
+
+    #[test]
+    fn non_finite_components_stay_finite_and_zero_coded() {
+        // An Inf/NaN must not poison the scale: it stays finite and the
+        // offending components code to 0, so dequantize never yields NaN.
+        let (codes, scale) = quantize_i8(&[0.5, f32::INFINITY, -0.25, f32::NAN]);
+        assert!(scale.is_finite(), "scale must be finite, got {scale}");
+        assert_eq!(codes[0], 127, "0.5 is the max finite component");
+        assert_eq!(codes[1], 0, "Inf codes to 0");
+        assert_eq!(codes[3], 0, "NaN codes to 0");
+        assert!(dequantize_i8(&codes, scale).iter().all(|x| x.is_finite()));
+    }
+
+    #[test]
+    fn all_non_finite_degrades_to_zero_vector() {
+        let (codes, scale) = quantize_i8(&[f32::INFINITY, f32::NAN, f32::NEG_INFINITY]);
+        assert_eq!(codes, vec![0, 0, 0]);
+        assert_eq!(scale, 0.0);
     }
 }


### PR DESCRIPTION
First PR of the int8 quantization campaign (4× less memory/disk for vectors). Harness-first, so the quantization scheme is validated **before** the storage layer commits to it.

## What

- **`namidb-core::quantize`** — per-vector symmetric max-abs int8 quantization: `quantize_i8(&[f32]) -> (Vec<i8>, f32)` and `dequantize_i8(&[i8], scale)`. Each vector is scaled by its own `max|component|`, so the full int8 range [-127,127] is used regardless of dimension; the f32 scale is kept alongside the codes (`x_i ≈ code_i · scale`). The asymmetric scorer will fold the scale into the dot (`scale · Σ q_i·code_i`), never expanding the stored side back to f32.
- **`namidb-bench vector-recall`** — measures recall@k and latency of the int8 path vs exact f32, on clustered (embedding-like) and uniform-random vectors. Reports a naive fixed-127 scale for contrast.

## Why per-vector scale (the key finding)

The harness caught that a **fixed scale of 127 is wrong** for normalized embeddings: a unit vector's components are ~1/√dim (≈0.025 at dim 1536), so `x·127` lands in single digits and wastes most of the int8 range.

recall@10, 10k vectors, k=10:

| workload | dim | per-vector (ship) | fixed-127 |
|---|---|---|---|
| clustered | 256 | **0.984** | 0.949 |
| clustered | 1536 | **0.983** | 0.866 |
| random | 256 | **0.991** | 0.938 |
| random | 1536 | **0.990** | 0.871 |

Per-vector scale clears the ~0.98 gate at both dimensions and on both workloads; fixed-127 collapses at high dim. int8 is also already faster than exact even in a debug build. Compression ~3.94–3.99× (codes + a 4-byte per-vector scale).

## Consequence for later PRs

Storing a per-vector scale means the int8 storage representation (PR 3) is one self-contained `FixedSizeBinary(4 + dim)` column (4-byte f32 scale + dim int8 codes), not a bare `FixedSizeList(Int8)` — keeps one-property-one-column intact. (Updates the plan's earlier fixed-scale assumption, which this harness disproved.)

## Scope / tests

Core quantizer unit tests (round-trip bound, max-abs exactness, full-range use, zero vector, negation symmetry). No storage or query behavior changes yet (the new types/scorer land in PRs 2–4). Full CI gate green locally (fmt, clippy `-D warnings`, `cargo test --workspace --exclude namidb-py` — 1209 passed).