### PR TITLE
feat: property DDL triggers the compaction that materializes the index

### DIFF
--- a/crates/namidb-server/src/bolt.rs
+++ b/crates/namidb-server/src/bolt.rs
@@ -573,16 +573,31 @@ impl ServerBackend {
         drop(writer);
         let elapsed = started.elapsed();
         match result {
-            Ok(_) => RunObservation {
-                kind: Some(QueryKind::Write),
-                elapsed,
-                result: Ok(RunOutcome {
-                    fields: vec![],
-                    rows: vec![],
-                    statement_type: StatementType::Schema,
-                    counters: BTreeMap::new(),
-                }),
-            },
+            Ok(_) => {
+                // Materialize the new index on already-flushed SSTs now
+                // instead of waiting for the periodic tick — same rationale
+                // as the HTTP DDL path (item 38).
+                let _ = crate::maintenance::request_compaction(
+                    &self.state.compaction_scheduler,
+                    crate::metrics::CompactionTrigger::Ddl,
+                    &self.state.writer,
+                    &self.state.snapshot,
+                    &self.state.writer_health,
+                    &self.state.namespace,
+                    &self.state.metrics,
+                    None,
+                );
+                RunObservation {
+                    kind: Some(QueryKind::Write),
+                    elapsed,
+                    result: Ok(RunOutcome {
+                        fields: vec![],
+                        rows: vec![],
+                        statement_type: StatementType::Schema,
+                        counters: BTreeMap::new(),
+                    }),
+                }
+            }
             Err(e) => {
                 let is_user = matches!(
                     &e,

--- a/crates/namidb-server/src/lib.rs
+++ b/crates/namidb-server/src/lib.rs
@@ -2312,6 +2312,8 @@ async fn run_create_property_ddl(
     namespace: &str,
     namespace_state: Option<&NamespaceState>,
     authz: &Arc<dyn authz::AuthzHook>,
+    compaction_scheduler: &Arc<CompactionScheduler>,
+    metrics: &Arc<metrics::Metrics>,
     name: Option<&str>,
     label: &str,
     properties: &[String],
@@ -2384,17 +2386,37 @@ async fn run_create_property_ddl(
     drop(w);
     let elapsed = started.elapsed();
     match result {
-        Ok(_) => ObservedQuery {
-            kind: Some(QueryKind::Write),
-            ok: true,
-            elapsed,
-            response: Json(CypherResponse {
-                columns: vec![],
-                rows: vec![],
-                write_outcome: None,
-            })
-            .into_response(),
-        },
+        Ok(_) => {
+            // The schema commit alone makes `needs_compaction()` true for
+            // every node SST whose descriptors lack the posting sidecar the
+            // new index requires. Without this request, materialization
+            // waits for the next periodic tick — or never happens when
+            // periodic compaction is disabled — leaving the "index" at
+            // full-scan speed on already-loaded data (item 38). An
+            // IF NOT EXISTS no-op re-request is harmless: the pass gates on
+            // metadata and answers Noop.
+            let _ = request_compaction(
+                compaction_scheduler,
+                CompactionTrigger::Ddl,
+                writer,
+                snapshot,
+                writer_health,
+                namespace,
+                metrics,
+                None,
+            );
+            ObservedQuery {
+                kind: Some(QueryKind::Write),
+                ok: true,
+                elapsed,
+                response: Json(CypherResponse {
+                    columns: vec![],
+                    rows: vec![],
+                    write_outcome: None,
+                })
+                .into_response(),
+            }
+        }
         Err(e) => {
             // A pre-existing duplicate (constraint) is a user error (400); a
             // fence/lost CAS is a server condition (503).
@@ -2550,6 +2572,8 @@ async fn run_cypher(state: &AppState, req: &CypherRequest, principal: &Principal
             &state.namespace,
             None,
             &state.authz,
+            &state.compaction_scheduler,
+            &state.metrics,
             c.name.as_ref().map(|n| n.name.as_str()),
             &c.label.name,
             &properties,
@@ -2569,6 +2593,8 @@ async fn run_cypher(state: &AppState, req: &CypherRequest, principal: &Principal
             &state.namespace,
             None,
             &state.authz,
+            &state.compaction_scheduler,
+            &state.metrics,
             c.name.as_ref().map(|n| n.name.as_str()),
             &c.label.name,
             &properties,
@@ -3150,6 +3176,8 @@ async fn run_cypher_multi(
             &ns_state.namespace,
             Some(ns_state),
             &shared.authz,
+            &ns_state.compaction_scheduler,
+            &shared.metrics,
             c.name.as_ref().map(|n| n.name.as_str()),
             &c.label.name,
             &properties,
@@ -3169,6 +3197,8 @@ async fn run_cypher_multi(
             &ns_state.namespace,
             Some(ns_state),
             &shared.authz,
+            &ns_state.compaction_scheduler,
+            &shared.metrics,
             c.name.as_ref().map(|n| n.name.as_str()),
             &c.label.name,
             &properties,

--- a/crates/namidb-server/src/metrics.rs
+++ b/crates/namidb-server/src/metrics.rs
@@ -100,15 +100,20 @@ impl WriterLockKind {
 pub enum CompactionTrigger {
     Periodic = 0,
     Reactive = 1,
+    /// Requested by a successful property DDL so a new index materializes
+    /// on already-flushed SSTs immediately instead of waiting for the next
+    /// periodic tick (item 38 of the 25 TB readiness plan).
+    Ddl = 2,
 }
 
 impl CompactionTrigger {
-    const ALL: [Self; 2] = [Self::Periodic, Self::Reactive];
+    const ALL: [Self; 3] = [Self::Periodic, Self::Reactive, Self::Ddl];
 
     fn as_str(self) -> &'static str {
         match self {
             Self::Periodic => "periodic",
             Self::Reactive => "reactive",
+            Self::Ddl => "ddl",
         }
     }
 }

--- a/crates/namidb-server/tests/ddl_index_backfill.rs
+++ b/crates/namidb-server/tests/ddl_index_backfill.rs
@@ -1,0 +1,205 @@
+//! Item 38 (25 TB readiness): `CREATE CONSTRAINT` / `CREATE INDEX` on
+//! ALREADY-LOADED data must materialize the posting sidecars without
+//! waiting for the periodic compaction tick (or forever, when periodic
+//! compaction is disabled).
+//!
+//! The compaction planner has recognized "this SST predates the current
+//! indexed set" since 2.0.5 (`node_descriptor_needs_migration`); what was
+//! missing is the trigger at DDL time. This test disables every periodic
+//! maintenance loop so the ONLY thing that can rewrite the SSTs is the
+//! DDL-requested pass, then watches the manifest (via a second store handle
+//! on the same file:// directory) until the sidecars appear.
+
+use std::time::Duration;
+
+use namidb_storage::{ManifestStore, SstKind};
+use tokio::net::TcpStream;
+
+const NS: &str = "ddl-backfill";
+const TOKEN: &str = "test-token";
+
+async fn boot(store_uri: String) -> String {
+    let http_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let http_addr = http_listener.local_addr().unwrap();
+    drop(http_listener);
+    let config = namidb_server::Config {
+        store_uri,
+        listen: http_addr,
+        auth_token: Some(TOKEN.into()),
+        auth_tokens_file: None,
+        #[cfg(feature = "jwt")]
+        jwt: None,
+        #[cfg(feature = "pdp")]
+        pdp_url: None,
+        // Every periodic loop off: only the DDL trigger may compact.
+        flush_interval: Duration::ZERO,
+        compaction_interval: Duration::ZERO,
+        sweep_min_age: Duration::ZERO,
+        sweep_delete: false,
+        bolt_listen: None,
+        bolt_max_message_bytes: 64 << 20,
+        bolt_tx_timeout: Duration::ZERO,
+        query_timeout: Duration::from_secs(30),
+        write_timeout: Duration::from_secs(30),
+        query_row_cap: 0,
+        compaction_l0_trigger: 0,
+        write_stall_l0: 0,
+        write_stall_delay: Duration::ZERO,
+        memtable_flush_bytes: 0,
+        memtable_stall_bytes: 0,
+        writer_lock_timeout: Duration::from_secs(5),
+        tls_cert: None,
+        tls_key: None,
+        slow_query_threshold: Duration::ZERO,
+        multi_tenant: false,
+        default_namespace: NS.to_string(),
+        max_namespaces: 100,
+        namespace_idle_timeout: Duration::from_secs(3600),
+    };
+    tokio::spawn(async move {
+        if let Err(e) = namidb_server::run(config).await {
+            eprintln!("server exited: {e}");
+        }
+    });
+    for _ in 0..100 {
+        if TcpStream::connect(http_addr).await.is_ok() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    format!("http://{http_addr}")
+}
+
+async fn cypher(base: &str, query: &str) -> (u16, String) {
+    let response = reqwest::Client::new()
+        .post(format!("{base}/v0/cypher"))
+        .bearer_auth(TOKEN)
+        .json(&serde_json::json!({ "query": query }))
+        .send()
+        .await
+        .unwrap();
+    (response.status().as_u16(), response.text().await.unwrap())
+}
+
+/// For every Nodes SST in the current manifest: does each carry a complete
+/// equality posting index for `property`? (None when there are no node SSTs.)
+async fn all_node_ssts_cover(manifest_store: &ManifestStore, property: &str) -> Option<bool> {
+    let loaded = manifest_store.load_current().await.unwrap();
+    let node_descs: Vec<_> = loaded
+        .manifest
+        .ssts
+        .iter()
+        .filter(|d| d.kind == SstKind::Nodes)
+        .collect();
+    if node_descs.is_empty() {
+        return None;
+    }
+    Some(node_descs.iter().all(|d| {
+        d.equality_property_indices
+            .iter()
+            .any(|idx| idx.property == property && idx.mixed_type_complete)
+    }))
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn create_index_on_loaded_data_materializes_without_periodic_compaction() {
+    let dir = tempfile::tempdir().unwrap();
+    let store_uri = format!("file://{}?ns={NS}", dir.path().display());
+    let base = boot(store_uri.clone()).await;
+
+    // Load 300 rows across two string properties, then flush: the SSTs are
+    // born WITHOUT any posting sidecars (nothing is indexed yet).
+    for chunk in 0..3 {
+        let mut parts = Vec::new();
+        for i in 0..100 {
+            let n = chunk * 100 + i;
+            parts.push(format!(
+                "(:Person {{cedula: 'ced-{n:04}', ciudad: 'ciudad-{:02}'}})",
+                n % 20
+            ));
+        }
+        let (status, body) = cypher(&base, &format!("CREATE {}", parts.join(", "))).await;
+        assert_eq!(status, 200, "seed chunk: {body}");
+    }
+    let flush = reqwest::Client::new()
+        .post(format!("{base}/v0/admin/flush"))
+        .bearer_auth(TOKEN)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(flush.status().as_u16(), 200);
+
+    let (store, paths) = namidb_storage::parse_uri(&store_uri).unwrap();
+    let manifest_store = ManifestStore::new(store, paths);
+    assert_eq!(
+        all_node_ssts_cover(&manifest_store, "cedula").await,
+        Some(false),
+        "pre-DDL SSTs must not carry the sidecar (or the test proves nothing)"
+    );
+
+    // The DDL under test: a unique constraint and a plain index, on data
+    // that is already flushed. Each must answer immediately (metadata-only)
+    // and schedule the materializing pass itself.
+    let (status, body) = cypher(
+        &base,
+        "CREATE CONSTRAINT persona_cedula IF NOT EXISTS \
+         FOR (p:Person) REQUIRE p.cedula IS UNIQUE",
+    )
+    .await;
+    assert_eq!(status, 200, "constraint DDL: {body}");
+    let (status, body) = cypher(
+        &base,
+        "CREATE INDEX persona_ciudad IF NOT EXISTS FOR (p:Person) ON (p.ciudad)",
+    )
+    .await;
+    assert_eq!(status, 200, "index DDL: {body}");
+
+    // No periodic loops are running: only the DDL-triggered pass can do
+    // this. Poll the manifest from the outside until both sidecars exist.
+    let deadline = std::time::Instant::now() + Duration::from_secs(60);
+    loop {
+        let cedula = all_node_ssts_cover(&manifest_store, "cedula").await;
+        let ciudad = all_node_ssts_cover(&manifest_store, "ciudad").await;
+        if cedula == Some(true) && ciudad == Some(true) {
+            break;
+        }
+        assert!(
+            std::time::Instant::now() < deadline,
+            "the DDL-triggered compaction must materialize both sidecars; \
+             last state: cedula={cedula:?} ciudad={ciudad:?}"
+        );
+        tokio::time::sleep(Duration::from_millis(250)).await;
+    }
+
+    // The materialized index answers correctly through the query surface.
+    let (status, body) = cypher(
+        &base,
+        "MATCH (p:Person {cedula: 'ced-0123'}) RETURN p.ciudad AS ciudad",
+    )
+    .await;
+    assert_eq!(status, 200);
+    assert!(
+        body.contains("ciudad-03"),
+        "unique lookup must return the row: {body}"
+    );
+
+    // And the trigger is visible in metrics as its own kind.
+    let metrics = reqwest::Client::new()
+        .get(format!("{base}/v0/metrics"))
+        .bearer_auth(TOKEN)
+        .send()
+        .await
+        .unwrap()
+        .text()
+        .await
+        .unwrap();
+    let applied = metrics.lines().find(|l| {
+        l.contains("namidb_compactions_total")
+            && l.contains("trigger=\"ddl\"")
+            && l.contains("status=\"applied\"")
+    });
+    assert!(
+        applied.is_some_and(|l| !l.trim_end().ends_with(" 0")),
+        "an applied ddl-triggered compaction must be counted; got: {applied:?}"
+    );
+}

--- a/docs/testing/25tb-readiness.md
+++ b/docs/testing/25tb-readiness.md
@@ -329,7 +329,7 @@ any flush once the memtable passes the stall threshold — acceptable at
 ~20 s per flush, but a soak asserting an upper bound on write-outage
 windows during sustained load would pin it.
 
-### 38. [product, target 2.2] CREATE INDEX on already-loaded data has no effect until a flush/compaction rewrites the SSTs — there is no backfill or REINDEX.
+### 38. [DONE — product, lands in 2.1.3] CREATE INDEX on already-loaded data has no effect until a flush/compaction rewrites the SSTs — there is no backfill or REINDEX.
 
 Reported from field validation 2026-08-17 (twin-namespace experiment:
 index-before-load = sub-millisecond lookups; index-after-load = ~850 ms,
@@ -343,6 +343,32 @@ compaction of SSTs whose generation predates the DDL (the search-LSM
 already does exactly this via signature retirement — PR #133 — the graph
 side needs its twin), (c) an explicit `db.index.build()` procedure.
 Recommend (b): the machinery and the precedent both exist.
+
+**Resolution (2026-08-17):** option (b), and it turned out the heavy half
+already existed: since 2.0.5 the compaction planner treats a node SST
+whose descriptors lack a posting sidecar for a currently-indexed
+Utf8/Bool property as needing migration (`node_descriptor_needs_migration`,
+compact.rs) and will rewrite even a single fully-compacted L1 SST
+(`plan_node_bucket`) — the schema commit alone flips `needs_compaction()`
+to true. What was missing was the trigger: materialization waited for the
+periodic compaction tick (default 5 min) and never happened with periodic
+compaction disabled. Now every successful property DDL — HTTP
+CREATE CONSTRAINT / CREATE INDEX (single- and multi-tenant) and the Bolt
+twin — requests one compaction pass with a new `CompactionTrigger::Ddl`
+(visible as `namidb_compactions_total{trigger="ddl"}`); the scheduler's
+single-flight admission coalesces storms and an IF NOT EXISTS no-op
+re-request answers Noop from metadata. Pinned by
+`namidb-server/tests/ddl_index_backfill.rs`: with every periodic loop
+disabled, 300 flushed rows + CREATE CONSTRAINT + CREATE INDEX →
+both posting sidecars appear on every node SST (observed via a second
+store handle on the same file:// prefix, in under 2 s), the lookup
+answers through the query surface, and the ddl-trigger counter moves.
+Still true and now recorded here: postings only exist for
+Utf8/LargeUtf8/Bool properties (numeric equality stays scan-side — the
+type filter in `union_indexed_props`/`EqualitySidecarCollector`), and in
+the window between DDL and the pass finishing, one uncovered SST in
+scope silently disables the index for the whole lookup (no metric) —
+that observability gap is item 39's territory.
 
 ### 39. [observability, target 2.2] EXPLAIN shows NodeScan + Filter even when the posting index accelerates the scan at runtime.
 


### PR DESCRIPTION
Item 38 of docs/testing/25tb-readiness.md — field finding: `CREATE INDEX`/`CREATE CONSTRAINT` on already-loaded data never takes effect (twin-namespace experiment: index-before-load = sub-millisecond; index-after-load = ~850 ms, identical to no index).

## What was actually missing

Recon found the heavy machinery already shipped in 2.0.5: the compaction planner treats a node SST whose descriptors lack a posting sidecar for a currently-indexed Utf8/Bool property as needing migration, and rewrites even a single fully-compacted L1 SST (`plan_node_bucket` + `node_descriptor_needs_migration`). The DDL schema commit alone makes `needs_compaction()` true. **The only gap was the trigger**: materialization waited for the periodic tick (default 5 min) — and never happened with periodic compaction disabled or in embedded deployments.

## Change

Every successful property DDL — HTTP `CREATE CONSTRAINT`/`CREATE INDEX` (single- and multi-tenant) and the Bolt twin — now requests one compaction pass with a new `CompactionTrigger::Ddl` (third trigger kind, visible as `namidb_compactions_total{trigger="ddl"}`). The scheduler's existing single-flight admission coalesces storms; an `IF NOT EXISTS` no-op re-request gates on metadata and answers Noop.

## Test

`namidb-server/tests/ddl_index_backfill.rs`: with **every periodic loop disabled**, 300 flushed rows + both DDL forms → both posting sidecars appear on every node SST in under 2 s (verified by reading the manifest through a second store handle on the same `file://` prefix — descriptor-level witness, not timing), the lookup answers through the query surface, and the `trigger="ddl", status="applied"` counter moves. Full namidb-server suite: 128 passed, 0 failed; fmt + clippy clean on default and all-features.

## Recorded, out of scope

Postings only exist for Utf8/LargeUtf8/Bool properties (numeric equality stays scan-side — format-level work), and during the DDL→pass window one uncovered SST silently disables the index for the whole lookup with no metric; that observability gap is item 39's territory.