### PR TITLE
fix: disk-full flush degrades the namespace instead of wedging it

### DIFF
--- a/crates/namidb-server/src/bolt.rs
+++ b/crates/namidb-server/src/bolt.rs
@@ -34,6 +34,15 @@ use crate::AppState;
 /// it failed before planning), the wall-clock it took (up to the end of
 /// execution, excluding any write-stall sleep), and the outcome the protocol
 /// returns to the driver.
+/// Typed failure for writes rejected while the namespace's local
+/// persistence is degraded (spool disk full/unwritable — the flush cannot
+/// drain the memtable). Distinct from `writer_busy_error`: this one is not
+/// resolved by retrying, so it carries the operator-facing reason. Mirrors
+/// HTTP's 507.
+fn persistence_degraded_error(reason: &str) -> BackendError {
+    BackendError::Storage(format!("namespace degraded: {reason}"))
+}
+
 /// The uniform transient failure for a foreground writer-lock timeout.
 fn writer_busy_error() -> BackendError {
     BackendError::Storage(
@@ -178,6 +187,13 @@ impl ServerBackend {
                 result: Err(BackendError::Forbidden(denied.to_string())),
             };
         }
+        if let Some(reason) = self.state.writer_health.persistence_degraded_reason() {
+            return RunObservation {
+                kind: Some(QueryKind::Write),
+                elapsed: started.elapsed(),
+                result: Err(persistence_degraded_error(&reason)),
+            };
+        }
         let Some(mut writer) = self.state.lock_writer_bounded(WriterLockKind::Bolt).await else {
             return RunObservation {
                 kind: Some(QueryKind::Write),
@@ -259,6 +275,13 @@ impl ServerBackend {
                 result: Err(BackendError::Forbidden(denied.to_string())),
             };
         }
+        if let Some(reason) = self.state.writer_health.persistence_degraded_reason() {
+            return RunObservation {
+                kind: Some(QueryKind::Write),
+                elapsed: started.elapsed(),
+                result: Err(persistence_degraded_error(&reason)),
+            };
+        }
         let Some(mut writer) = self.state.lock_writer_bounded(WriterLockKind::Bolt).await else {
             return RunObservation {
                 kind: Some(QueryKind::Write),
@@ -323,6 +346,13 @@ impl ServerBackend {
                 kind: None,
                 elapsed: started.elapsed(),
                 result: Err(BackendError::Forbidden(denied.to_string())),
+            };
+        }
+        if let Some(reason) = self.state.writer_health.persistence_degraded_reason() {
+            return RunObservation {
+                kind: Some(QueryKind::Write),
+                elapsed: started.elapsed(),
+                result: Err(persistence_degraded_error(&reason)),
             };
         }
         let Some(mut writer) = self.state.lock_writer_bounded(WriterLockKind::Bolt).await else {
@@ -402,6 +432,13 @@ impl ServerBackend {
                 kind: None,
                 elapsed: started.elapsed(),
                 result: Err(BackendError::Forbidden(denied.to_string())),
+            };
+        }
+        if let Some(reason) = self.state.writer_health.persistence_degraded_reason() {
+            return RunObservation {
+                kind: Some(QueryKind::Write),
+                elapsed: started.elapsed(),
+                result: Err(persistence_degraded_error(&reason)),
             };
         }
         let Some(mut writer) = self.state.lock_writer_bounded(WriterLockKind::Bolt).await else {
@@ -486,6 +523,13 @@ impl ServerBackend {
                 kind: None,
                 elapsed: started.elapsed(),
                 result: Err(BackendError::Forbidden(denied.to_string())),
+            };
+        }
+        if let Some(reason) = self.state.writer_health.persistence_degraded_reason() {
+            return RunObservation {
+                kind: Some(QueryKind::Write),
+                elapsed: started.elapsed(),
+                result: Err(persistence_degraded_error(&reason)),
             };
         }
         let Some(mut writer) = self.state.lock_writer_bounded(WriterLockKind::Bolt).await else {
@@ -699,6 +743,13 @@ impl ServerBackend {
                     kind: Some(QueryKind::Write),
                     elapsed: started.elapsed(),
                     result: Err(err),
+                };
+            }
+            if let Some(reason) = self.state.writer_health.persistence_degraded_reason() {
+                return RunObservation {
+                    kind: Some(QueryKind::Write),
+                    elapsed: started.elapsed(),
+                    result: Err(persistence_degraded_error(&reason)),
                 };
             }
             // Writes still take the writer lock (single-writer invariant),
@@ -1220,6 +1271,12 @@ impl Backend for ServerBackend {
         // release the lock and its staged memory.
         if let Err(pressure) = self.state.memory.admit_query().await {
             return Err(memory_pressure_error(pressure));
+        }
+        // A transaction exists to write; reject it up front while local
+        // persistence is degraded instead of letting it pin the writer
+        // mutex on a namespace whose memtable cannot drain.
+        if let Some(reason) = self.state.writer_health.persistence_degraded_reason() {
+            return Err(persistence_degraded_error(&reason));
         }
         // Take the global writer lock for the whole transaction, bounded so
         // a BEGIN queued behind a stuck/long transaction fails fast instead

--- a/crates/namidb-server/src/lib.rs
+++ b/crates/namidb-server/src/lib.rs
@@ -925,6 +925,12 @@ pub async fn run_with_memory_max_bytes(
             let mut tick = tokio::time::interval(interval);
             tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
             tick.tick().await; // first tick fires immediately; skip.
+                               // After a local-persistence flush failure (spool disk full),
+                               // an immediate retry re-runs the same doomed O(corpus) build
+                               // under the writer lock. Hold retries back so the mutex stays
+                               // available and the degraded state can be observed; the next
+                               // attempt after the window self-heals once the disk clears.
+            let mut retry_after: Option<std::time::Instant> = None;
             loop {
                 // Flush on the timer OR when a committed write crossed the
                 // memtable byte threshold (`after_commit_backpressure`
@@ -933,6 +939,9 @@ pub async fn run_with_memory_max_bytes(
                 tokio::select! {
                     _ = tick.tick() => {}
                     _ = state_for_flush.flush_notify.notified() => {}
+                }
+                if retry_after.is_some_and(|at| std::time::Instant::now() < at) {
+                    continue;
                 }
                 // Flush under the writer lock, then only enqueue a trigger
                 // when the L0 high-water mark trips. The scheduler captures
@@ -949,6 +958,8 @@ pub async fn run_with_memory_max_bytes(
                     let schema = w.snapshot().manifest().manifest.schema.clone();
                     match w.flush(schema.clone()).await {
                         Ok(_) => {
+                            retry_after = None;
+                            state_for_flush.writer_health.clear_persistence_degraded();
                             state_for_flush.snapshot.store(w.owned_snapshot());
                             state_for_flush
                                 .memtable_bytes_gauge
@@ -957,6 +968,13 @@ pub async fn run_with_memory_max_bytes(
                         }
                         Err(e) => {
                             error!(error = %e, "periodic flush failed");
+                            if e.is_local_persistence() {
+                                state_for_flush
+                                    .writer_health
+                                    .mark_persistence_degraded(persistence_degraded_reason(&e));
+                                retry_after =
+                                    Some(std::time::Instant::now() + FLUSH_FAILURE_RETRY_BACKOFF);
+                            }
                             // A fenced/poisoned writer would fail every later
                             // flush AND every write; reopen under the held lock.
                             recovery::recover_writer_if_needed(
@@ -1413,6 +1431,49 @@ pub(crate) async fn lock_writer_bounded(
     tokio::time::timeout(timeout, writer.lock()).await.ok()
 }
 
+/// How long the periodic flush loop waits after a local-persistence flush
+/// failure before retrying. Immediate retries re-run the same doomed
+/// O(corpus) build against the same full disk while holding the writer
+/// mutex; this window keeps the mutex available and gives the operator a
+/// stable degraded state instead of a grinding loop.
+pub(crate) const FLUSH_FAILURE_RETRY_BACKOFF: Duration = Duration::from_secs(30);
+
+/// The reason recorded in `WriterHealth` when a flush fails on local
+/// persistence. Written for the operator who reads `/v0/health`.
+pub(crate) fn persistence_degraded_reason(e: &namidb_storage::Error) -> String {
+    format!(
+        "flush failed on local persistence (spool disk full or unwritable?): {e}; \
+         writes are rejected with 507 and reads keep serving the last committed \
+         state; the flush retries automatically and recovery clears this"
+    )
+}
+
+/// The uniform 507 body for writes rejected while the namespace is
+/// persistence-degraded. 507 (Insufficient Storage) so clients and load
+/// balancers can tell "stop sending writes, the disk is the problem" apart
+/// from the transient 503 "writer is busy; retry".
+fn persistence_degraded_response(reason: &str) -> Response {
+    (
+        StatusCode::INSUFFICIENT_STORAGE,
+        Json(ErrorBody {
+            error: format!("namespace degraded: {reason}"),
+        }),
+    )
+        .into_response()
+}
+
+/// Typed rejection for write intake while the namespace's local persistence
+/// is degraded (spool disk full/unwritable — the flush cannot drain the
+/// memtable). Checked BEFORE queueing on the writer mutex so a doomed flush
+/// cycle cannot convert every write into an opaque lock-timeout 503, and so
+/// rejected writes never pin a concurrency slot waiting on the mutex.
+/// Reads are never gated on this.
+fn write_intake_rejection(health: &recovery::WriterHealth) -> Option<Response> {
+    health
+        .persistence_degraded_reason()
+        .map(|reason| persistence_degraded_response(&reason))
+}
+
 /// The uniform 503 body for a foreground writer-lock timeout.
 fn writer_busy_response() -> Response {
     (
@@ -1761,6 +1822,14 @@ async fn run_create_vector_index(
                 .into_response(),
         };
     }
+    if let Some(rejection) = write_intake_rejection(writer_health) {
+        return ObservedQuery {
+            kind: None,
+            ok: false,
+            elapsed: started.elapsed(),
+            response: rejection,
+        };
+    }
     let mut w = writer.lock().await;
     if namespace_state.is_some_and(NamespaceState::is_retired) {
         drop(w);
@@ -1891,6 +1960,14 @@ async fn run_create_fulltext_index(
                 .into_response(),
         };
     }
+    if let Some(rejection) = write_intake_rejection(writer_health) {
+        return ObservedQuery {
+            kind: None,
+            ok: false,
+            elapsed: started.elapsed(),
+            response: rejection,
+        };
+    }
     let mut w = writer.lock().await;
     if namespace_state.is_some_and(NamespaceState::is_retired) {
         drop(w);
@@ -2004,6 +2081,14 @@ async fn run_drop_vector_index(
                 }),
             )
                 .into_response(),
+        };
+    }
+    if let Some(rejection) = write_intake_rejection(writer_health) {
+        return ObservedQuery {
+            kind: None,
+            ok: false,
+            elapsed: started.elapsed(),
+            response: rejection,
         };
     }
     let mut w = writer.lock().await;
@@ -2121,6 +2206,14 @@ async fn run_drop_fulltext_index(
                 }),
             )
                 .into_response(),
+        };
+    }
+    if let Some(rejection) = write_intake_rejection(writer_health) {
+        return ObservedQuery {
+            kind: None,
+            ok: false,
+            elapsed: started.elapsed(),
+            response: rejection,
         };
     }
     let mut w = writer.lock().await;
@@ -2261,6 +2354,14 @@ async fn run_create_property_ddl(
                 }),
             )
                 .into_response(),
+        };
+    }
+    if let Some(rejection) = write_intake_rejection(writer_health) {
+        return ObservedQuery {
+            kind: None,
+            ok: false,
+            elapsed: started.elapsed(),
+            response: rejection,
         };
     }
     let mut w = writer.lock().await;
@@ -2565,6 +2666,14 @@ async fn run_cypher(state: &AppState, req: &CypherRequest, principal: &Principal
                     .into_response(),
             };
         }
+        if let Some(rejection) = write_intake_rejection(&state.writer_health) {
+            return ObservedQuery {
+                kind: Some(QueryKind::Write),
+                ok: false,
+                elapsed: started.elapsed(),
+                response: rejection,
+            };
+        }
         let Some(mut writer) = state.lock_writer_bounded(WriterLockKind::Http).await else {
             return ObservedQuery {
                 kind: Some(QueryKind::Write),
@@ -2703,12 +2812,41 @@ async fn admin_flush(
     run_admin_flush(state).await
 }
 
+/// Bound for the admin-flush waits (the process-wide flush permit and the
+/// writer mutex). This route is excluded from the request timeout, so an
+/// unbounded wait pins one global HTTP concurrency slot per queued client —
+/// enough stuck clients exhaust the cap and starve reads process-wide (the
+/// disk-full field outage, item 40). A 503 keeps the slot economy honest.
+const ADMIN_FLUSH_WAIT: Duration = Duration::from_secs(30);
+
+fn admin_flush_busy_response() -> Response {
+    (
+        StatusCode::SERVICE_UNAVAILABLE,
+        Json(ErrorBody {
+            error: "another flush is already running; retry shortly".into(),
+        }),
+    )
+        .into_response()
+}
+
 async fn run_admin_flush(state: AppState) -> Response {
-    let flush_permit = state.memory.admin_flush_permit().await;
-    let mut w = state.writer.lock().await;
+    let Ok(flush_permit) =
+        tokio::time::timeout(ADMIN_FLUSH_WAIT, state.memory.admin_flush_permit()).await
+    else {
+        return admin_flush_busy_response();
+    };
+    let bound = if state.writer_lock_timeout.is_zero() {
+        ADMIN_FLUSH_WAIT
+    } else {
+        state.writer_lock_timeout
+    };
+    let Some(mut w) = lock_writer_bounded(&state.writer, bound).await else {
+        return writer_busy_response();
+    };
     let schema = w.snapshot().manifest().manifest.schema.clone();
     match w.flush(schema).await {
         Ok(outcome) => {
+            state.writer_health.clear_persistence_degraded();
             state.snapshot.store(w.owned_snapshot());
             state
                 .memtable_bytes_gauge
@@ -2738,6 +2876,13 @@ async fn run_admin_flush(state: AppState) -> Response {
                 &e,
             )
             .await;
+            if e.is_local_persistence() {
+                let reason = persistence_degraded_reason(&e);
+                state
+                    .writer_health
+                    .mark_persistence_degraded(reason.clone());
+                return persistence_degraded_response(&reason);
+            }
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(ErrorBody {
@@ -3119,6 +3264,14 @@ async fn run_cypher_multi(
                     .into_response(),
             };
         }
+        if let Some(rejection) = write_intake_rejection(&ns_state.writer_health) {
+            return ObservedQuery {
+                kind: Some(QueryKind::Write),
+                ok: false,
+                elapsed: started.elapsed(),
+                response: rejection,
+            };
+        }
         let lock_started = std::time::Instant::now();
         let writer = lock_writer_bounded(&ns_state.writer, shared.writer_lock_timeout).await;
         shared.metrics.observe_writer_lock(
@@ -3273,7 +3426,11 @@ async fn dispatch_admin_flush_multi(
 }
 
 async fn run_admin_flush_multi(shared: SharedAppState, namespace: String) -> Response {
-    let flush_permit = shared.memory.admin_flush_permit().await;
+    let Ok(flush_permit) =
+        tokio::time::timeout(ADMIN_FLUSH_WAIT, shared.memory.admin_flush_permit()).await
+    else {
+        return admin_flush_busy_response();
+    };
     // Refresh the gauge because this route intentionally bypasses query
     // admission. At the hard limit, only an already-open namespace can own a
     // memtable worth flushing; recovering a cold one would allocate memory
@@ -3309,7 +3466,14 @@ async fn run_admin_flush_multi(shared: SharedAppState, namespace: String) -> Res
             }
         }
     };
-    let mut w = ns_state.writer.lock().await;
+    let bound = if shared.writer_lock_timeout.is_zero() {
+        ADMIN_FLUSH_WAIT
+    } else {
+        shared.writer_lock_timeout
+    };
+    let Some(mut w) = lock_writer_bounded(&ns_state.writer, bound).await else {
+        return writer_busy_response();
+    };
     // Same post-lock incarnation check as normal writes and schema DDL.
     if ns_state.is_retired() {
         drop(w);
@@ -3318,6 +3482,7 @@ async fn run_admin_flush_multi(shared: SharedAppState, namespace: String) -> Res
     let schema = w.snapshot().manifest().manifest.schema.clone();
     match w.flush(schema).await {
         Ok(outcome) => {
+            ns_state.writer_health.clear_persistence_degraded();
             ns_state.snapshot.store(w.owned_snapshot());
             let response = FlushResponse {
                 ssts_written: outcome.ssts_written,
@@ -3340,6 +3505,13 @@ async fn run_admin_flush_multi(shared: SharedAppState, namespace: String) -> Res
                     &e,
                 )
                 .await;
+            }
+            if e.is_local_persistence() {
+                let reason = persistence_degraded_reason(&e);
+                ns_state
+                    .writer_health
+                    .mark_persistence_degraded(reason.clone());
+                return persistence_degraded_response(&reason);
             }
             (
                 StatusCode::INTERNAL_SERVER_ERROR,

--- a/crates/namidb-server/src/recovery.rs
+++ b/crates/namidb-server/src/recovery.rs
@@ -35,6 +35,15 @@ const REOPEN_BACKOFF: Duration = Duration::from_millis(50);
 #[derive(Debug, Default)]
 pub struct WriterHealth {
     degraded: std::sync::Mutex<Option<String>>,
+    /// Local-persistence failure (spool disk full/unwritable during flush).
+    /// Kept separate from `degraded`: that slot is owned by the
+    /// fence-probe/commit-recovery machinery and its prefix-matching clear
+    /// logic, while this one is set and cleared strictly by flush outcomes.
+    /// While set, write intake is rejected with a typed error (the memtable
+    /// cannot drain, so accepting writes only grows an unbounded buffer and
+    /// turns into "writer is busy" confusion); reads keep serving the last
+    /// committed snapshot. It self-clears on the first successful flush.
+    persistence: std::sync::Mutex<Option<String>>,
 }
 
 impl WriterHealth {
@@ -43,11 +52,32 @@ impl WriterHealth {
     }
 
     /// The failure keeping the writer degraded, or `None` when healthy.
+    /// A local-persistence failure reports here too so `/v0/health` and
+    /// readiness surface it without a second field.
     pub fn degraded_reason(&self) -> Option<String> {
         self.degraded
             .lock()
             .expect("writer health poisoned")
             .clone()
+            .or_else(|| self.persistence_degraded_reason())
+    }
+
+    /// The local-persistence failure currently rejecting write intake, or
+    /// `None`. Write handlers consult this before queueing on the writer
+    /// mutex; reads never consult it.
+    pub fn persistence_degraded_reason(&self) -> Option<String> {
+        self.persistence
+            .lock()
+            .expect("writer health poisoned")
+            .clone()
+    }
+
+    pub(crate) fn mark_persistence_degraded(&self, reason: String) {
+        *self.persistence.lock().expect("writer health poisoned") = Some(reason);
+    }
+
+    pub(crate) fn clear_persistence_degraded(&self) {
+        *self.persistence.lock().expect("writer health poisoned") = None;
     }
 
     /// `"ok"` / `"degraded"` — the `writer` field of the health payload.

--- a/crates/namidb-server/src/registry.rs
+++ b/crates/namidb-server/src/registry.rs
@@ -295,12 +295,18 @@ impl NamespaceRegistry {
                 let mut tick = tokio::time::interval(interval);
                 tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
                 tick.tick().await; // first tick fires immediately; skip
+                                   // Back off after a local-persistence flush failure — see the
+                                   // single-tenant loop and `FLUSH_FAILURE_RETRY_BACKOFF`.
+                let mut retry_after: Option<Instant> = None;
                 loop {
                     tokio::select! {
                         biased;
                         _ = cancel.wait_for(|evicted| *evicted) => break,
                         _ = tick.tick() => {}
                         _ = s.flush_notify.notified() => {}
+                    }
+                    if retry_after.is_some_and(|at| Instant::now() < at) {
+                        continue;
                     }
                     // Flush under the writer lock, then only enqueue a
                     // trigger when the L0 high-water mark trips. The
@@ -325,11 +331,20 @@ impl NamespaceRegistry {
                         let schema = w.snapshot().manifest().manifest.schema.clone();
                         match w.flush(schema.clone()).await {
                             Ok(_) => {
+                                retry_after = None;
+                                s.writer_health.clear_persistence_degraded();
                                 s.snapshot.store(w.owned_snapshot());
                                 l0_trigger > 0 && w.max_l0_bucket_len() >= l0_trigger
                             }
                             Err(e) => {
                                 error!(namespace = %ns, error = %e, "periodic flush failed");
+                                if e.is_local_persistence() {
+                                    s.writer_health.mark_persistence_degraded(
+                                        crate::persistence_degraded_reason(&e),
+                                    );
+                                    retry_after =
+                                        Some(Instant::now() + crate::FLUSH_FAILURE_RETRY_BACKOFF);
+                                }
                                 // A fenced/poisoned writer would fail every later
                                 // flush AND every write on this namespace; reopen
                                 // it under the lock we already hold.

--- a/crates/namidb-server/tests/disk_full_degraded.rs
+++ b/crates/namidb-server/tests/disk_full_degraded.rs
@@ -1,0 +1,163 @@
+//! Item 40 (25 TB readiness), server half: a disk-full flush must degrade
+//! the namespace into read-only with a typed error instead of wedging it.
+//!
+//! Contract pinned here, over the real HTTP surface:
+//! 1. A flush that fails on local persistence answers 507 (not 500) and
+//!    marks the namespace persistence-degraded.
+//! 2. While degraded: writes are rejected 507 with the reason BEFORE
+//!    queueing on the writer mutex; reads keep serving every acknowledged
+//!    row; `/v0/health` reports the writer degraded with the reason.
+//! 3. After the disk condition clears, a flush retry succeeds, clears the
+//!    degraded state, and writes resume — no restart, nothing lost.
+//!
+//! This file must stay a single-test integration binary: it mutates the
+//! process-global `NAMIDB_SPOOL_DIR`.
+
+use std::time::Duration;
+
+use tokio::net::TcpStream;
+
+const NS: &str = "disk-full-degraded";
+const TOKEN: &str = "test-token";
+
+async fn boot() -> String {
+    let http_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let http_addr = http_listener.local_addr().unwrap();
+    drop(http_listener);
+    let config = namidb_server::Config {
+        store_uri: format!("memory://{NS}"),
+        listen: http_addr,
+        auth_token: Some(TOKEN.into()),
+        auth_tokens_file: None,
+        #[cfg(feature = "jwt")]
+        jwt: None,
+        #[cfg(feature = "pdp")]
+        pdp_url: None,
+        // No background flush: the test drives flushes via /v0/admin/flush
+        // so every transition is deterministic.
+        flush_interval: Duration::ZERO,
+        compaction_interval: Duration::ZERO,
+        sweep_min_age: Duration::ZERO,
+        sweep_delete: false,
+        bolt_listen: None,
+        bolt_max_message_bytes: 64 << 20,
+        bolt_tx_timeout: Duration::ZERO,
+        query_timeout: Duration::from_secs(30),
+        write_timeout: Duration::from_secs(30),
+        query_row_cap: 0,
+        compaction_l0_trigger: 0,
+        write_stall_l0: 0,
+        write_stall_delay: Duration::ZERO,
+        memtable_flush_bytes: 0,
+        memtable_stall_bytes: 0,
+        writer_lock_timeout: Duration::from_secs(5),
+        tls_cert: None,
+        tls_key: None,
+        slow_query_threshold: Duration::ZERO,
+        multi_tenant: false,
+        default_namespace: NS.to_string(),
+        max_namespaces: 100,
+        namespace_idle_timeout: Duration::from_secs(3600),
+    };
+    tokio::spawn(async move {
+        if let Err(e) = namidb_server::run(config).await {
+            eprintln!("server exited: {e}");
+        }
+    });
+    for _ in 0..100 {
+        if TcpStream::connect(http_addr).await.is_ok() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    format!("http://{http_addr}")
+}
+
+async fn cypher(base: &str, query: &str) -> (u16, String) {
+    let response = reqwest::Client::new()
+        .post(format!("{base}/v0/cypher"))
+        .bearer_auth(TOKEN)
+        .json(&serde_json::json!({ "query": query }))
+        .send()
+        .await
+        .unwrap();
+    let status = response.status().as_u16();
+    (status, response.text().await.unwrap())
+}
+
+async fn admin_flush(base: &str) -> (u16, String) {
+    let response = reqwest::Client::new()
+        .post(format!("{base}/v0/admin/flush"))
+        .bearer_auth(TOKEN)
+        .send()
+        .await
+        .unwrap();
+    let status = response.status().as_u16();
+    (status, response.text().await.unwrap())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn disk_full_degrades_to_read_only_and_self_heals() {
+    let base = boot().await;
+
+    // Healthy intake.
+    let (status, _) = cypher(&base, "CREATE (:Doc {k: 'antes'}) RETURN 1 AS ok").await;
+    assert_eq!(status, 200);
+
+    // Disk goes bad: the flush must fail typed, not wedge.
+    std::env::set_var("NAMIDB_SPOOL_DIR", "/nonexistent/namidb-disk-full-test");
+    let (status, body) = admin_flush(&base).await;
+    assert_eq!(
+        status, 507,
+        "flush on a broken spool must answer 507: {body}"
+    );
+    assert!(body.contains("namespace degraded"), "typed body: {body}");
+
+    // Writes: typed 507 with the reason, fast (no writer-mutex queueing).
+    let (status, body) = cypher(&base, "CREATE (:Doc {k: 'durante'}) RETURN 1 AS ok").await;
+    assert_eq!(status, 507, "writes while degraded must answer 507: {body}");
+    assert!(body.contains("namespace degraded"), "typed body: {body}");
+
+    // Reads: keep serving the acknowledged state.
+    let (status, body) = cypher(&base, "MATCH (d:Doc) RETURN count(d) AS c").await;
+    assert_eq!(
+        status, 200,
+        "reads must keep serving while degraded: {body}"
+    );
+    assert!(body.contains("\"c\":1"), "read must see the row: {body}");
+
+    // Health surfaces the reason.
+    let health = reqwest::Client::new()
+        .get(format!("{base}/v0/health"))
+        .bearer_auth(TOKEN)
+        .send()
+        .await
+        .unwrap();
+    let health_status = health.status().as_u16();
+    let health_body = health.text().await.unwrap();
+    assert_eq!(health_status, 503, "health must degrade: {health_body}");
+    assert!(
+        health_body.contains("flush failed on local persistence"),
+        "health must carry the reason: {health_body}"
+    );
+
+    // Disk recovers: the retry clears the state without a restart.
+    let spool = tempfile::tempdir().unwrap();
+    std::env::set_var("NAMIDB_SPOOL_DIR", spool.path());
+    let (status, body) = admin_flush(&base).await;
+    assert_eq!(status, 200, "flush retry must succeed: {body}");
+
+    let (status, body) = cypher(&base, "CREATE (:Doc {k: 'despues'}) RETURN 1 AS ok").await;
+    assert_eq!(status, 200, "writes must resume after recovery: {body}");
+    let (status, body) = cypher(&base, "MATCH (d:Doc) RETURN count(d) AS c").await;
+    assert_eq!(status, 200);
+    assert!(body.contains("\"c\":2"), "both rows must exist: {body}");
+
+    let health = reqwest::Client::new()
+        .get(format!("{base}/v0/health"))
+        .bearer_auth(TOKEN)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(health.status().as_u16(), 200, "health must clear");
+}

--- a/crates/namidb-storage/src/error.rs
+++ b/crates/namidb-storage/src/error.rs
@@ -173,4 +173,16 @@ impl Error {
     pub fn requires_writer_reopen(&self) -> bool {
         matches!(self, Error::Fenced { .. } | Error::ManifestCommitCas { .. })
     }
+
+    /// True when the failure is machine-local persistence (spool/scratch
+    /// disk I/O — disk full, unwritable spool directory) rather than the
+    /// object store or a logical error. A flush that fails this way will
+    /// fail identically on every immediate retry: the O(corpus) build
+    /// grinds the same full disk while holding the writer lock, starving
+    /// every write into "writer is busy". Servers should treat it as a
+    /// degrade-writes-keep-serving-reads condition and back off the retry
+    /// cadence until the local condition clears.
+    pub fn is_local_persistence(&self) -> bool {
+        matches!(self, Error::Io(_))
+    }
 }

--- a/crates/namidb-storage/src/flush.rs
+++ b/crates/namidb-storage/src/flush.rs
@@ -395,14 +395,39 @@ pub async fn flush(
     })
 }
 
+/// How long a flush may wait for the process-wide build gate before giving
+/// up. The permit lives inside an unabortable `spawn_blocking` closure, so a
+/// build wedged on pathological local I/O (a full, thrashing spool disk)
+/// holds the gate with no owner visible to the async side; an unbounded
+/// acquire here would then park every later flush — in every namespace —
+/// while it holds its writer mutex, freezing all writes process-wide until a
+/// restart. Bounding the wait converts that permanent wedge into a failed
+/// flush the caller can log, classify, and retry.
+fn flush_build_gate_timeout() -> std::time::Duration {
+    std::env::var("NAMIDB_FLUSH_BUILD_GATE_TIMEOUT_SECS")
+        .ok()
+        .and_then(|raw| raw.parse::<u64>().ok())
+        .filter(|secs| *secs > 0)
+        .map(std::time::Duration::from_secs)
+        .unwrap_or(std::time::Duration::from_secs(600))
+}
+
 pub(crate) async fn run_flush_build<T, F>(build: F) -> Result<T>
 where
     T: Send + 'static,
     F: FnOnce() -> Result<T> + Send + 'static,
 {
-    let permit = FLUSH_BUILD_GATE
-        .acquire()
+    let wait = flush_build_gate_timeout();
+    let permit = tokio::time::timeout(wait, FLUSH_BUILD_GATE.acquire())
         .await
+        .map_err(|_| {
+            Error::precondition(format!(
+                "flush build gate saturated for {}s: another corpus-sized \
+                 build is still running (possibly wedged on local spool I/O); \
+                 this flush attempt is abandoned and will be retried",
+                wait.as_secs()
+            ))
+        })?
         .map_err(|_| Error::invariant("flush SST build gate closed"))?;
     tokio::task::spawn_blocking(move || {
         let _permit = permit;

--- a/crates/namidb-storage/src/sst/nodes.rs
+++ b/crates/namidb-storage/src/sst/nodes.rs
@@ -233,8 +233,12 @@ impl NodeSstWriter {
 
         let schema = node_arrow_schema(&label);
         let writer_props = build_writer_properties(&options);
-        let spool = crate::sst::paged_index::create_spool_file()
-            .map_err(|e| Error::invariant(format!("node SST spool create: {e}")))?;
+        let spool = crate::sst::paged_index::create_spool_file().map_err(|e| {
+            Error::Io(std::io::Error::new(
+                e.kind(),
+                format!("node SST spool create: {e}"),
+            ))
+        })?;
         let inner = ArrowWriter::try_new(spool, schema.clone(), Some(writer_props))
             .map_err(|e| Error::invariant(format!("parquet writer init: {e}")))?;
 
@@ -377,20 +381,31 @@ impl NodeSstWriter {
             .inner
             .into_inner()
             .map_err(|e| Error::invariant(format!("parquet close: {e}")))?;
-        spool
-            .flush()
-            .map_err(|e| Error::invariant(format!("node SST spool flush: {e}")))?;
+        spool.flush().map_err(|e| {
+            Error::Io(std::io::Error::new(
+                e.kind(),
+                format!("node SST spool flush: {e}"),
+            ))
+        })?;
         // Make the spool reclaimable before the immutable mapping is read by
         // property-stat collection and object upload. Merely flushing the
         // `File` exposes the bytes but may leave a corpus-sized dirty page
         // cache charged to the process cgroup on a slow disk. It also defers
         // delayed-allocation failures until after the SST is being published.
-        spool
-            .sync_data()
-            .map_err(|e| Error::invariant(format!("node SST spool sync: {e}")))?;
+        spool.sync_data().map_err(|e| {
+            Error::Io(std::io::Error::new(
+                e.kind(),
+                format!("node SST spool sync: {e}"),
+            ))
+        })?;
         let body_len_u64 = spool
             .metadata()
-            .map_err(|e| Error::invariant(format!("node SST spool metadata: {e}")))?
+            .map_err(|e| {
+                Error::Io(std::io::Error::new(
+                    e.kind(),
+                    format!("node SST spool metadata: {e}"),
+                ))
+            })?
             .len();
         if body_len_u64 == 0 {
             return Err(Error::invariant(
@@ -405,10 +420,12 @@ impl NodeSstWriter {
         // the file handle is dropped, and `Bytes::from_owner` keeps it alive
         // for every clone sent through the existing upload/read APIs.
         let mapped = unsafe {
-            MmapOptions::new()
-                .len(body_len)
-                .map(&spool)
-                .map_err(|e| Error::invariant(format!("node SST spool mmap: {e}")))?
+            MmapOptions::new().len(body_len).map(&spool).map_err(|e| {
+                Error::Io(std::io::Error::new(
+                    e.kind(),
+                    format!("node SST spool mmap: {e}"),
+                ))
+            })?
         };
         if mapped.len() != body_len {
             return Err(Error::invariant(

--- a/crates/namidb-storage/tests/flush_spool_failure.rs
+++ b/crates/namidb-storage/tests/flush_spool_failure.rs
@@ -1,0 +1,108 @@
+//! Item 40 (25 TB readiness), storage half: a flush that fails on LOCAL
+//! persistence (unwritable/full spool disk) must be a clean, recoverable
+//! error — writer not poisoned, memtable restored so reads keep serving
+//! every acknowledged row, later commits still accepted — and a retry after
+//! the disk clears must succeed losslessly.
+//!
+//! This file must stay a single-test integration binary: it mutates the
+//! process-global `NAMIDB_SPOOL_DIR`, which every concurrent flush in the
+//! same process would observe. As its own test binary it owns the process.
+
+use std::collections::BTreeMap;
+
+use namidb_core::id::NodeId;
+use namidb_core::schema::{DataType, LabelDef, PropertyDef, SchemaBuilder};
+use namidb_core::value::Value;
+use namidb_storage::{NodeWriteRecord, WriterSession};
+
+fn schema() -> namidb_core::schema::Schema {
+    SchemaBuilder::new()
+        .label(LabelDef {
+            name: "Person".into(),
+            properties: vec![PropertyDef::new("name", DataType::Utf8, false)
+                .unwrap()
+                .with_unique(true)],
+        })
+        .unwrap()
+        .build()
+}
+
+fn upsert(writer: &mut WriterSession, name: &str) {
+    let mut props: BTreeMap<String, Value> = BTreeMap::new();
+    props.insert("name".into(), Value::Str(name.into()));
+    writer
+        .upsert_node(
+            "Person",
+            NodeId::new(),
+            &NodeWriteRecord {
+                properties: props,
+                schema_version: 1,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+}
+
+async fn person_found(writer: &WriterSession, name: &str) -> bool {
+    writer
+        .snapshot()
+        .lookup_node_by_property("Person", "name", name)
+        .await
+        .unwrap()
+        .is_some()
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn spool_failure_is_recoverable_and_lossless() {
+    let (store, paths) = namidb_storage::parse_uri("memory://spool-fail").unwrap();
+    let mut writer = WriterSession::open(store, paths).await.unwrap();
+    for i in 0..200 {
+        upsert(&mut writer, &format!("persona-{i:03}"));
+    }
+    writer.commit_batch().await.unwrap();
+    assert!(person_found(&writer, "persona-007").await);
+    let staged_bytes = writer.memtable_bytes();
+    assert!(staged_bytes > 0);
+
+    // Break the spool: every flush build now fails opening scratch files.
+    std::env::set_var("NAMIDB_SPOOL_DIR", "/nonexistent/namidb-spool-fail-test");
+    let err = writer
+        .flush(schema())
+        .await
+        .expect_err("flush must fail with the spool unwritable");
+    assert!(
+        err.is_local_persistence(),
+        "spool failure must classify as local persistence, got: {err}"
+    );
+    assert!(
+        !writer.is_poisoned(),
+        "a local-persistence flush failure must not poison the session"
+    );
+    assert_eq!(
+        writer.memtable_bytes(),
+        staged_bytes,
+        "the frozen memtable must be restored intact after the failed flush"
+    );
+    assert!(
+        person_found(&writer, "persona-007").await,
+        "reads must keep serving acknowledged rows after the failed flush"
+    );
+
+    // The writer still accepts and commits new work while unable to flush.
+    upsert(&mut writer, "persona-tardia");
+    writer.commit_batch().await.unwrap();
+    assert!(person_found(&writer, "persona-tardia").await);
+
+    // Clear the disk condition: the retry must succeed and lose nothing.
+    let spool = tempfile::tempdir().unwrap();
+    std::env::set_var("NAMIDB_SPOOL_DIR", spool.path());
+    let outcome = writer.flush(schema()).await.expect("retry flush succeeds");
+    assert!(outcome.ssts_written >= 1, "the retry must publish SSTs");
+    assert_eq!(writer.memtable_bytes(), 0, "the memtable must drain");
+    for name in ["persona-007", "persona-199", "persona-tardia"] {
+        assert!(
+            person_found(&writer, name).await,
+            "{name} must survive into the SSTs"
+        );
+    }
+}

--- a/docs/testing/25tb-readiness.md
+++ b/docs/testing/25tb-readiness.md
@@ -357,7 +357,7 @@ the physical access path chosen at execution (or at minimum a
 the `namidb_search_route_total{route}` pattern that already exists for
 search.
 
-### 40. [resilience, blocker, target 2.1.3] Disk-full during flush permanently wedges the namespace: writer lock never released, reads queue behind the guard, no error, no timeout — only a restart recovers.
+### 40. [DONE — resilience, lands in 2.1.3] Disk-full during flush permanently wedges the namespace: writer lock never released, reads queue behind the guard, no error, no timeout — only a restart recovers.
 
 Reported reproduced twice in field validation with a full spool disk.
 The flush error path must (1) release the writer lock on ANY failure,
@@ -370,6 +370,38 @@ FaultStore/ENOSPC injection test (tmpfs with a size cap) pinning all
 three behaviors. This is the most serious resilience finding of the
 round; the production mitigation until fixed is disk alerting
 (node_exporter) plus the bulk deadline's clean 408.
+
+**Resolution (2026-08-17):** the wedge was a four-link chain, each link now
+cut. (1) The flush's local spool I/O errors were wrapped into
+`Error::invariant`, hiding their nature — they now stay `Error::Io` and a
+new `Error::is_local_persistence()` classifies them. (2) On such a failure
+the periodic flush loops (single- and multi-tenant) mark the namespace
+persistence-degraded in `WriterHealth` and back off retries 30 s
+(`FLUSH_FAILURE_RETRY_BACKOFF`) instead of immediately re-running the doomed
+O(corpus) build under the writer mutex; the first successful flush clears
+the state. (3) While degraded, every write intake point — HTTP write, all
+five schema-DDL handlers, all six Bolt write sites, Bolt BEGIN — rejects
+with a typed 507 `namespace degraded: …` (Bolt: a non-retriable failure
+carrying the reason) BEFORE queueing on the writer mutex, and reads are
+never gated; `/v0/health` carries the reason. (4) The starvation vectors
+that let the outage swallow reads are bounded: `/v0/admin/flush` now bounds
+both its process-wide permit wait and its writer-lock wait (30 s → 503)
+instead of pinning global HTTP concurrency slots on a route excluded from
+every timeout, and the process-wide `FLUSH_BUILD_GATE` acquire — which a
+detached, unabortable spool build could trap forever — is bounded at 10 min
+(`NAMIDB_FLUSH_BUILD_GATE_TIMEOUT_SECS`). Pinned by
+`namidb-storage/tests/flush_spool_failure.rs` (failed flush: Io-classified,
+session not poisoned, memtable restored byte-exact, later commits accepted,
+retry lossless) and `namidb-server/tests/disk_full_degraded.rs` (real HTTP:
+flush on broken spool → 507 + degraded; writes 507 typed, reads 200,
+health 503 with reason; after the disk clears one flush retry restores
+writes with nothing lost — no restart). Both are single-test integration
+binaries because they mutate the process-global `NAMIDB_SPOOL_DIR`.
+Remaining (recorded, not blocking): each backoff-spaced retry still holds
+the writer mutex for its build duration; the multi-tenant registry eviction
+still waits unbounded on the evicted writer while holding the sessions
+lock (short now that the mutex frees); moving the flush build off-lock like
+compaction's prepare stays future work.
 
 ### 41. [performance, target 2.2] Concurrent large scans collapse aggregate throughput (~660 rps mixed ceiling; pathological control: ~2 rps aggregate, 8 GB RSS on parallel 1M-row scans without index).
 


### PR DESCRIPTION
Item 40 of docs/testing/25tb-readiness.md — the most serious resilience finding from the post-2.1.2 field validation (reproduced twice with a full spool disk): a disk-full flush permanently wedged the namespace — writes into infinite \`writer is busy\`, reads eventually queueing forever, no error, no timeout, restart-only recovery.

## The four-link chain (all cut)

1. **Misclassified errors.** Local spool I/O failures were wrapped into \`Error::invariant\`, hiding that they are machine-local persistence problems. They now stay \`Error::Io\`, and \`Error::is_local_persistence()\` names the class.
2. **Doomed retries under the mutex.** The flush loops re-ran the failing O(corpus) build on every tick while holding the writer mutex — saturating it forever. They now mark the namespace **persistence-degraded** (\`WriterHealth\`) and back off 30 s between retries; the first successful flush clears the state (self-healing, no restart).
3. **Writes queueing into opacity.** Every write intake point — HTTP write, the five schema-DDL handlers, the six Bolt write sites, and Bolt \`BEGIN\` — now rejects with a **typed 507** \`namespace degraded: <reason>\` *before* queueing on the writer mutex. Reads are never gated. \`/v0/health\` carries the reason.
4. **Read starvation via slot exhaustion.** \`/v0/admin/flush\` (excluded from every request timeout) waited unbounded on the process-wide flush permit and the writer mutex, pinning global HTTP concurrency slots (cap 1024) until even reads and \`/v0/livez\` parked in \`poll_ready\`. Both waits are now bounded (30 s → 503), and the process-wide \`FLUSH_BUILD_GATE\` acquire — whose permit a detached, unabortable spool build could trap forever — is bounded at 600 s (\`NAMIDB_FLUSH_BUILD_GATE_TIMEOUT_SECS\`).

## Tests

- \`namidb-storage/tests/flush_spool_failure.rs\`: failed flush is Io-classified, session not poisoned, memtable restored byte-exact, later commits accepted, retry lossless into SSTs.
- \`namidb-server/tests/disk_full_degraded.rs\` (real HTTP surface): flush on a broken spool → 507 + degraded; writes 507 with reason; reads 200 serving acknowledged rows; health 503 with reason; after the disk clears, one flush retry restores writes with nothing lost.
- Both are single-test integration binaries (own process) because they mutate the process-global \`NAMIDB_SPOOL_DIR\`.
- Full suites green: namidb-storage 703 passed, namidb-server 127 passed, 0 failed. fmt + clippy \`-D warnings\` clean on default and all-features.

## Recorded follow-ups (not blocking)

Each backoff-spaced retry still holds the writer mutex for its build duration (moving the flush build off-lock like compaction's prepare is future work), and the multi-tenant registry eviction still waits unbounded on the evicted writer — short now that the mutex frees.