### PR TITLE
ci: publish official Docker image to GHCR (multi-arch)

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -1,0 +1,123 @@
+# Build and publish the official `namidb-server` container image.
+#
+# Triggers:
+#   * `v*` tag push          → build linux/amd64 + linux/arm64 and push to GHCR
+#                              (and Docker Hub, if the secrets are configured)
+#                              tagged `X.Y.Z`, `X.Y`, `X` and `latest`.
+#   * workflow_dispatch      → with a `version` input (e.g. `2.0.0`): checks out
+#                              tag `v<version>` and publishes it — for releases
+#                              that predate this workflow. Without the input:
+#                              build-check only.
+#   * pull_request           → build-check only (amd64, no push), so a broken
+#                              Dockerfile is caught before the release tag.
+#
+# The image is the same config as the prebuilt `namidb-server` release
+# archive: `--features vector-index,text-index` (see the Dockerfile).
+#
+# Registries:
+#   ghcr.io/namidb/namidb-server     — always (GITHUB_TOKEN, zero config)
+#   docker.io/namidb/namidb-server   — only when the `DOCKERHUB_USERNAME` /
+#                                      `DOCKERHUB_TOKEN` secrets exist.
+
+name: docker-image
+
+on:
+  push:
+    tags:
+      - "v*"
+  pull_request:
+    paths:
+      - "crates/namidb-server/Dockerfile"
+      - ".dockerignore"
+      - ".github/workflows/docker-image.yml"
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Released version to publish (e.g. 2.0.0) — checks out tag v<version> and pushes. Empty = build-check only."
+        required: false
+        default: ""
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  # Secrets are not readable in step-level `if:`, so surface the check here.
+  HAS_DOCKERHUB: ${{ secrets.DOCKERHUB_USERNAME != '' }}
+
+jobs:
+  build:
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          ref: ${{ inputs.version != '' && format('refs/tags/v{0}', inputs.version) || github.ref }}
+
+      - name: Compute version and image tags
+        id: meta
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          PUBLISH=false VERSION=""
+          case "$GITHUB_REF" in
+            refs/tags/v*) VERSION="${GITHUB_REF#refs/tags/v}"; PUBLISH=true ;;
+          esac
+          if [[ -n "$INPUT_VERSION" ]]; then
+            VERSION="${INPUT_VERSION#v}"; PUBLISH=true
+          fi
+
+          IMAGES="ghcr.io/namidb/namidb-server"
+          if [[ "$HAS_DOCKERHUB" == "true" ]]; then
+            IMAGES="$IMAGES docker.io/namidb/namidb-server"
+          fi
+
+          TAGS=""
+          for IMG in $IMAGES; do
+            if [[ "$PUBLISH" == "true" ]]; then
+              TAGS="$TAGS,$IMG:$VERSION"
+              # Rolling tags only for stable X.Y.Z releases, not prereleases.
+              if [[ "$VERSION" =~ ^([0-9]+)\.([0-9]+)\.[0-9]+$ ]]; then
+                TAGS="$TAGS,$IMG:${BASH_REMATCH[1]}.${BASH_REMATCH[2]}"
+                TAGS="$TAGS,$IMG:${BASH_REMATCH[1]}"
+                TAGS="$TAGS,$IMG:latest"
+              fi
+            else
+              TAGS="$TAGS,$IMG:build-check"
+            fi
+          done
+
+          echo "publish=$PUBLISH"      >> "$GITHUB_OUTPUT"
+          echo "tags=${TAGS#,}"        >> "$GITHUB_OUTPUT"
+          echo "Publishing=$PUBLISH version=$VERSION tags=${TAGS#,}"
+
+      - uses: docker/setup-qemu-action@v3
+        if: steps.meta.outputs.publish == 'true'
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        if: steps.meta.outputs.publish == 'true'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Log in to Docker Hub
+        if: steps.meta.outputs.publish == 'true' && env.HAS_DOCKERHUB == 'true'
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build (and push when publishing)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: crates/namidb-server/Dockerfile
+          platforms: ${{ steps.meta.outputs.publish == 'true' && 'linux/amd64,linux/arm64' || 'linux/amd64' }}
+          push: ${{ steps.meta.outputs.publish == 'true' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/crates/namidb-query/src/optimize/decorrelation.rs
+++ b/crates/namidb-query/src/optimize/decorrelation.rs
@@ -160,7 +160,6 @@ fn collect_outer_labels(plan: &LogicalPlan, out: &mut BTreeMap<String, Option<St
             input,
             target_alias,
             target_labels,
-            rel_alias: _,
             ..
         } => {
             collect_outer_labels(input, out);

--- a/crates/namidb-server/README.md
+++ b/crates/namidb-server/README.md
@@ -12,10 +12,16 @@ From source (workspace root):
 cargo install --path crates/namidb-server
 ```
 
-Container image (build from the repo root):
+Container image (official, multi-arch amd64/arm64):
 
 ```bash
-docker build -t namidb-server:0.1 -f crates/namidb-server/Dockerfile .
+docker pull ghcr.io/namidb/namidb-server:2
+```
+
+Or build it yourself from the repo root:
+
+```bash
+docker build -t ghcr.io/namidb/namidb-server:2 -f crates/namidb-server/Dockerfile .
 ```
 
 ## Run

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,10 +1,12 @@
 # Self-hosted NamiDB on MinIO.
 #
-# Usage:
-#   docker build -t namidb-server:0.1 -f crates/namidb-server/Dockerfile .
+# Usage (pulls the official image from GHCR, nothing to build):
 #   export NAMIDB_AUTH_TOKEN=$(openssl rand -hex 32)
 #   docker compose up -d
 #   curl -s http://localhost:8080/v0/health | jq .
+#
+# To run a locally built image instead:
+#   docker build -t ghcr.io/namidb/namidb-server:2 -f crates/namidb-server/Dockerfile .
 #
 # After it boots, the graph database is reachable on :8080 with bearer
 # token = $NAMIDB_AUTH_TOKEN. The MinIO console is on :9001
@@ -39,7 +41,7 @@ services:
       "
 
   namidb-server:
-    image: namidb-server:0.1
+    image: ghcr.io/namidb/namidb-server:2
     depends_on:
       bucket-init:
         condition: service_completed_successfully


### PR DESCRIPTION
## What

- New `docker-image` workflow:
  - **`v*` tag push** → builds `linux/amd64` + `linux/arm64` and pushes `ghcr.io/namidb/namidb-server` tagged `X.Y.Z`, `X.Y`, `X`, `latest`.
  - **Manual dispatch with `version` input** (e.g. `2.0.0`) → checks out `v<version>` and publishes it — lets us publish already-released versions without re-tagging.
  - **PRs touching the Dockerfile** → amd64 build-check, no push.
- Docker Hub (`docker.io/namidb/namidb-server`) activates automatically once `DOCKERHUB_USERNAME`/`DOCKERHUB_TOKEN` secrets are configured.
- `docker-compose.yml` and the server README now reference the published image — self-hosting no longer requires a local cargo build.

## Why

We ship prebuilt binaries and Python wheels, but the server image had to be built from source (10–25 min of cargo). This makes `docker compose up` work out of the box.

## After merge

Run the workflow manually with `version: 2.0.0` to publish the current release, then set the GHCR package visibility to **public** (org settings → Packages).