### PR TITLE
feat(storage): int8 vector type, storage, and quantize-on-write

### DIFF
--- a/crates/namidb-bolt/src/mapping.rs
+++ b/crates/namidb-bolt/src/mapping.rs
@@ -55,6 +55,13 @@ pub fn runtime_to_bolt(v: &RuntimeValue, mode: ElementIdMode) -> Value {
         RuntimeValue::String(s) => Value::String(s.clone()),
         RuntimeValue::Bytes(b) => Value::Bytes(b.clone()),
         RuntimeValue::Vector(v) => Value::List(v.iter().map(|x| Value::Float(*x as f64)).collect()),
+        // Dequantize int8 to floats on the wire so clients see a float vector.
+        RuntimeValue::Vector8 { codes, scale } => Value::List(
+            codes
+                .iter()
+                .map(|&c| Value::Float(c as f64 * *scale as f64))
+                .collect(),
+        ),
         RuntimeValue::List(items) => {
             Value::List(items.iter().map(|v| runtime_to_bolt(v, mode)).collect())
         }

--- a/crates/namidb-cli/src/main.rs
+++ b/crates/namidb-cli/src/main.rs
@@ -580,6 +580,7 @@ fn format_runtime(v: &RuntimeValue) -> String {
         RuntimeValue::DateTime(d) => format!("datetime({})", d),
         RuntimeValue::Bytes(b) => format!("bytes({} bytes)", b.len()),
         RuntimeValue::Vector(v) => format!("vec[{}]", v.len()),
+        RuntimeValue::Vector8 { codes, .. } => format!("vec8[{}]", codes.len()),
     }
 }
 

--- a/crates/namidb-core/src/schema.rs
+++ b/crates/namidb-core/src/schema.rs
@@ -36,6 +36,14 @@ pub enum DataType {
     FloatVector {
         dim: u32,
     },
+    /// Fixed-size int8-quantized vector (used for embeddings, 4x smaller than
+    /// `FloatVector`). Stored as one `FixedSizeBinary(4 + dim)` column: the
+    /// first 4 bytes are the per-vector f32 scale (little-endian), the next
+    /// `dim` bytes are the int8 codes, with `x_i ≈ code_i * scale` (see
+    /// [`crate::quantize`]). One property = one column, like `FloatVector`.
+    Int8Vector {
+        dim: u32,
+    },
     /// Catch-all for JSON-shaped values that the engine still needs to
     /// represent as one Arrow column.
     Json,
@@ -61,6 +69,8 @@ impl DataType {
                 std::sync::Arc::new(Field::new("item", ArrowDataType::Float32, false)),
                 *dim as i32,
             ),
+            // 4-byte f32 scale prefix + `dim` int8 code bytes, in one column.
+            DataType::Int8Vector { dim } => ArrowDataType::FixedSizeBinary(4 + *dim as i32),
             DataType::Json => ArrowDataType::Utf8,
         }
     }
@@ -484,6 +494,15 @@ mod tests {
             f.data_type(),
             ArrowDataType::FixedSizeList(_, 1536)
         ));
+        assert!(f.is_nullable());
+    }
+
+    #[test]
+    fn int8_vector_maps_to_fixed_size_binary() {
+        // 4-byte f32 scale prefix + `dim` int8 code bytes, one column.
+        let p = PropertyDef::new("emb", DataType::Int8Vector { dim: 256 }, true).unwrap();
+        let f = p.to_arrow_field();
+        assert!(matches!(f.data_type(), ArrowDataType::FixedSizeBinary(260)));
         assert!(f.is_nullable());
     }
 

--- a/crates/namidb-core/src/value.rs
+++ b/crates/namidb-core/src/value.rs
@@ -30,6 +30,11 @@ const TAG_MAP: &str = "$map";
 /// on the way back. The tagged form `{"$bytes": [0, 1, 2]}` keeps
 /// the type stable through `__overflow_json`.
 const TAG_BYTES: &str = "$bytes";
