### PR TITLE
test: serialize profile tests that share process-global state

### DIFF
--- a/crates/namidb-core/src/profile.rs
+++ b/crates/namidb-core/src/profile.rs
@@ -174,10 +174,15 @@ macro_rules! profile_scope {
 mod tests {
     use super::*;
 
+    /// Both tests mutate process-global state (the stats map and
+    /// `ENABLED_CACHE`) and the test harness runs them on parallel
+    /// threads, so a `reset()` from one can wipe rows the other just
+    /// recorded. Serialize them.
+    static TEST_LOCK: Mutex<()> = Mutex::new(());
+
     #[test]
     fn dump_is_empty_initially() {
-        // Note: tests run in the same process; if another test already
-        // recorded something we'll see it. Reset first.
+        let _guard = TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         reset();
         let _ = enabled(); // populate cache
         let rows = dump();
@@ -186,6 +191,7 @@ mod tests {
 
     #[test]
     fn record_accumulates_per_stage() {
+        let _guard = TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         reset();
         // Force-enable: bypass env var for this unit test.
         ENABLED_CACHE.store(2, Ordering::Relaxed);


### PR DESCRIPTION
`profile::tests::record_accumulates_per_stage` flakes in CI (`index out of bounds: the len is 0 but the index is 0` at `dump()`) — seen on the first runs of #112 and #115.

**Root cause:** both tests in `namidb-core/src/profile.rs` mutate process-global state (`reset()`, `ENABLED_CACHE`) and the test harness runs them on parallel threads. If `dump_is_empty_initially` executes its `reset()` between the other test's `record(...)` calls and its `dump()`, the rows vanish and `rows[0]` panics.

**Fix:** a `static TEST_LOCK: Mutex<()>` held by both tests (poison-tolerant via `into_inner`), so they serialize without affecting the rest of the suite.