### PR TITLE
feat: EXPLAIN serves the plan with its physical route; property-lookup route telemetry

### DIFF
--- a/crates/namidb-query/src/parser/ast.rs
+++ b/crates/namidb-query/src/parser/ast.rs
@@ -17,8 +17,12 @@ use super::error::SourceSpan;
 
 /// A whole query — one or more single-queries joined by `UNION` / `UNION ALL`.
 ///
-/// - `explain`: user wrote `EXPLAIN <query>`. The executor honours it by
-/// returning the plan tree instead of executing.
+/// - `explain`: user wrote `EXPLAIN <query>`. The SERVER honours it
+/// (HTTP and Bolt): the optimized plan tree is rendered and returned —
+/// one row per line plus a `# route:` footer stating the physical
+/// access path per index lookup — and nothing executes. The embedded
+/// `execute*` functions do NOT consult this flag; a library caller
+/// renders via [`crate::plan::explain`] themselves.
 /// - `explain_verbose`: user wrote `EXPLAIN VERBOSE <query>`. Implies
 /// `explain`. The plan is rendered with per-operator cardinality
 /// estimates from the [`StatsCatalog`] (RFC-010).

--- a/crates/namidb-server/src/bolt.rs
+++ b/crates/namidb-server/src/bolt.rs
@@ -751,6 +751,26 @@ impl ServerBackend {
             );
         }
 