+/// Tag for `Value::VecI8 { codes, scale }`. The JSON form is
+/// `{"$i8vec": [<scale>, [<codes>...]]}` so an int8-quantized vector keeps
+/// its type (codes + per-vector scale) through `__overflow_json` and the WAL
+/// instead of being re-decoded as a `Vec<f32>` via `visit_seq`.
+const TAG_I8VEC: &str = "$i8vec";
 
 /// A single property value. Loose, JSON-ish.
 #[derive(Debug, Clone, PartialEq)]
@@ -41,6 +46,13 @@ pub enum Value {
     Str(String),
     Bytes(Vec<u8>),
     Vec(Vec<f32>),
+    /// Int8-quantized vector: int8 `codes` plus the per-vector f32 `scale`,
+    /// with `x_i ≈ codes_i * scale` (see [`crate::quantize`]). The in-memory
+    /// form of a `DataType::Int8Vector` column; tagged `$i8vec` on the wire.
+    VecI8 {
+        codes: Vec<i8>,
+        scale: f32,
+    },
     /// Calendar date stored as days since 1970-01-01. Round-trips
     /// through Arrow `Date32`. Tagged as `{"$date": <days>}` in JSON
     /// so the typing survives the `__overflow_json` path.
@@ -130,6 +142,11 @@ impl Serialize for Value {
                 m.end()
             }
             Value::Vec(v) => v.serialize(s),
+            Value::VecI8 { codes, scale } => {
+                let mut m = s.serialize_map(Some(1))?;
+                m.serialize_entry(TAG_I8VEC, &(*scale, codes))?;
+                m.end()
+            }
             Value::Date(d) => {
                 let mut m = s.serialize_map(Some(1))?;
                 m.serialize_entry(TAG_DATE, d)?;
@@ -253,9 +270,23 @@ impl<'de> Deserialize<'de> for Value {
                         }
                         Ok(Value::Bytes(bytes))
                     }
+                    TAG_I8VEC => {
+                        let (scale, codes): (f32, Vec<i8>) = map.next_value()?;
+                        if map.next_key::<String>()?.is_some() {
+                            return Err(de::Error::custom("$i8vec map must have exactly one key"));
+                        }
+                        Ok(Value::VecI8 { codes, scale })
+                    }
                     other => Err(de::Error::unknown_field(
                         other,
-                        &[TAG_DATE, TAG_DATETIME, TAG_LIST, TAG_MAP, TAG_BYTES],
+                        &[
+                            TAG_DATE,
+                            TAG_DATETIME,
+                            TAG_LIST,
+                            TAG_MAP,
+                            TAG_BYTES,
+                            TAG_I8VEC,
+                        ],
                     )),
                 }
             }
@@ -303,6 +334,19 @@ mod tests {
         eprintln!("bytes serialized as: {json}");
         let back: Value = serde_json::from_str(&json).unwrap();
         assert_eq!(back, v, "bytes must round-trip; got {back:?}");
+    }
+
+    #[test]
+    fn value_vec_i8_roundtrips_through_json() {
+        let v = Value::VecI8 {
+            codes: vec![1, -2, 127, -127, 0],
+            scale: 0.0123,
+        };
+        let json = serde_json::to_string(&v).unwrap();
+        let back: Value = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, v, "int8 vector must round-trip; got {back:?}");
+        // It must NOT silently re-decode as a plain Vec<f32>.
+        assert!(matches!(back, Value::VecI8 { .. }));
     }
 
     #[test]

--- a/crates/namidb-mcp/src/lib.rs
+++ b/crates/namidb-mcp/src/lib.rs
@@ -821,6 +821,11 @@ fn rv_to_json(v: &RuntimeValue) -> Value {
         RuntimeValue::DateTime(micros) => json!({ "datetime_micros": micros }),
         RuntimeValue::Bytes(b) => json!({ "bytes_len": b.len() }),
         RuntimeValue::Vector(v) => json!(v),
+        RuntimeValue::Vector8 { codes, scale } => {
+            // Dequantize int8 to floats so clients see a float vector.
+            let f: Vec<f32> = codes.iter().map(|&c| c as f32 * *scale).collect();
+            json!(f)
+        }
     }
 }
 

