### PR TITLE
docs: surface the official Docker image (Docker Hub)

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Point it at a bucket (or a local folder, or nothing at all), write Cypher, and y
 [![License: BSL 1.1](https://img.shields.io/badge/License-BSL%201.1-1f6feb.svg)](LICENSE)
 [![Rust](https://img.shields.io/badge/Rust-1.85%2B-dea584.svg?logo=rust&logoColor=white)](https://www.rust-lang.org)
 [![PyPI](https://img.shields.io/badge/PyPI-namidb-3776ab.svg?logo=pypi&logoColor=white)](https://pypi.org/project/namidb/)
-[![Docker](https://img.shields.io/badge/Docker-namidb--server-2496ed.svg?logo=docker&logoColor=white)](crates/namidb-server/Dockerfile)
+[![Docker Hub](https://img.shields.io/docker/v/namidb/namidb-server?sort=semver&label=Docker&logo=docker&logoColor=white&color=2496ed)](https://hub.docker.com/r/namidb/namidb-server)
 [![Website](https://img.shields.io/badge/Website-namidb.com-0a7ea4.svg)](https://namidb.com)
 [![Docs](https://img.shields.io/badge/Docs-docs.namidb.com-0a7ea4.svg)](https://docs.namidb.com)
 
@@ -348,6 +348,17 @@ The tools it exposes:
 
 ## Run it as a server (HTTP + Bolt)
 
+The official image is on [Docker Hub](https://hub.docker.com/r/namidb/namidb-server) (multi-arch: `linux/amd64` + `linux/arm64`), built with vector + full-text search on:
+
+```bash
+# Official image, plain HTTP on :8080.
+docker run --rm -p 8080:8080 \
+  -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY \
+  namidb/namidb-server:2 --store "s3://my-bucket?ns=prod&region=us-west-2"
+```
+
+For a full self-hosted stack (server + MinIO as the bucket) see [`docker-compose.yml`](docker-compose.yml). Or run it from source:
+
 ```bash
 # Plain HTTP on :8080.
 cargo run --release -p namidb-server -- --store "s3://my-bucket?ns=prod&region=us-west-2"
@@ -386,7 +397,7 @@ cargo run --release -p namidb-server --features jwt,pdp,vector-index -- \
 
 > Build features: `jwt` (OIDC), `pdp` (external policy), `vector-index` (`CREATE VECTOR INDEX`), `text-index` (`CREATE FULLTEXT INDEX`). Omit them for a smaller binary; the default build is static-token auth only.
 >
-> **Prebuilt server binary.** Each GitHub Release ships a `namidb-server-<tag>-<target>` archive built with `--features vector-index,text-index`, so `CREATE VECTOR INDEX` / `CREATE FULLTEXT INDEX` work out of the box. The `namidb` and `namidb-mcp` archives are feature-light — no optional features — so build the server from source with your own `--features` set when you also want `jwt`/`pdp` or a slimmer binary.
+> **Prebuilt server binary.** Each GitHub Release ships a `namidb-server-<tag>-<target>` archive built with `--features vector-index,text-index`, so `CREATE VECTOR INDEX` / `CREATE FULLTEXT INDEX` work out of the box — the [official Docker image](https://hub.docker.com/r/namidb/namidb-server) is the same configuration. The `namidb` and `namidb-mcp` archives are feature-light — no optional features — so build the server from source with your own `--features` set when you also want `jwt`/`pdp` or a slimmer binary.
 
 <br />
 

--- a/crates/namidb-server/README.md
+++ b/crates/namidb-server/README.md
@@ -12,16 +12,18 @@ From source (workspace root):
 cargo install --path crates/namidb-server
 ```
 
-Container image (official, multi-arch amd64/arm64):
+Container image (official, multi-arch amd64/arm64, from
+[Docker Hub](https://hub.docker.com/r/namidb/namidb-server) — also mirrored
+at `ghcr.io/namidb/namidb-server`):
 
 ```bash
-docker pull ghcr.io/namidb/namidb-server:2
+docker pull namidb/namidb-server:2
 ```
 
 Or build it yourself from the repo root:
 
 ```bash
-docker build -t ghcr.io/namidb/namidb-server:2 -f crates/namidb-server/Dockerfile .
+docker build -t namidb/namidb-server:2 -f crates/namidb-server/Dockerfile .
 ```
 
 ## Run

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,12 +1,12 @@
 # Self-hosted NamiDB on MinIO.
 #
-# Usage (pulls the official image from GHCR, nothing to build):
+# Usage (pulls the official image from Docker Hub, nothing to build):
 #   export NAMIDB_AUTH_TOKEN=$(openssl rand -hex 32)
 #   docker compose up -d
 #   curl -s http://localhost:8080/v0/health | jq .
 #
 # To run a locally built image instead:
-#   docker build -t ghcr.io/namidb/namidb-server:2 -f crates/namidb-server/Dockerfile .
+#   docker build -t namidb/namidb-server:2 -f crates/namidb-server/Dockerfile .
 #
 # After it boots, the graph database is reachable on :8080 with bearer
 # token = $NAMIDB_AUTH_TOKEN. The MinIO console is on :9001
@@ -41,7 +41,7 @@ services:
       "
 
   namidb-server:
-    image: ghcr.io/namidb/namidb-server:2
+    image: namidb/namidb-server:2
     depends_on:
       bucket-init:
         condition: service_completed_successfully


### PR DESCRIPTION
Follow-up to #112/#113/#114 — the image is now live at [`namidb/namidb-server`](https://hub.docker.com/r/namidb/namidb-server) (multi-arch, tags `2.0.0`/`2.0`/`2`/`latest`).

- README: the Docker badge now shows the latest published version and links to Docker Hub; `docker run` leads the server section, with the compose stack and cargo as alternatives.
- `docker-compose.yml` + server README: reference Docker Hub as canonical (public today; the GHCR mirror stays private until flipped in org settings).