+        if parsed.explain {
+            let lines = crate::explain_plan_lines(&parsed, &plan, &owned, &catalog);
+            let rows = lines
+                .into_iter()
+                .map(|line| {
+                    namidb_query::Row::new().with("plan", namidb_query::RuntimeValue::String(line))
+                })
+                .collect();
+            return RunObservation {
+                kind: Some(QueryKind::Read),
+                elapsed: started.elapsed(),
+                result: Ok(RunOutcome {
+                    fields: vec!["plan".into()],
+                    rows,
+                    statement_type: StatementType::Read,
+                    counters: Default::default(),
+                }),
+            };
+        }
+
         if plan.contains_write() {
             // A read-only token may not write — reject before the writer lock.
             if let Some(err) = self.write_forbidden() {

--- a/crates/namidb-server/src/lib.rs
+++ b/crates/namidb-server/src/lib.rs
@@ -1409,6 +1409,123 @@ fn exec_error_classification(
 /// deliberately-unsupported feature surfaces as 400/`unsupported` instead of
 /// a bare 500. The `code` field is emitted only when classified, so existing
 /// clients that deserialize the body loosely see no change on plain 500s.
+/// Serve `EXPLAIN [RAW] [VERBOSE] <query>`: render the plan instead of
+/// executing. The AST has always promised this ("the executor honours it by
+/// returning the plan tree"), but the server previously ignored the prefix
+/// and silently EXECUTED the query — an `EXPLAIN CREATE ...` wrote data.
+/// Non-RAW forms render the plan the optimizer actually produced against
+/// the real manifest catalog, so index rewrites like `NodeByPropertyValue`
+/// are visible (the CLI's offline explain has an empty catalog and can
+/// never show them). A `# route:` footer then states the PHYSICAL access
+/// path for every index lookup in the plan: posting-sidecar coverage
+/// decides index-vs-scan at run time, and until item 39 that decision was
+/// observable only through `elapsed_ms`.
+fn explain_observation(
+    parsed: &namidb_query::Query,
+    plan: &namidb_query::LogicalPlan,
+    owned: &namidb_storage::OwnedSnapshot,
+    catalog: &StatsCatalog,
+    started: std::time::Instant,
+) -> ObservedQuery {
+    let rows = explain_plan_lines(parsed, plan, owned, catalog)
+        .into_iter()
+        .map(|line| {
+            let mut row = serde_json::Map::new();
+            row.insert("plan".into(), serde_json::Value::String(line));
+            row
+        })
+        .collect();
+    ObservedQuery {
+        kind: Some(QueryKind::Read),
+        ok: true,
+        elapsed: started.elapsed(),
+        response: Json(CypherResponse {
+            columns: vec!["plan".into()],
+            rows,
+            write_outcome: None,
+        })
+        .into_response(),
+    }
+}
+
+/// The rendered EXPLAIN lines (plan tree + `# route:` footer), shared by
+/// the HTTP and Bolt surfaces.
+pub(crate) fn explain_plan_lines(
+    parsed: &namidb_query::Query,
+    plan: &namidb_query::LogicalPlan,
+    owned: &namidb_storage::OwnedSnapshot,
+    catalog: &StatsCatalog,
+) -> Vec<String> {
+    let text = if parsed.explain_raw && parsed.explain_verbose {
+        namidb_query::explain_query_raw_verbose(parsed, catalog)
+            .unwrap_or_else(|e| format!("explain error: {e}"))
+    } else if parsed.explain_raw {
+        namidb_query::explain_query_raw(parsed).unwrap_or_else(|e| format!("explain error: {e}"))
+    } else if parsed.explain_verbose {
+        namidb_query::explain_verbose(plan, catalog)
+    } else {
+        namidb_query::explain(plan)
+    };
+    let mut lines: Vec<String> = text.lines().map(str::to_string).collect();
+    if !parsed.explain_raw {
+        let snapshot = owned.borrow();
+        collect_route_notes(plan, &snapshot, &mut lines);
+    }
+    lines
+}
+
+/// Append one `# route:` line per index-lookup operator in the plan.
+fn collect_route_notes(
+    plan: &namidb_query::LogicalPlan,
+    snapshot: &namidb_storage::Snapshot<'_>,
+    out: &mut Vec<String>,
+) {
+    if let namidb_query::LogicalPlan::NodeByPropertyValue {
+        label,
+        property,
+        value,
+        multi,
+        ..
+    } = plan
+    {
+        let shown = if label.is_empty() { "*" } else { label };
+        let kind = if *multi { "posting" } else { "unique" };
+        let numeric = matches!(
+            &value.kind,
+            namidb_query::parser::ast::ExpressionKind::Literal(
+                namidb_query::parser::ast::Literal::Integer(_)
+                    | namidb_query::parser::ast::Literal::Float(_)
+            )
+        );
+        let note = if numeric {
+            format!(
+                "# route: {shown}.{property} → scan \
+                 (numeric equality is not posting-indexed; only String/Bool are)"
+            )
+        } else {
+            let (covered, total) = snapshot.property_index_coverage(label, property);
+            if total == 0 {
+                format!("# route: {shown}.{property} → memtable ({kind} lookup; no SSTs in scope)")
+            } else if covered == total {
+                format!(
+                    "# route: {shown}.{property} → index \
+                     ({kind} lookup; posting sidecars {covered}/{total} SSTs)"
+                )
+            } else {
+                format!(
+                    "# route: {shown}.{property} → SCAN FALLBACK \
+                     (posting sidecars {covered}/{total} SSTs; \
+                     a compaction pass materializes the rest)"
+                )
+            }
+        };
+        out.push(note);
+    }
+    for child in plan.children() {
+        collect_route_notes(child, snapshot, out);
+    }
+}
+
 fn exec_failure_response(prefix: &str, e: &namidb_query::exec::ExecError) -> Response {
     let (status, code) = exec_error_classification(e);
     let error = format!("{prefix}: {e}");
@@ -2636,24 +2753,22 @@ async fn run_cypher(state: &AppState, req: &CypherRequest, principal: &Principal
 
     // Plan against the latest published snapshot — no writer lock yet.
     let owned = state.snapshot.load();
-    let plan = {
-        let catalog = state.catalog_for(&owned.manifest().manifest);
-        match build_plan(&parsed, &catalog) {
-            Ok(p) => p,
-            Err(e) => {
-                return ObservedQuery {
-                    kind: None,
-                    ok: false,
-                    elapsed: started.elapsed(),
-                    response: (
-                        StatusCode::BAD_REQUEST,
-                        Json(ErrorBody {
-                            error: format!("plan error: {e}"),
-                        }),
-                    )
-                        .into_response(),
-                };
-            }
+    let catalog = state.catalog_for(&owned.manifest().manifest);
+    let plan = match build_plan(&parsed, &catalog) {
+        Ok(p) => p,
+        Err(e) => {
+            return ObservedQuery {
+                kind: None,
+                ok: false,
+                elapsed: started.elapsed(),
+                response: (
+                    StatusCode::BAD_REQUEST,
+                    Json(ErrorBody {
+                        error: format!("plan error: {e}"),
+                    }),
+                )
+                    .into_response(),
+            };
         }
     };
 
@@ -2673,6 +2788,10 @@ async fn run_cypher(state: &AppState, req: &CypherRequest, principal: &Principal
             )
                 .into_response(),
         };
+    }
+
+    if parsed.explain {
+        return explain_observation(&parsed, &plan, &owned, &catalog, started);
     }
 
     if plan.contains_write() {
@@ -3241,24 +3360,22 @@ async fn run_cypher_multi(
     // memoised per manifest version on the namespace state (building it is
     // O(ssts)), so a read-heavy namespace does not rebuild it every query.
     let owned = ns_state.snapshot.load();
-    let plan = {
-        let catalog = ns_state.catalog_for(&owned.manifest().manifest);
-        match build_plan(&parsed, &catalog) {
-            Ok(p) => p,
-            Err(e) => {
-                return ObservedQuery {
-                    kind: None,
-                    ok: false,
-                    elapsed: started.elapsed(),
-                    response: (
-                        StatusCode::BAD_REQUEST,
-                        Json(ErrorBody {
-                            error: format!("plan error: {e}"),
-                        }),
-                    )
-                        .into_response(),
-                };
-            }
+    let catalog = ns_state.catalog_for(&owned.manifest().manifest);
+    let plan = match build_plan(&parsed, &catalog) {
+        Ok(p) => p,
+        Err(e) => {
+            return ObservedQuery {
+                kind: None,
+                ok: false,
+                elapsed: started.elapsed(),
+                response: (
+                    StatusCode::BAD_REQUEST,
+                    Json(ErrorBody {
+                        error: format!("plan error: {e}"),
+                    }),
+                )
+                    .into_response(),
+            };
         }
     };
 
@@ -3276,6 +3393,10 @@ async fn run_cypher_multi(
             )
                 .into_response(),
         };
+    }
+
+    if parsed.explain {
+        return explain_observation(&parsed, &plan, &owned, &catalog, started);
     }
 
     if plan.contains_write() {

--- a/crates/namidb-server/src/metrics.rs
+++ b/crates/namidb-server/src/metrics.rs
@@ -963,6 +963,24 @@ impl Metrics {
         );
         let _ = writeln!(
             out,
+            "# HELP namidb_property_lookup_route_total Graph property lookups by physical route. \
+             A climbing fallback counter beside a flat native one means an indexed property is \
+             silently paying O(label) scan prices (pre-sidecar SSTs in scope, unreadable sidecar, \
+             or oversized posting)."
+        );
+        let _ = writeln!(out, "# TYPE namidb_property_lookup_route_total counter");
+        let _ = writeln!(
+            out,
+            "namidb_property_lookup_route_total{{route=\"native\"}} {}",
+            routes.property_native
+        );
+        let _ = writeln!(
+            out,
+            "namidb_property_lookup_route_total{{route=\"fallback\"}} {}",
+            routes.property_fallback
+        );
+        let _ = writeln!(
+            out,
             "# HELP namidb_search_workspace_enabled Whether the process-wide object-native search workspace has been initialized."
         );
         let _ = writeln!(out, "# TYPE namidb_search_workspace_enabled gauge");

--- a/crates/namidb-server/tests/explain_surface.rs
+++ b/crates/namidb-server/tests/explain_surface.rs
@@ -1,0 +1,217 @@
+//! Item 39 (25 TB readiness): the server serves `EXPLAIN` instead of
+//! silently executing, renders the OPTIMIZED plan against the real manifest
+//! catalog (so `NodeByPropertyValue` is finally visible), and a `# route:`
+//! footer states the physical access path — index, memtable, numeric-scan —
+//! that was previously observable only through `elapsed_ms`.
+
+use std::time::Duration;
+
+use tokio::net::TcpStream;
+
+const NS: &str = "explain-surface";
+const TOKEN: &str = "test-token";
+
+async fn boot() -> String {
+    let http_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let http_addr = http_listener.local_addr().unwrap();
+    drop(http_listener);
+    let config = namidb_server::Config {
+        store_uri: format!("memory://{NS}"),
+        listen: http_addr,
+        auth_token: Some(TOKEN.into()),
+        auth_tokens_file: None,
+        #[cfg(feature = "jwt")]
+        jwt: None,
+        #[cfg(feature = "pdp")]
+        pdp_url: None,
+        flush_interval: Duration::ZERO,
+        compaction_interval: Duration::ZERO,
+        sweep_min_age: Duration::ZERO,
+        sweep_delete: false,
+        bolt_listen: None,
+        bolt_max_message_bytes: 64 << 20,
+        bolt_tx_timeout: Duration::ZERO,
+        query_timeout: Duration::from_secs(30),
+        write_timeout: Duration::from_secs(30),
+        query_row_cap: 0,
+        compaction_l0_trigger: 0,
+        write_stall_l0: 0,
+        write_stall_delay: Duration::ZERO,
+        memtable_flush_bytes: 0,
+        memtable_stall_bytes: 0,
+        writer_lock_timeout: Duration::from_secs(5),
+        tls_cert: None,
+        tls_key: None,
+        slow_query_threshold: Duration::ZERO,
+        multi_tenant: false,
+        default_namespace: NS.to_string(),
+        max_namespaces: 100,
+        namespace_idle_timeout: Duration::from_secs(3600),
+    };
+    tokio::spawn(async move {
+        if let Err(e) = namidb_server::run(config).await {
+            eprintln!("server exited: {e}");
+        }
+    });
+    for _ in 0..100 {
+        if TcpStream::connect(http_addr).await.is_ok() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    format!("http://{http_addr}")
+}
+
+async fn cypher(base: &str, query: &str) -> (u16, String) {
+    let response = reqwest::Client::new()
+        .post(format!("{base}/v0/cypher"))
+        .bearer_auth(TOKEN)
+        .json(&serde_json::json!({ "query": query }))
+        .send()
+        .await
+        .unwrap();
+    (response.status().as_u16(), response.text().await.unwrap())
+}
+
+async fn person_count(base: &str) -> i64 {
+    let (status, body) = cypher(base, "MATCH (p:Person) RETURN count(p) AS c").await;
+    assert_eq!(status, 200, "{body}");
+    let parsed: serde_json::Value = serde_json::from_str(&body).unwrap();
+    parsed["rows"][0]["c"].as_i64().unwrap()
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn explain_renders_the_plan_and_its_physical_route_without_executing() {
+    let base = boot().await;
+
+    let (status, body) = cypher(
+        &base,
+        "CREATE CONSTRAINT persona_cedula IF NOT EXISTS \
+         FOR (p:Person) REQUIRE p.cedula IS UNIQUE",
+    )
+    .await;
+    assert_eq!(status, 200, "{body}");
+
+    // Seed into the memtable only (no flush yet).
+    for chunk in 0..2 {
+        let parts: Vec<String> = (0..50)
+            .map(|i| {
+                format!(
+                    "(:Person {{cedula: 'ced-{:03}', seq: {}}})",
+                    chunk * 50 + i,
+                    chunk * 50 + i
+                )
+            })
+            .collect();
+        let (status, body) = cypher(&base, &format!("CREATE {}", parts.join(", "))).await;
+        assert_eq!(status, 200, "{body}");
+    }
+
+    // EXPLAIN of a write must NOT execute.
+    let before = person_count(&base).await;
+    let (status, body) = cypher(&base, "EXPLAIN CREATE (:Person {cedula: 'fantasma'})").await;
+    assert_eq!(status, 200, "{body}");
+    assert!(body.contains("\"plan\""), "plan rows expected: {body}");
+    assert!(
+        body.contains("Create"),
+        "plan must show the operator: {body}"
+    );
+    assert_eq!(
+        person_count(&base).await,
+        before,
+        "EXPLAIN of a write must create nothing"
+    );
+
+    // Memtable-only: the optimizer picks the index operator (schema says
+    // unique) and the route footer says the store is memtable-backed.
+    let (status, body) = cypher(
+        &base,
+        "EXPLAIN MATCH (p:Person {cedula: 'ced-007'}) RETURN p.seq AS seq",
+    )
+    .await;
+    assert_eq!(status, 200, "{body}");
+    assert!(
+        body.contains("NodeByPropertyValue"),
+        "the optimized plan must show the index operator: {body}"
+    );
+    assert!(
+        body.contains("route: Person.cedula") && body.contains("memtable"),
+        "memtable route note expected: {body}"
+    );
+
+    // Flushed with the constraint predating the flush: full sidecar
+    // coverage, so the footer states the index route with the coverage.
+    let flush = reqwest::Client::new()
+        .post(format!("{base}/v0/admin/flush"))
+        .bearer_auth(TOKEN)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(flush.status().as_u16(), 200);
+    let (status, body) = cypher(
+        &base,
+        "EXPLAIN MATCH (p:Person {cedula: 'ced-007'}) RETURN p.seq AS seq",
+    )
+    .await;
+    assert_eq!(status, 200, "{body}");
+    assert!(
+        body.contains("→ index") && body.contains("unique lookup"),
+        "index route note expected after flush: {body}"
+    );
+
+    // A numeric equality is not posting-indexed — the footer says so
+    // instead of letting the operator name imply index speed.
+    let (status, body) = cypher(
+        &base,
+        "CREATE INDEX persona_seq IF NOT EXISTS FOR (p:Person) ON (p.seq)",
+    )
+    .await;
+    assert_eq!(status, 200, "{body}");
+    let (status, body) = cypher(&base, "EXPLAIN MATCH (p:Person {seq: 7}) RETURN p").await;
+    assert_eq!(status, 200, "{body}");
+    if body.contains("NodeByPropertyValue") {
+        assert!(
+            body.contains("numeric equality is not posting-indexed"),
+            "numeric route caveat expected: {body}"
+        );
+    }
+
+    // VERBOSE adds the estimate header.
+    let (status, body) = cypher(
+        &base,
+        "EXPLAIN VERBOSE MATCH (p:Person {cedula: 'ced-007'}) RETURN p",
+    )
+    .await;
+    assert_eq!(status, 200, "{body}");
+    assert!(body.contains("Estimated rows"), "verbose estimates: {body}");
+
+    // The route counters exist on /v0/metrics, and running the real lookup
+    // moves the native counter.
+    let (status, body) = cypher(
+        &base,
+        "MATCH (p:Person {cedula: 'ced-007'}) RETURN p.seq AS seq",
+    )
+    .await;
+    assert_eq!(status, 200, "{body}");
+    let metrics = reqwest::Client::new()
+        .get(format!("{base}/v0/metrics"))
+        .bearer_auth(TOKEN)
+        .send()
+        .await
+        .unwrap()
+        .text()
+        .await
+        .unwrap();
+    let native = metrics
+        .lines()
+        .find(|l| l.starts_with("namidb_property_lookup_route_total{route=\"native\"}"))
+        .expect("native property route counter must render");
+    assert!(
+        !native.trim_end().ends_with(" 0"),
+        "an indexed lookup must count as native: {native}"
+    );
+    assert!(
+        metrics.contains("namidb_property_lookup_route_total{route=\"fallback\"}"),
+        "fallback series must render"
+    );
+}

--- a/crates/namidb-storage/src/read.rs
+++ b/crates/namidb-storage/src/read.rs
@@ -1367,11 +1367,13 @@ impl<'mt> Snapshot<'mt> {
                 })
                 .collect();
             let Some(sidecars) = sidecars else {
+                crate::route_telemetry::record_property(false);
                 return Ok(IndexedPropertyLookup::Unavailable);
             };
             // No SSTs means the committed/staged memtable is the whole store.
             // Otherwise every relevant SST must have contributed one sidecar.
             if have_node_ssts && sidecars.len() != sst_idxs.len() {
+                crate::route_telemetry::record_property(false);
                 return Ok(IndexedPropertyLookup::Unavailable);
             }
 
@@ -1409,6 +1411,7 @@ impl<'mt> Snapshot<'mt> {
                             error = %error,
                             "equality accelerator unavailable; falling back to exact scan"
                         );
+                        crate::route_telemetry::record_property(false);
                         return Ok(IndexedPropertyLookup::Unavailable);
                     }
                     Err(error) => return Err(error),
@@ -1510,6 +1513,7 @@ impl<'mt> Snapshot<'mt> {
             // the cutoff or every posting is exhausted.
             return Ok(IndexedPropertyLookup::Truncated);
         }
+        crate::route_telemetry::record_property(true);
         Ok(IndexedPropertyLookup::Available(confirmed))
     }
 
@@ -1763,6 +1767,31 @@ impl<'mt> Snapshot<'mt> {
         }
     }
 
+    /// Posting-sidecar coverage for `(label, property)` over the node SSTs
+    /// that can contain the label: `(covered, in_scope)`. The lookup routes
+    /// demote to a label scan unless every in-scope SST is covered, so
+    /// `covered < in_scope` means "the index exists in the schema but this
+    /// snapshot pays scan prices" — the physical-route fact EXPLAIN
+    /// annotates (item 39). `(0, 0)` = memtable-only (no SSTs in scope;
+    /// the claimant map serves natively).
+    pub fn property_index_coverage(&self, label: &str, property: &str) -> (usize, usize) {
+        let in_scope: Vec<usize> = self
+            .manifest
+            .index
+            .node_descriptors()
+            .into_iter()
+            .filter(|i| node_sst_can_contain_label(&self.manifest.manifest, *i, label))
+            .collect();
+        let covered = in_scope
+            .iter()
+            .filter(|i| {
+                string_property_sidecar(&self.manifest.manifest.ssts[**i], label, property)
+                    .is_some()
+            })
+            .count();
+        (covered, in_scope.len())
+    }
+
     /// Point-lookup a node by a *unique* user property. The first call
     /// per (label, prop) pays a full label scan to populate the
     /// cross-snapshot cache; subsequent calls are `O(1)`. Caller is
@@ -1812,6 +1841,7 @@ impl<'mt> Snapshot<'mt> {
                 .property_index_generation
                 .unwrap_or_else(|| cache.generation());
             if let Some(idx) = cache.get_at(label, property, generation) {
+                crate::route_telemetry::record_property(true);
                 if let Some(node_id) = idx.get(value).copied() {
                     return self.lookup_node(label, node_id).await;
                 } else {
@@ -1955,6 +1985,7 @@ impl<'mt> Snapshot<'mt> {
             }
 
             if sidecars_available {
+                crate::route_telemetry::record_property(true);
                 // Under a valid unique constraint there is at most one
                 // confirmed live owner. If legacy/corrupt data contains more,
                 // select deterministically by newest row LSN, then lowest
@@ -1987,6 +2018,7 @@ impl<'mt> Snapshot<'mt> {
         // pre-sidecar build (or when the property wasn't declared
         // `unique` at flush time). The in-memory cache caches the
         // result so subsequent calls bypass the scan.
+        crate::route_telemetry::record_property(!have_node_ssts);
         let all_nodes = self.scan_label(label).await?;
         let mut idx: std::collections::HashMap<String, namidb_core::id::NodeId> =
             std::collections::HashMap::with_capacity(all_nodes.len());
@@ -2113,9 +2145,11 @@ impl<'mt> Snapshot<'mt> {
         // intentionally per-SST so a rolling-upgrade generation can combine a
         // legacy unique map with a current global equality posting map.
         if have_node_ssts && sidecars.is_none() {
+            crate::route_telemetry::record_property(false);
             let views = self.scan_label(label).await?;
             return self.batch_unique_from_scan(label, property, values, views);
         }
+        crate::route_telemetry::record_property(true);
 
         let memtable_claimants = self.memtable_property_claimants(label, property)?;
         for (value, ids_out) in &mut candidates {
@@ -2146,6 +2180,7 @@ impl<'mt> Snapshot<'mt> {
                                 error = %error,
                                 "unique property accelerator unavailable; falling back to one exact batch label scan"
                             );
+                            crate::route_telemetry::record_property(false);
                             let views = self.scan_label(label).await?;
                             return self.batch_unique_from_scan(label, property, values, views);
                         }
@@ -2181,6 +2216,7 @@ impl<'mt> Snapshot<'mt> {
                                 error = %error,
                                 "equality property accelerator unavailable; falling back to one exact batch label scan"
                             );
+                            crate::route_telemetry::record_property(false);
                             let views = self.scan_label(label).await?;
                             return self.batch_unique_from_scan(label, property, values, views);
                         }
@@ -2355,6 +2391,7 @@ impl<'mt> Snapshot<'mt> {
         // `indexed` at flush time). A memtable-only store is NOT cold: its
         // claimant map is the complete index and is cached per generation.
         if have_node_ssts && !all_have_sidecar {
+            crate::route_telemetry::record_property(false);
             let all_nodes = self.scan_label(label).await?;
             return Ok(all_nodes
                 .into_iter()
@@ -2364,6 +2401,7 @@ impl<'mt> Snapshot<'mt> {
                 })
                 .collect());
         }
+        crate::route_telemetry::record_property(true);
 
         namidb_core::profile_scope!("Snapshot::lookup_nodes_by_property.sidecar");
         // Gather candidate ids: memtable upserts carrying `value`, plus the

--- a/crates/namidb-storage/src/route_telemetry.rs
+++ b/crates/namidb-storage/src/route_telemetry.rs
@@ -17,6 +17,8 @@ static TEXT_NATIVE: AtomicU64 = AtomicU64::new(0);
 static TEXT_FALLBACK: AtomicU64 = AtomicU64::new(0);
 static VECTOR_NATIVE: AtomicU64 = AtomicU64::new(0);
 static VECTOR_FALLBACK: AtomicU64 = AtomicU64::new(0);
+static PROPERTY_NATIVE: AtomicU64 = AtomicU64::new(0);
+static PROPERTY_FALLBACK: AtomicU64 = AtomicU64::new(0);
 
 /// Record one text index search outcome: `native = true` when the index
 /// served the answer, `false` when it declined (freshness gate, missing or
@@ -38,6 +40,21 @@ pub fn record_vector(native: bool) {
     }
 }
 
+/// Record one graph property-lookup outcome: `native = true` when the
+/// posting-sidecar/warm-index route served (or the store is memtable-only,
+/// where a scan is the correct route and no index could exist), `false`
+/// when SSTs exist but the lookup fell back to an O(label) scan — a
+/// pre-sidecar SST in scope, an unreadable sidecar, or an oversized
+/// posting. A climbing fallback counter beside a flat native one is the
+/// item-39 signature: the "index" is silently paying scan prices.
+pub fn record_property(native: bool) {
+    if native {
+        PROPERTY_NATIVE.fetch_add(1, Ordering::Relaxed);
+    } else {
+        PROPERTY_FALLBACK.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
 /// A monotonic snapshot of every route counter.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct RouteTelemetrySnapshot {
@@ -45,6 +62,8 @@ pub struct RouteTelemetrySnapshot {
     pub text_fallback: u64,
     pub vector_native: u64,
     pub vector_fallback: u64,
+    pub property_native: u64,
+    pub property_fallback: u64,
 }
 
 pub fn snapshot() -> RouteTelemetrySnapshot {
@@ -53,6 +72,8 @@ pub fn snapshot() -> RouteTelemetrySnapshot {
         text_fallback: TEXT_FALLBACK.load(Ordering::Relaxed),
         vector_native: VECTOR_NATIVE.load(Ordering::Relaxed),
         vector_fallback: VECTOR_FALLBACK.load(Ordering::Relaxed),
+        property_native: PROPERTY_NATIVE.load(Ordering::Relaxed),
+        property_fallback: PROPERTY_FALLBACK.load(Ordering::Relaxed),
     }
 }
 
@@ -67,10 +88,14 @@ mod tests {
         super::record_text(false);
         super::record_vector(true);
         super::record_vector(false);
+        super::record_property(true);
+        super::record_property(false);
         let after = super::snapshot();
         assert!(after.text_native > before.text_native);
         assert!(after.text_fallback > before.text_fallback);
         assert!(after.vector_native > before.vector_native);
         assert!(after.vector_fallback > before.vector_fallback);
+        assert!(after.property_native > before.property_native);
+        assert!(after.property_fallback > before.property_fallback);
     }
 }

--- a/docs/testing/25tb-readiness.md
+++ b/docs/testing/25tb-readiness.md
@@ -370,7 +370,7 @@ the window between DDL and the pass finishing, one uncovered SST in
 scope silently disables the index for the whole lookup (no metric) —
 that observability gap is item 39's territory.
 
-### 39. [observability, target 2.2] EXPLAIN shows NodeScan + Filter even when the posting index accelerates the scan at runtime.
+### 39. [DONE — observability, lands in 2.1.3] EXPLAIN shows NodeScan + Filter even when the posting index accelerates the scan at runtime.
 
 The pushed-predicate/posting acceleration happens INSIDE the scan
 operator, so the logical plan is truthful about shape but silent about
@@ -382,6 +382,31 @@ the physical access path chosen at execution (or at minimum a
 `route: native|scan` counter per operator in EXPLAIN VERBOSE), mirroring
 the `namidb_search_route_total{route}` pattern that already exists for
 search.
+
+**Resolution (2026-08-17):** the recon found the reality was worse than
+reported: the SERVER never handled EXPLAIN at all — `EXPLAIN <query>`
+over HTTP or Bolt silently EXECUTED the query (an `EXPLAIN CREATE` wrote
+data), and the only real consumer, `namidb explain` (CLI), renders with
+an empty StatsCatalog so it can never show `NodeByPropertyValue`. Now:
+(1) both surfaces serve `EXPLAIN [RAW] [VERBOSE]` — the optimized plan
+against the real manifest catalog, one row per line, nothing executes;
+(2) a `# route:` footer states the physical access path per index
+lookup, computed from actual sidecar coverage
+(`Snapshot::property_index_coverage`): `index (unique|posting lookup;
+posting sidecars N/N SSTs)`, `memtable (no SSTs in scope)`,
+`SCAN FALLBACK (sidecars K/N SSTs)`, or the numeric caveat
+(`numeric equality is not posting-indexed`); (3) the silent
+index-to-scan demotions in the storage lookup routes (pre-sidecar SST in
+scope, unreadable sidecar — across the unique, string-multi, batch, and
+equality-inner paths) now count into
+`namidb_property_lookup_route_total{route="native"|"fallback"}` on
+/v0/metrics, the same alarm shape as `namidb_search_route_total`; and
+(4) the stale AST doc promising executor-side EXPLAIN handling was
+corrected. Pinned by `namidb-server/tests/explain_surface.rs`: EXPLAIN
+of a write creates nothing, the optimized plan shows
+`NodeByPropertyValue`, the footer transitions memtable→index across a
+flush, numeric equality carries the caveat, VERBOSE adds estimates, and
+a real indexed lookup moves the native route counter on /v0/metrics.
 
 ### 40. [DONE — resilience, lands in 2.1.3] Disk-full during flush permanently wedges the namespace: writer lock never released, reads queue behind the guard, no error, no timeout — only a restart recovers.
 


### PR DESCRIPTION
Item 39 of docs/testing/25tb-readiness.md — field finding: "EXPLAIN lies by omission; the plan shows NodeScan + Filter even when the index accelerates at runtime; to know if an index works you must look at elapsed_ms."

## Recon found it was worse

- The **server never handled EXPLAIN at all**: over HTTP or Bolt the prefix parsed and the query **silently executed** — `EXPLAIN CREATE ...` wrote data.
- The only real consumer (`namidb explain`, CLI) renders with an **empty StatsCatalog**, so the unique-lookup rewrite never fires and `NodeByPropertyValue` can never appear — which is exactly why the plan seemed to "lie".

## Changes

1. **Both surfaces serve `EXPLAIN [RAW] [VERBOSE]`** (HTTP single- and multi-tenant, Bolt): the **optimized** plan against the real manifest catalog, one row per line (`columns: ["plan"]`), nothing executes. VERBOSE adds cardinality estimates; RAW renders the lowering.
2. **`# route:` footer** — the physical access path per index lookup, computed from actual posting-sidecar coverage (new `Snapshot::property_index_coverage`): `index (unique|posting lookup; posting sidecars N/N SSTs)`, `memtable (no SSTs in scope)`, `SCAN FALLBACK (sidecars K/N SSTs; a compaction pass materializes the rest)`, and the honesty caveat `numeric equality is not posting-indexed`.
3. **Route telemetry**: the silent index-to-scan demotions in the storage lookup routes (pre-sidecar SST in scope, unreadable sidecar — across the unique, string-multi, batch, and equality-inner paths) now count into `namidb_property_lookup_route_total{route="native"|"fallback"}` on `/v0/metrics` — the same flatlined-native/climbing-fallback alarm shape as `namidb_search_route_total`. Memtable-only scans count as native (no index could exist; the claimant map is the correct route).
4. The stale AST doc promising executor-side EXPLAIN handling is corrected.

## Tests

`namidb-server/tests/explain_surface.rs` over the real HTTP surface: EXPLAIN of a write creates nothing; the optimized plan shows `NodeByPropertyValue`; the route footer transitions memtable→index across a flush; numeric equality carries the caveat; VERBOSE adds estimates; a real indexed lookup moves the native route counter and both series render on `/v0/metrics`. Full suites: **1788 passed, 0 failed** across namidb-storage + namidb-query + namidb-server; fmt + clippy clean on default and all-features.

## Noted follow-ups

The Bolt EXPLAIN branch mirrors HTTP but has no dedicated Bolt-protocol test yet; the `SCAN FALLBACK` footer branch is exercised by unit logic but not e2e (deterministically holding a partially-covered state now races the item-38 DDL-triggered compaction — a FaultStore-style hold would pin it).