--- a/crates/namidb-py/src/lib.rs
+++ b/crates/namidb-py/src/lib.rs
@@ -793,6 +793,14 @@ fn value_to_py(py: Python<'_>, v: &Value) -> PyResult<Py<PyAny>> {
             }
             list.into_any().unbind()
         }
+        Value::VecI8 { codes, scale } => {
+            // Dequantize int8 to floats so Python sees a float vector.
+            let list = PyList::empty_bound(py);
+            for &c in codes {
+                list.append(c as f32 * *scale)?;
+            }
+            list.into_any().unbind()
+        }
         Value::Date(days) => {
             let epoch = NaiveDate::from_ymd_opt(1970, 1, 1).expect("static epoch");
             let d = epoch + chrono::Duration::days(*days as i64);
@@ -946,6 +954,14 @@ fn runtime_value_to_py(py: Python<'_>, v: &RuntimeValue) -> PyResult<Py<PyAny>> 
             let list = PyList::empty_bound(py);
             for x in v {
                 list.append(*x)?;
+            }
+            list.into_any().unbind()
+        }
+        RuntimeValue::Vector8 { codes, scale } => {
+            // Dequantize int8 to floats so Python sees a float vector.
+            let list = PyList::empty_bound(py);
+            for &c in codes {
+                list.append(c as f32 * *scale)?;
             }
             list.into_any().unbind()
         }

--- a/crates/namidb-query/src/exec/value.rs
+++ b/crates/namidb-query/src/exec/value.rs
@@ -30,6 +30,14 @@ pub enum RuntimeValue {
     Bytes(Vec<u8>),
     /// Float-vector — carried through but no arithmetic in v0.
     Vector(Vec<f32>),
+    /// Int8-quantized vector: int8 codes plus the per-vector f32 scale
+    /// (`x_i ≈ codes_i * scale`). Stays int8 in memory to keep the 4x size
+    /// win; the asymmetric scorer reads it directly and presentation paths
+    /// dequantize to floats on the way out.
+    Vector8 {
+        codes: Vec<i8>,
+        scale: f32,
+    },
     /// Alternating sequence `Node, Rel, Node, Rel, ..., Node` produced
     /// by binding a pattern part `p = (a)-[r]->(b)`. RFC-009 §"Path
     /// binding (caso simple)". Variable-length paths land.
@@ -67,6 +75,7 @@ impl RuntimeValue {
             RuntimeValue::DateTime(_) => "DATETIME",
             RuntimeValue::Bytes(_) => "BYTES",
             RuntimeValue::Vector(_) => "VECTOR",
+            RuntimeValue::Vector8 { .. } => "VECTOR",
             RuntimeValue::Path(_) => "PATH",
         }
     }
@@ -130,6 +139,7 @@ impl From<CoreValue> for RuntimeValue {
             CoreValue::Str(s) => RuntimeValue::String(s),
             CoreValue::Bytes(b) => RuntimeValue::Bytes(b),
             CoreValue::Vec(v) => RuntimeValue::Vector(v),
+            CoreValue::VecI8 { codes, scale } => RuntimeValue::Vector8 { codes, scale },
             CoreValue::Date(d) => RuntimeValue::Date(d),
             CoreValue::DateTime(m) => RuntimeValue::DateTime(m),
             CoreValue::List(items) => {

--- a/crates/namidb-query/src/exec/walker.rs
+++ b/crates/namidb-query/src/exec/walker.rs
@@ -1565,6 +1565,7 @@ fn fingerprint_value(v: &RuntimeValue) -> String {
         RuntimeValue::DateTime(d) => format!("dt:{}", d),
         RuntimeValue::Bytes(b) => format!("b:{}", b.len()),
         RuntimeValue::Vector(v) => format!("v:{}", v.len()),
+        RuntimeValue::Vector8 { codes, .. } => format!("v8:{}", codes.len()),
         RuntimeValue::Path(items) => {
             let mut s = "p:[".to_string();
             for (i, it) in items.iter().enumerate() {

--- a/crates/namidb-server/src/introspect.rs
+++ b/crates/namidb-server/src/introspect.rs
@@ -629,6 +629,7 @@ fn datatype_name(dt: &DataType) -> &'static str {
         DataType::Date32 => "Date",
         DataType::TimestampMicrosUtc => "LocalDateTime",
         DataType::FloatVector { .. } => "List",
+        DataType::Int8Vector { .. } => "List",
         DataType::Json => "Map",
     }
 }

--- a/crates/namidb-server/src/lib.rs
+++ b/crates/namidb-server/src/lib.rs
@@ -1038,6 +1038,17 @@ fn runtime_to_json(v: &RuntimeValue) -> serde_json::Value {
                 })
                 .collect(),
         ),
+        // Dequantize int8 to floats so HTTP clients see a float vector.
+        RuntimeValue::Vector8 { codes, scale } => J::Array(
+            codes
+                .iter()
+                .map(|&c| {
+                    serde_json::Number::from_f64(c as f64 * *scale as f64)
+                        .map(J::Number)
+                        .unwrap_or(J::Null)
+                })
+                .collect(),
+        ),
         RuntimeValue::List(items) => J::Array(items.iter().map(runtime_to_json).collect()),
         RuntimeValue::Map(m) => J::Object(
             m.iter()

--- a/crates/namidb-storage/src/flush.rs
+++ b/crates/namidb-storage/src/flush.rs
@@ -855,7 +855,7 @@ fn value_to_stat_scalar(v: &Value) -> Option<StatScalar> {
         Value::Bytes(b) => Some(StatScalar::Binary(b.clone())),
         Value::Date(d) => Some(StatScalar::Date32(*d)),
         Value::DateTime(m) => Some(StatScalar::TimestampMicrosUtc(*m)),
-        Value::Null | Value::Vec(_) | Value::List(_) | Value::Map(_) => None,
+        Value::Null | Value::Vec(_) | Value::VecI8 { .. } | Value::List(_) | Value::Map(_) => None,
     }
 }
 
@@ -1186,6 +1186,12 @@ enum PropertyBuilder {
         dim: u32,
         builder: FixedSizeListBuilder<Float32Builder>,
     },
+    /// int8-quantized vector packed into one `FixedSizeBinary(4 + dim)`:
+    /// 4-byte little-endian f32 scale, then `dim` int8 code bytes.
+    Int8Vector {
+        dim: u32,
+        builder: FixedSizeBinaryBuilder,
+    },
     Json(StringBuilder),
 }
 
@@ -1216,6 +1222,10 @@ impl PropertyBuilder {
                 let inner = Float32Builder::with_capacity(capacity * *dim as usize);
                 let builder = FixedSizeListBuilder::new(inner, *dim as i32);
                 PropertyBuilder::FloatVector { dim: *dim, builder }
+            }
+            DataType::Int8Vector { dim } => {
+                let builder = FixedSizeBinaryBuilder::with_capacity(capacity, 4 + *dim as i32);
+                PropertyBuilder::Int8Vector { dim: *dim, builder }
             }
             DataType::Json => {
                 PropertyBuilder::Json(StringBuilder::with_capacity(capacity, 64 * capacity.max(1)))
@@ -1319,6 +1329,42 @@ impl PropertyBuilder {
                 builder.append(true);
                 Ok(())
             }
+            // Already-quantized int8 vector: pack scale + codes and store.
+            (PropertyBuilder::Int8Vector { dim, builder }, Value::VecI8 { codes, scale }) => {
+                if codes.len() != *dim as usize {
+                    return Err(Error::invariant(format!(
+                        "property '{}' int8 vector dim={} != declared {}",
+                        def.name,
+                        codes.len(),
+                        dim
+                    )));
+                }
+                builder
+                    .append_value(pack_i8vec(*scale, codes))
+                    .map_err(|e| {
+                        Error::invariant(format!("int8 vector append for '{}': {e}", def.name))
+                    })?;
+                Ok(())
+            }
+            // Convenience: an f32 vector written to an int8 column is quantized
+            // on the fly, so callers can hand the writer raw embeddings.
+            (PropertyBuilder::Int8Vector { dim, builder }, Value::Vec(v)) => {
+                if v.len() != *dim as usize {
+                    return Err(Error::invariant(format!(
+                        "property '{}' vector dim={} != declared int8 vector {}",
+                        def.name,
+                        v.len(),
+                        dim
+                    )));
+                }
+                let (codes, scale) = namidb_core::quantize::quantize_i8(v);
+                builder
+                    .append_value(pack_i8vec(scale, &codes))
+                    .map_err(|e| {
+                        Error::invariant(format!("int8 vector append for '{}': {e}", def.name))
+                    })?;
+                Ok(())
+            }
             (PropertyBuilder::Json(b), v) => {
                 let s = serde_json::to_string(v).map_err(|e| {
                     Error::invariant(format!("json encode for '{}': {e}", def.name))
@@ -1355,6 +1401,7 @@ impl PropertyBuilder {
                 }
                 builder.append(false);
             }
+            PropertyBuilder::Int8Vector { builder, .. } => builder.append_null(),
             PropertyBuilder::Json(b) => b.append_null(),
         }
     }
@@ -1372,6 +1419,7 @@ impl PropertyBuilder {
             PropertyBuilder::Date32(_) => "Date32",
             PropertyBuilder::Timestamp(_) => "TimestampMicrosUtc",
             PropertyBuilder::FloatVector { .. } => "FloatVector",
+            PropertyBuilder::Int8Vector { .. } => "Int8Vector",
             PropertyBuilder::Json(_) => "Json",
         }
     }
@@ -1389,9 +1437,20 @@ impl PropertyBuilder {
             PropertyBuilder::Date32(b) => Arc::new(b.finish()),
             PropertyBuilder::Timestamp(b) => Arc::new(b.finish()),
             PropertyBuilder::FloatVector { builder, .. } => Arc::new(builder.finish()),
+            PropertyBuilder::Int8Vector { builder, .. } => Arc::new(builder.finish()),
             PropertyBuilder::Json(b) => Arc::new(b.finish()),
         }
     }
