### PR TITLE
fix: stop fsyncing per distinct value in the posting spool

### DIFF
--- a/crates/namidb-storage/src/flush.rs
+++ b/crates/namidb-storage/src/flush.rs
@@ -2037,7 +2037,14 @@ fn finish_external_posting(
     distinct_counts: &mut [u64],
     legacy: &mut [Option<LegacyMapSpool>],
 ) -> Result<()> {
-    posting.file.sync_data()?;
+    // Deliberately NO sync_data here: this runs once per DISTINCT VALUE, so an
+    // fsync makes a string-heavy flush O(distinct values) journal commits — a
+    // 500k-value flush crawls at KB/s and holds the writer lock for hours (the
+    // 5M-row live-load outage). The scratch is an anonymous deleted temp file:
+    // it needs no durability, its bytes are copied out immediately below while
+    // still page-cache resident, the copy is covered end-to-end by the crc32
+    // stored in the paged-index leaf, and ENOSPC still surfaces at the value
+    // region's own sync_data when the builder finishes.
     let ordinal = posting.property as usize;
     let checksum = posting.checksum.finalize();
     builders[ordinal].push_external_file(&posting.key, &mut posting.file, posting.len, checksum)?;

--- a/docs/testing/25tb-readiness.md
+++ b/docs/testing/25tb-readiness.md
@@ -295,3 +295,36 @@ but the semantically identical `MATCH (p:Person)-[w:WORKS_AT]->(c:Company
 should consider anchoring at the most selective pattern endpoint regardless of
 the direction the user wrote. Reproduction: any big label -> tiny
 unique-anchored endpoint written left-to-right.
+
+### 37. [DONE — storage, blocker-at-scale, fix on fix/flush-posting-fsync-storm] First large flush fsyncs once per distinct indexed-property value, holding the writer lock for hours.
+
+Found 2026-08-16 during the 5M-record live S3 validation (LocalStack,
+released 2.1.1 and 2.1.0 binaries — NOT a 2.1.1 regression). Loading 5M
+records (2.475M Person + 50k Company with a UNIQUE string `cid` + 2.475M
+WORKS_AT) stalled permanently at ~265k rows: the first flush past the
+memtable threshold acquired the writer lock and crawled at ~128 KB/s to
+anonymous O_TMPFILE scratch files, so every write got "writer is busy"
+(503) for what would have been hours. Root cause:
+`finish_external_posting` (flush.rs) called `sync_data()` once per
+DISTINCT VALUE of every posting-indexed property — with string-heavy
+properties (names are per-row distinct) that is O(rows) ext4 journal
+commits at ~3 ms each. The fsync bought nothing: the scratch is a deleted
+anonymous file (no durability role), its bytes are copied into the
+paged-index value spool immediately while page-cache resident, that copy
+is covered end-to-end by the crc32 stored in the index leaf (fail-stop on
+read), and ENOSPC still surfaces at the value region's own amortized
+`sync_data` when the builder finishes. The other nine `sync_data` sites
+in the flush/SST pipeline are per-run or per-builder (amortized over MBs)
+and remain untouched.
+
+**Resolution (2026-08-16):** removed the per-value `sync_data`. With the
+fix the same 5M load completes in 210 s (~24k rows/s sustained; flushes
+now finish in ~20 s, visible only as brief throughput dips), RSS peaks at
+1.50 GB under the 3 GB ceiling, and the item-36 validation passes 13/13
+on the flushed data through both the patched build and the released 2.1.1
+binary. Also re-verified during diagnosis: WAL recovery after `kill -9`
+restored 580k acknowledged records exactly. Remaining related exposure
+(untested, future work): writes are unavailable for the full duration of
+any flush once the memtable passes the stall threshold — acceptable at
+~20 s per flush, but a soak asserting an upper bound on write-outage
+windows during sustained load would pin it.


### PR DESCRIPTION
Item 37 of docs/testing/25tb-readiness.md — found during the 5M-record live S3 validation of 2.1.1. **Not a 2.1.1 regression**: the released 2.1.0 binary wedges identically on the same state (A/B verified).

## Symptom

Loading 5M records (2.475M Person + 50k Company with a UNIQUE string `cid` + 2.475M WORKS_AT edges, LocalStack S3) stalled permanently at ~265k rows: the first flush past the memtable threshold acquired the writer lock and never finished, so every write got `writer is busy` (503) indefinitely. The flush was alive but glacial — ~128 KB/s into anonymous O_TMPFILE scratch files, one ext4 journal commit at a time (`jbd2_log_wait_commit`).

## Root cause

`finish_external_posting` (flush.rs) called `sync_data()` **once per distinct value** of every posting-indexed property. Names are per-row distinct, so a string-heavy flush is O(rows) fsyncs at ~3 ms each — hours for a few hundred thousand rows, all while holding the writer lock.

## Why removing it is safe

- The scratch is a **deleted anonymous temp file**: it has no durability role — on any crash the flush restarts from the WAL.
- Its bytes are copied into the paged-index value spool **immediately**, while still page-cache resident.
- That copy is covered **end-to-end by the crc32** stored in the index leaf (`push_external_file` embeds it; readers verify — fail-stop, not silent corruption).
- The ENOSPC-surfacing role (the documented reason these spools fsync) is preserved by the value region's own **amortized** `sync_data` when the builder finishes.
- The other nine `sync_data` sites in the flush/SST pipeline are per-run or per-builder (amortized over MBs) and are untouched.

## Verification

- Live 5M re-run with the patched build: load completes in **210 s** (~24k rows/s sustained; flushes now ~20 s, visible only as brief throughput dips), RSS peak 1.50 GB under the 3 GB ceiling, final counts exact (2,525,000 nodes + 2,475,000 edges).
- Item-36 validation on the flushed data: **13/13 PASS** through the patched build AND the released 2.1.1 binary (HTTP + Bolt, oracle-exact rows, slow-spelling anchored in 67–585 ms); released 2.1.0 contrast: fast form correct, slow form scans 2.475M and dies on the row cap (HTTP 413).
- During diagnosis, WAL recovery after `kill -9` restored all 580k acknowledged records exactly.
- `cargo test -p namidb-storage`: 702 passed, 0 failed. fmt + clippy `-D warnings` clean.

The performance pin is the live measurement above; flush output correctness is already covered by the existing storage suites (checksum, parity, and format tests).