### PR TITLE
perf: admission gate for concurrent full scans; index-surface audit

### DIFF
--- a/crates/namidb-server/README.md
+++ b/crates/namidb-server/README.md
@@ -6,10 +6,14 @@ the HTTP boundary, bearer-token auth, and a periodic flush loop.
 
 ## Install
 
-From source (workspace root):
+From source (workspace root). Note the feature flags: vector and
+full-text search are compile-time features that the official binaries,
+image, and wheels all enable, but a bare `cargo install` does NOT — a
+from-source build without them rejects `CREATE VECTOR INDEX` /
+`CREATE FULLTEXT INDEX` with HTTP 400:
 
 ```bash
-cargo install --path crates/namidb-server
+cargo install --path crates/namidb-server --features vector-index,text-index
 ```
 
 Container image (official, multi-arch amd64/arm64, from

--- a/crates/namidb-server/src/bolt.rs
+++ b/crates/namidb-server/src/bolt.rs
@@ -911,6 +911,7 @@ impl ServerBackend {
             // Read path: borrow a short-lived `Snapshot` from the owned
             // snapshot; the Arc keeps the underlying memtable alive for
             // the duration of the query, no writer lock needed.
+            let _scan_permit = crate::acquire_scan_permit(&plan).await;
             let snap = owned.borrow();
             let read = execute_with_limits(
                 &plan,
@@ -1142,6 +1143,7 @@ impl ServerBackend {
                     };
                 }
             };
+            let _scan_permit = crate::acquire_scan_permit(&plan).await;
             let snap = tx.writer.overlay_snapshot();
             let read = execute_with_limits(
                 &plan,

--- a/crates/namidb-server/src/lib.rs
+++ b/crates/namidb-server/src/lib.rs
@@ -1409,6 +1409,55 @@ fn exec_error_classification(
 /// deliberately-unsupported feature surfaces as 400/`unsupported` instead of
 /// a bare 500. The `code` field is emitted only when classified, so existing
 /// clients that deserialize the body loosely see no change on plain 500s.
+/// Process-wide admission gate for full-scan queries (item 41).
+///
+/// A `NodeScan` materializes its whole label (and, through the LWW
+/// reconciliation fallback, potentially the whole store) into memory, and
+/// nothing else bounds how many of those run at once — the global HTTP
+/// concurrency cap (1024) counts a point lookup and a 10M-row scan the
+/// same. In field testing, parallel 1M-row scans collapsed aggregate
+/// throughput to ~2 rps at 8 GB RSS: each scan's working set ballooned
+/// past the memory governor's wire-byte-sized reservation and their
+/// combined cache traffic evicted every point-lookup working set. This
+/// gate bounds worst-case scan memory to `permits x largest-label` and
+/// keeps the box responsive for indexed traffic. Waiters queue fairly
+/// INSIDE the request-timeout layer, so a queued scan times out cleanly.
+///
+/// `NAMIDB_MAX_CONCURRENT_SCANS` overrides the default of 4; `0` disables
+/// the gate.
+fn scan_gate() -> Option<&'static tokio::sync::Semaphore> {
+    static GATE: std::sync::OnceLock<Option<tokio::sync::Semaphore>> = std::sync::OnceLock::new();
+    GATE.get_or_init(|| {
+        let permits = std::env::var("NAMIDB_MAX_CONCURRENT_SCANS")
+            .ok()
+            .and_then(|raw| raw.parse::<usize>().ok())
+            .unwrap_or(4);
+        (permits > 0).then(|| tokio::sync::Semaphore::new(permits))
+    })
+    .as_ref()
+}
+
+/// True when the plan contains a full `NodeScan` anywhere (subplans
+/// included) — the operator class the scan gate meters. Index lookups
+/// (`NodeByPropertyValue`, `NodeById`) and pure expand chains pass free.
+pub(crate) fn plan_contains_node_scan(plan: &namidb_query::LogicalPlan) -> bool {
+    matches!(plan, namidb_query::LogicalPlan::NodeScan { .. })
+        || plan.children().into_iter().any(plan_contains_node_scan)
+}
+
+/// Acquire a scan permit when the plan needs one. Holding the returned
+/// guard for the duration of execution is the whole contract.
+pub(crate) async fn acquire_scan_permit(
+    plan: &namidb_query::LogicalPlan,
+) -> Option<tokio::sync::SemaphorePermit<'static>> {
+    let gate = scan_gate()?;
+    if !plan_contains_node_scan(plan) {
+        return None;
+    }
+    // The semaphore is never closed, so acquire cannot fail.
+    gate.acquire().await.ok()
+}
+
 /// Serve `EXPLAIN [RAW] [VERBOSE] <query>`: render the plan instead of
 /// executing. The AST has always promised this ("the executor honours it by
 /// returning the plan tree"), but the server previously ignored the prefix
@@ -2888,6 +2937,7 @@ async fn run_cypher(state: &AppState, req: &CypherRequest, principal: &Principal
         // Read path: no writer lock. Borrow a short-lived `Snapshot`
         // from the owned one; the `OwnedSnapshot` Arc keeps the
         // underlying memtable alive for the duration of the query.
+        let _scan_permit = acquire_scan_permit(&plan).await;
         let snap = owned.borrow();
         let result = execute_with_limits(
             &plan,
@@ -3504,6 +3554,7 @@ async fn run_cypher_multi(
         }
     } else {
         // Read path.
+        let _scan_permit = acquire_scan_permit(&plan).await;
         let snap = owned.borrow();
         let result = execute_with_limits(
             &plan,

--- a/crates/namidb-server/tests/scan_gate.rs
+++ b/crates/namidb-server/tests/scan_gate.rs
@@ -1,0 +1,112 @@
+//! Item 41 (25 TB readiness): the scan admission gate. With
+//! `NAMIDB_MAX_CONCURRENT_SCANS=1`, many concurrent full-label scans must
+//! all complete correctly (serialized through the gate, no deadlock, no
+//! starvation), and non-scan traffic keeps flowing while scans queue.
+//!
+//! Single-test integration binary: it sets the process-global env knob
+//! before the gate's lazy initialization.
+
+use std::time::Duration;
+
+use tokio::net::TcpStream;
+
+const NS: &str = "scan-gate";
+const TOKEN: &str = "test-token";
+
+async fn boot() -> String {
+    let http_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let http_addr = http_listener.local_addr().unwrap();
+    drop(http_listener);
+    let config = namidb_server::Config {
+        store_uri: format!("memory://{NS}"),
+        listen: http_addr,
+        auth_token: Some(TOKEN.into()),
+        auth_tokens_file: None,
+        #[cfg(feature = "jwt")]
+        jwt: None,
+        #[cfg(feature = "pdp")]
+        pdp_url: None,
+        flush_interval: Duration::ZERO,
+        compaction_interval: Duration::ZERO,
+        sweep_min_age: Duration::ZERO,
+        sweep_delete: false,
+        bolt_listen: None,
+        bolt_max_message_bytes: 64 << 20,
+        bolt_tx_timeout: Duration::ZERO,
+        query_timeout: Duration::from_secs(30),
+        write_timeout: Duration::from_secs(30),
+        query_row_cap: 0,
+        compaction_l0_trigger: 0,
+        write_stall_l0: 0,
+        write_stall_delay: Duration::ZERO,
+        memtable_flush_bytes: 0,
+        memtable_stall_bytes: 0,
+        writer_lock_timeout: Duration::from_secs(5),
+        tls_cert: None,
+        tls_key: None,
+        slow_query_threshold: Duration::ZERO,
+        multi_tenant: false,
+        default_namespace: NS.to_string(),
+        max_namespaces: 100,
+        namespace_idle_timeout: Duration::from_secs(3600),
+    };
+    tokio::spawn(async move {
+        if let Err(e) = namidb_server::run(config).await {
+            eprintln!("server exited: {e}");
+        }
+    });
+    for _ in 0..100 {
+        if TcpStream::connect(http_addr).await.is_ok() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    format!("http://{http_addr}")
+}
+
+async fn cypher(base: &str, query: &str) -> (u16, String) {
+    let response = reqwest::Client::new()
+        .post(format!("{base}/v0/cypher"))
+        .bearer_auth(TOKEN)
+        .json(&serde_json::json!({ "query": query }))
+        .send()
+        .await
+        .unwrap();
+    (response.status().as_u16(), response.text().await.unwrap())
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn concurrent_scans_serialize_through_the_gate_without_starvation() {
+    // Before the gate's lazy init (first read query).
+    std::env::set_var("NAMIDB_MAX_CONCURRENT_SCANS", "1");
+    let base = boot().await;
+
+    for chunk in 0..4 {
+        let parts: Vec<String> = (0..250)
+            .map(|i| format!("(:Person {{seq: {}}})", chunk * 250 + i))
+            .collect();
+        let (status, body) = cypher(&base, &format!("CREATE {}", parts.join(", "))).await;
+        assert_eq!(status, 200, "{body}");
+    }
+
+    // Eight concurrent full scans through one permit: all must complete
+    // with the exact count — serialized, not deadlocked, none starved.
+    let mut handles = Vec::new();
+    for _ in 0..8 {
+        let base = base.clone();
+        handles.push(tokio::spawn(async move {
+            cypher(&base, "MATCH (p:Person) RETURN count(p) AS c").await
+        }));
+    }
+    // Non-scan traffic keeps flowing while the scans queue.
+    let (status, body) = cypher(&base, "RETURN 1 AS ok").await;
+    assert_eq!(status, 200, "{body}");
+    for handle in handles {
+        let (status, body) = handle.await.unwrap();
+        assert_eq!(status, 200, "{body}");
+        assert!(
+            body.contains("\"c\":1000"),
+            "exact count under gating: {body}"
+        );
+    }
+}

--- a/docs/testing/25tb-readiness.md
+++ b/docs/testing/25tb-readiness.md
@@ -454,7 +454,7 @@ still waits unbounded on the evicted writer while holding the sessions
 lock (short now that the mutex frees); moving the flush build off-lock like
 compaction's prepare stays future work.
 
-### 41. [performance, target 2.2] Concurrent large scans collapse aggregate throughput (~660 rps mixed ceiling; pathological control: ~2 rps aggregate, 8 GB RSS on parallel 1M-row scans without index).
+### 41. [CONTAINED — performance; gate lands in 2.1.4, deep fixes remain] Concurrent large scans collapse aggregate throughput (~660 rps mixed ceiling; pathological control: ~2 rps aggregate, 8 GB RSS on parallel 1M-row scans without index).
 
 Suspected shared-cache thrash (unprofiled). The per-query protections
 (row cap, deadline, breaker) contain the blast radius, but the engine
@@ -467,9 +467,66 @@ concurrent full scans per namespace), and per-tenant cache partitioning
 or scan-resistant eviction (e.g., segmented LRU so one scan cannot flush
 the point-lookup working set).
 
-### 42. [product surface, backlog] Index surface limits observed in the field: single-property indexes only (no composites), DDL must be a single statement, and vector/full-text are compile-time features the cloud build does not ship.
+**Containment (2026-08-17) + mechanism map.** Recon established the full
+chain: (1) a `NodeScan` materializes its whole label THREE times (the
+LWW-reconciliation `BTreeMap` over potentially the whole store, the
+`Vec<NodeView>`, then the walker's `Vec<Row>`) — nothing streams on the
+executor path even though `visit_label_with_projection` exists; (2) the
+memory governor's admission is wire-byte-sized (a 50-byte scan query
+reserves ~65 KiB against a multi-GB execution) and `admit_query` samples
+RSS point-in-time with zero headroom, so N scans admit low and balloon —
+that is the 8 GB; (3) every body a scan touches was inserted into the
+shared S3-FIFO body tier whose EFFECTIVE budget is ~86 MiB after
+proportional scaling, and N concurrent scans re-touching keys promote
+them past the probationary queue, flushing the point-lookup working set;
+(4) at 90% RSS the watchdog's only lever is `clear_shared_caches()` —
+nuking ALL tiers repeatedly while the scans keep allocating. Shipped
+now: a process-wide **scan admission gate** — plans containing a
+`NodeScan` acquire one of `NAMIDB_MAX_CONCURRENT_SCANS` permits
+(default 4, `0` disables) before execution, on HTTP (both tenants) and
+Bolt (auto-commit and in-tx); index lookups and expand chains pass free;
+waiters queue fairly inside the request-timeout layer. Worst-case scan
+memory drops from `1024 x largest-label` to `permits x largest-label`
+and indexed traffic keeps its cache working set. Pinned by
+`namidb-server/tests/scan_gate.rs` (8 concurrent full scans through one
+permit all answer exactly, non-scan traffic flows meanwhile). Remaining
+(recorded, sized): streaming `NodeScan` execution (the deep fix for
+per-scan RSS), stats-based per-scan memory reservation through the
+existing `reserve_query_headroom` CAS ledger (`LabelStats.node_count` x
+estimated row bytes), scan-resistant insertion across the body/decoded/
+page tiers (a first bypass attempt showed sweeps traverse the paged
+sidecar and range-cache routes too — a per-route audit must precede any
+policy change), and reclaim hysteresis so the watchdog stops
+re-clearing caches it just cleared.
+
+### 42. [AUDITED — product surface, backlog corrected] Index surface limits observed in the field: single-property indexes only (no composites), DDL must be a single statement, and vector/full-text are compile-time features the cloud build does not ship.
 
 Recording as product backlog rather than defects. Composite indexes and
 multi-statement DDL scripts are roadmap-sized; the cloud build's missing
 `vector-index`/text features is a packaging decision to revisit before
 any customer needs search on the managed tier.
+
+**Audit (2026-08-17)** — two of the three reports needed correction:
+- Composite UNIQUE CONSTRAINTS already work end-to-end (parser accepts
+  `(n.a, n.b)`, `create_unique_constraint_named` validates existing data
+  with a tuple scan and enforces on write via the transactional unique
+  index's tuple `encode_probe_key`) — they are enforcement-only, with no
+  read acceleration. What is actually missing: composite `CREATE INDEX`
+  (the parser accepts exactly one property; `parse_create_index` errors
+  on a comma) and a persisted tuple posting sidecar
+  (`EqualityKeyEncoding::TupleV1` + flush/compaction harvesters +
+  read-side tuple probe + planner conjunct-cover detection). Sized at
+  ~3-4 weeks; roadmap.
+- The OFFICIAL artifacts all ship `vector-index,text-index`: release
+  binaries (release-binaries.yml `features:` line), the Docker image
+  (Dockerfile bakes them), and the wheels (pyproject maturin features).
+  The field report's "cloud build lacks them" matches a FROM-SOURCE
+  build: the README's `cargo install --path crates/namidb-server` had no
+  `--features` flag, producing a server that 400s on search DDL — the
+  README now includes the flags.
+- Multi-statement DDL confirmed absent: the parser is one-statement
+  (`expect_eof`; a trailing `;` is tolerated, a second statement errors)
+  and there is no batch endpoint. Cheapest useful step is client-side
+  splitting in namidb-cli (~hours); server-side scripts (sequential,
+  stop-on-first-error, per-statement writer lock) are ~2-4 days.
+  Roadmap.


### PR DESCRIPTION
Items 41 and 42 of docs/testing/25tb-readiness.md. Item 41: process-wide scan admission gate — plans containing a NodeScan acquire one of NAMIDB_MAX_CONCURRENT_SCANS permits (default 4, 0 disables) on HTTP and Bolt; index lookups pass free; worst-case scan memory drops from 1024 x largest-label to permits x largest-label. Recon's full mechanism map (triple materialization, wire-byte admission, ~86 MiB effective body tier, cache-nuking watchdog) recorded in the plan doc with sized follow-ups (streaming NodeScan, stats-based reservation, per-route scan-resistant caching); a first cache-bypass attempt was deliberately reverted after empirical testing showed sweeps travel the paged-sidecar and range-cache routes too. Pinned by scan_gate.rs (8 concurrent scans through 1 permit, exact answers, non-scan traffic flows). Item 42 audit: composite UNIQUE constraints already work (enforcement-only; composite CREATE INDEX + tuple sidecar sized ~3-4 weeks, roadmap); ALL official artifacts ship vector-index,text-index — the field report matches a from-source build and the README install line now includes the flags; multi-statement DDL confirmed absent (sized, roadmap). Suite: 130 passed, 0 failed; fmt + clippy clean both configs. Targets 2.1.4.