+}
+
+/// Pack an int8-quantized vector into the `FixedSizeBinary(4 + dim)` layout:
+/// 4-byte little-endian f32 scale, then the int8 codes as raw bytes. The read
+/// path in `read.rs` reverses this exactly.
+fn pack_i8vec(scale: f32, codes: &[i8]) -> Vec<u8> {
+    let mut buf = Vec::with_capacity(4 + codes.len());
+    buf.extend_from_slice(&scale.to_le_bytes());
+    buf.extend(codes.iter().map(|&c| c as u8));
+    buf
 }
 
 // ───────────────────────── Offline SST builder facade (RFC-023) ─────────
@@ -1798,6 +1857,46 @@ mod tests {
         let bytes = r.encode().unwrap();
         let back = EdgeWriteRecord::decode(&bytes).unwrap();
         assert_eq!(back, r);
+    }
+
+    #[test]
+    fn int8_vector_property_round_trips_through_arrow() {
+        use namidb_core::value::Value;
+        let dt = DataType::Int8Vector { dim: 4 };
+        let def = PropertyDef::new("emb", dt.clone(), true).unwrap();
+        let mut b = PropertyBuilder::new(&dt, 3).unwrap();
+
+        // Row 0: an already-quantized vector (exact round-trip).
+        let v0 = Value::VecI8 {
+            codes: vec![127, -127, 0, 64],
+            scale: 0.01,
+        };
+        b.append(Some(&v0), &def).unwrap();
+        // Row 1: null.
+        b.append(None, &def).unwrap();
+        // Row 2: an f32 vector, quantized on the fly by the writer.
+        let f = vec![0.5f32, -0.25, 0.0, 0.1];
+        b.append(Some(&Value::Vec(f.clone())), &def).unwrap();
+
+        let arr = b.finish();
+
+        assert_eq!(
+            crate::read::arrow_value_to_value(arr.as_ref(), 0, &dt).unwrap(),
+            Some(v0)
+        );
+        assert_eq!(
+            crate::read::arrow_value_to_value(arr.as_ref(), 1, &dt).unwrap(),
+            None
+        );
+        match crate::read::arrow_value_to_value(arr.as_ref(), 2, &dt).unwrap() {
+            Some(Value::VecI8 { codes, scale }) => {
+                let back: Vec<f32> = codes.iter().map(|&c| c as f32 * scale).collect();
+                for (x, y) in f.iter().zip(&back) {
+                    assert!((x - y).abs() <= 0.5 * scale + 1e-6, "{x} vs {y}");
+                }
+            }
+            other => panic!("expected VecI8, got {other:?}"),
+        }
     }
 
     #[tokio::test]

