### PR TITLE
fix(parser): NOT binds tighter than AND (openCypher precedence) — 0.17.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2150,7 +2150,7 @@ dependencies = [
 
 [[package]]
 name = "namidb"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "namidb-core",
  "namidb-graph",
@@ -2160,7 +2160,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-bench"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -2179,7 +2179,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-bolt"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2199,7 +2199,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-cli"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -2219,7 +2219,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-core"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "arrow-array",
  "arrow-schema",
@@ -2235,7 +2235,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-graph"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -2256,7 +2256,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-markdown"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2279,7 +2279,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-mcp"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "anyhow",
  "clap",
@@ -2297,7 +2297,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-py"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "bytes",
  "chrono",
@@ -2315,7 +2315,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-query"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2339,7 +2339,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-server"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2374,7 +2374,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-storage"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "anyhow",
  "arrow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 ]
 
 [workspace.package]
-version = "0.17.0"
+version = "0.17.1"
 edition = "2021"
 rust-version = "1.85"
 license = "BUSL-1.1"
@@ -113,12 +113,12 @@ tower = "0.5"
 tower-http = { version = "0.6", features = ["trace", "cors"] }
 
 # Local workspace crates
-namidb-core = { path = "crates/namidb-core", version = "0.17.0" }
-namidb-storage = { path = "crates/namidb-storage", version = "0.17.0" }
-namidb-markdown = { path = "crates/namidb-markdown", version = "0.17.0" }
-namidb-graph = { path = "crates/namidb-graph", version = "0.17.0" }
-namidb-query = { path = "crates/namidb-query", version = "0.17.0" }
-namidb-bolt = { path = "crates/namidb-bolt", version = "0.17.0" }
+namidb-core = { path = "crates/namidb-core", version = "0.17.1" }
+namidb-storage = { path = "crates/namidb-storage", version = "0.17.1" }
+namidb-markdown = { path = "crates/namidb-markdown", version = "0.17.1" }
+namidb-graph = { path = "crates/namidb-graph", version = "0.17.1" }
+namidb-query = { path = "crates/namidb-query", version = "0.17.1" }
+namidb-bolt = { path = "crates/namidb-bolt", version = "0.17.1" }
 
 [profile.release]
 opt-level = 3

--- a/crates/namidb-query/src/parser/grammar.rs
+++ b/crates/namidb-query/src/parser/grammar.rs
@@ -1156,7 +1156,15 @@ impl<'src> Parser<'src> {
             Some(Token::Not) => {
                 let start = self.peek_span().start;
                 self.bump();
-                let inner = self.parse_expr_bp(5)?;
+                // NOT binds tighter than AND/XOR/OR but looser than the
+                // comparison operators (openCypher precedence). Parsing the
+                // operand at the comparison binding power (7) makes `NOT a = b`
+                // parse as `NOT (a = b)` while `NOT a AND b` parses as
+                // `(NOT a) AND b`. Using AND's bp (5) here was a bug: it let
+                // NOT swallow a trailing `AND`, so `NOT EXISTS(p) AND q` became
+                // `NOT (EXISTS(p) AND q)` — which hid the EXISTS from the
+                // SemiApply hoisting in lowering and blew up at evaluate().
+                let inner = self.parse_expr_bp(7)?;
                 let end = inner.span.end;
                 Ok(Expression {
                     kind: ExpressionKind::Unary {

--- a/crates/namidb-query/tests/exec_match_expand.rs
+++ b/crates/namidb-query/tests/exec_match_expand.rs
@@ -1114,3 +1114,33 @@ async fn indexed_property_match_uses_index_and_returns_all_matches() {
         "both LA persons must come back, not the NYC one"
     );
 }
+
+#[tokio::test]
+async fn not_exists_left_of_and_hoists_to_semiapply() {
+    // Regression: `NOT EXISTS(pattern) AND <scalar>` must parse so the
+    // NOT binds only the EXISTS (NOT tighter than AND). Previously NOT
+    // swallowed the AND -> `NOT (EXISTS AND scalar)`, which left the
+    // EXISTS un-hoisted and failed at evaluate() with "must be hoisted to
+    // a SemiApply operator". Covers the NOT-on-the-left position plus the
+    // multi-type / undirected / anonymous pattern the cloud MCP used.
+    let mut writer = WriterSession::open(store(), paths("exec-not-exists-and"))
+        .await
+        .unwrap();
+    build_friend_graph(&mut writer).await;
+    let snapshot = writer.snapshot();
+
+    // Every Person has an out-KNOWS, so NOT EXISTS((a)-[:KNOWS]-()) is false
+    // for all; AND-ed with a true scalar still yields 0 rows (and crucially
+    // does NOT error).
+    for q in [
+        "MATCH (a:Person) WHERE NOT EXISTS((a)-[:KNOWS]-()) AND a.age > 0 RETURN a.name AS name",
+        "MATCH (a:Person) WHERE NOT EXISTS((a)-[:KNOWS]-()) AND a.age IS NULL RETURN a.name AS name",
+        "MATCH (a:Person) WHERE NOT EXISTS((a)-[:KNOWS]->()) AND a.name = 'Alice' RETURN a.name AS name",
+    ] {
+        let plan = lower(&parse(q).unwrap()).unwrap();
+        let rows = execute(&plan, &snapshot, &Params::new())
+            .await
+            .unwrap_or_else(|e| panic!("query failed: {q}\n  err: {e}"));
+        assert_eq!(rows.len(), 0, "expected 0 rows for: {q}");
+    }
+}


### PR DESCRIPTION
## Bug
`NOT EXISTS(p) AND q` parsed as `NOT (EXISTS(p) AND q)` instead of `(NOT EXISTS(p)) AND q`.

`parse_unary` parsed NOT's operand at AND's binding power (5); the Pratt loop continues on operators with `lbp >= min_bp`, so NOT swallowed the trailing `AND`. The wrapped EXISTS then escaped the SemiApply hoisting in lowering (`classify_exists_term` only matches a bare `Exists` / `Not(Exists)` term), survived as a residual `Filter`, and hit the runtime guard *"EXISTS pattern predicates require storage access — must be hoisted to a SemiApply operator"*.

Confirmed by isolation: `EXISTS(p) AND x` ✓, `x AND NOT EXISTS(p)` ✓ (NOT on the right), but `NOT EXISTS(p) AND x` ✗ (NOT on the left swallows the AND).

## Fix
Parse NOT's operand at the comparison binding power (7): `NOT a = b` stays `NOT (a = b)`, while `NOT a AND b` becomes `(NOT a) AND b` — matching openCypher precedence (OR < XOR < AND < NOT < comparison). One-line change + a comment.

## Tests
New regression `not_exists_left_of_and_hoists_to_semiapply` (NOT-EXISTS left of AND, with multi-type / undirected / anonymous patterns). **Full `namidb-query` suite green (448 unit + all integration).** Parser-only — no storage or wire-format change, so it's a patch (**0.17.1**) and on-disk format stays 0.17.x-compatible.

Hotfix off `v0.17.0` (main was exactly at the tag). Unblocks the cloud MCP orphans/prune queries (currently on an OPTIONAL-MATCH workaround) and any user's `NOT EXISTS(...) AND ...` query.