--- a/crates/namidb-storage/src/read.rs
+++ b/crates/namidb-storage/src/read.rs
@@ -2810,6 +2810,23 @@ pub(crate) fn arrow_value_to_value(
             }
             Value::Vec(f.values().to_vec())
         }
+        DataType::Int8Vector { dim } => {
+            let a = array
+                .as_any()
+                .downcast_ref::<FixedSizeBinaryArray>()
+                .ok_or_else(|| Error::invariant("expected FixedSizeBinaryArray"))?;
+            let bytes = a.value(row);
+            let want = 4 + *dim as usize;
+            if bytes.len() != want {
+                return Err(Error::invariant(format!(
+                    "Int8Vector byte width mismatch: expected {want}, got {}",
+                    bytes.len()
+                )));
+            }
+            let scale = f32::from_le_bytes([bytes[0], bytes[1], bytes[2], bytes[3]]);
+            let codes = bytes[4..].iter().map(|&b| b as i8).collect();
+            Value::VecI8 { codes, scale }
+        }
         DataType::Json => {
             let a = array
                 .as_any()


### PR DESCRIPTION
Second PR of the int8 quantization campaign (after #101's quantizer + harness). Combines the planned "core types" + "storage" steps into one coherent unit, since adding the type forces every exhaustive match (storage, presentation) to handle it anyway — splitting would mean error-stubs that the next PR rewrites.

## What

- **Type:** `DataType::Int8Vector { dim }` → Arrow `FixedSizeBinary(4 + dim)`. One self-contained column: 4-byte little-endian f32 per-vector scale, then `dim` int8 codes (`x_i ≈ code_i · scale`). One property = one column, so `node_arrow_schema` and the exact-match SST validator are untouched.
- **In-memory:** `Value::VecI8 { codes, scale }` (core, tagged `$i8vec` so it round-trips through `__overflow_json`/WAL instead of being re-decoded as `Vec<f32>`), `RuntimeValue::Vector8 { codes, scale }` (query). Kept int8 in RAM for the 4× win.
- **Write:** the flush `PropertyBuilder` stores an already-quantized `VecI8` directly, and quantizes an f32 vector written to an int8 column on the fly (via `namidb-core::quantize`), so callers can hand the writer raw embeddings.
- **Read:** `arrow_value_to_value` unpacks the `FixedSizeBinary` back to `VecI8` (this same path serves compaction).
- **Presentation:** Bolt, HTTP, MCP, CLI, and Python all dequantize int8 → floats on output, so clients still see a float vector.

## Safety / scope

- Encoding is **fixed per property by design** (switching is a re-embed, like the one-embedder-per-namespace rule), so compaction never sees a mixed f32/int8 column — the failure mode flagged at the start of the campaign is avoided by construction.
- **Inert until follow-ups:** nothing declares an int8 column yet. The asymmetric scorer (cosine over int8) and the `--quantize` opt-in are the remaining PRs. Cosine on an int8 vector currently falls through to the existing "not a vector" path until the scorer lands.

## Tests

- int8 vector arrow round-trip through `PropertyBuilder` + `arrow_value_to_value`, including a null row and the f32→quantize-on-write path.
- `to_arrow` maps `Int8Vector { dim }` to `FixedSizeBinary(4 + dim)`.
- `Value::VecI8` JSON round-trip via the `$i8vec` tag (does not re-decode as `Vec<f32>`).

Full CI gate green locally (fmt, clippy `-D warnings`, `cargo test --workspace --exclude namidb-py` — 1219 passed).