### PR TITLE
fix: typed error taxonomy — resource exhaustion is not an argument error

### DIFF
--- a/crates/namidb-bolt/src/session.rs
+++ b/crates/namidb-bolt/src/session.rs
@@ -498,7 +498,14 @@ impl StatementType {
 
 /// Errors a backend can surface. The session translates them to
 /// dotted Neo4j error codes via [`backend_error_code`].
+///
+/// Retry semantics are encoded in the code's second segment, which official
+/// Neo4j drivers classify on: `Neo.TransientError.*` is auto-retried,
+/// `Neo.ClientError.*` is not. Deterministic limits (timeout, row cap) are
+/// therefore ClientError on purpose — a driver auto-retrying a query that
+/// will exceed the same budget again is a retry livelock.
 #[derive(Debug)]
+#[non_exhaustive]
 pub enum BackendError {
     /// Parser rejected the input.
     Syntax(String),
@@ -515,6 +522,12 @@ pub enum BackendError {
     /// The authenticated principal is not allowed to run this statement (e.g.
     /// a read-only token attempting a write).
     Forbidden(String),
+    /// The query ran past its configured wall-clock budget. A re-run would
+    /// time out again, so this is deliberately NOT a transient error.
+    Timeout(String),
+    /// The query exceeded a configured deterministic result limit (row cap,
+    /// search result caps). Also deliberately not transient.
+    ResourceLimit(String),
     /// Anything else.
     Other(String),
 }
@@ -529,6 +542,8 @@ impl BackendError {
             BackendError::Storage(_) => "Neo.TransientError.General.DatabaseUnavailable",
             BackendError::Constraint(_) => "Neo.ClientError.Schema.ConstraintValidationFailed",
             BackendError::Forbidden(_) => "Neo.ClientError.Security.Forbidden",
+            BackendError::Timeout(_) => "Neo.ClientError.Transaction.TransactionTimedOut",
+            BackendError::ResourceLimit(_) => "Neo.ClientError.Statement.ResourceLimitExceeded",
             BackendError::Other(_) => "Neo.DatabaseError.General.UnknownError",
         }
     }
@@ -542,6 +557,8 @@ impl BackendError {
             | BackendError::Storage(s)
             | BackendError::Constraint(s)
             | BackendError::Forbidden(s)
+            | BackendError::Timeout(s)
+            | BackendError::ResourceLimit(s)
             | BackendError::Other(s) => s,
         }
     }

--- a/crates/namidb-server/README.md
+++ b/crates/namidb-server/README.md
@@ -221,6 +221,41 @@ curl -s -X POST http://127.0.0.1:8080/v0/cypher \
   | jq .
 ```
 
+### Error taxonomy
+
+Failed statements return a JSON body with machine-readable fields (since
+2.2.0) so a client can decide "fix the query" vs "back off" vs "retry"
+without string-matching the message:
+
+```json
+{
+  "error": "read execution failed: query exceeded the configured timeout",
+  "code": "timeout",
+  "neo4j_code": "Neo.ClientError.Transaction.TransactionTimedOut",
+  "gql_status": "57014"
+}
+```
+
+| Condition | HTTP | `code` | `neo4j_code` | `gql_status` |
+|---|---|---|---|---|
+| Syntax error | 400 | `parse_error` | `Neo.ClientError.Statement.SyntaxError` | `42001` |
+| Semantic/plan error | 400 | `plan_error` | `Neo.ClientError.Statement.SemanticError` | `42000` |
+| Feature not supported | 400 | `unsupported` | `Neo.ClientError.Statement.NotSupported` | `0A000` |
+| Runtime evaluation error (division by zero, missing `$param`, type mismatch) | 400 | `eval_error` | `Neo.ClientError.Statement.ArgumentError` | `22000` |
+| Unique-constraint violation | 409 | `constraint` | `Neo.ClientError.Schema.ConstraintValidationFailed` | `23000` |
+| Query timeout | 504 | `timeout` | `Neo.ClientError.Transaction.TransactionTimedOut` | `57014` |
+| Row cap / search result caps | 413 | `row_cap`, `search_result_limit`, `search_document_limit` | `Neo.ClientError.Statement.ResourceLimitExceeded` | `54000` |
+| Transient resource pressure | 503 | `search_index_cache_capacity`, `search_workspace_capacity` | `Neo.TransientError.General.DatabaseUnavailable` | `53000` |
+| Unclassified server fault | 500 | — | `Neo.DatabaseError.General.UnknownError` | `50N42` |
+
+The same classes drive the Bolt `FAILURE` code, so official Neo4j drivers —
+which auto-retry `Neo.TransientError.*` and nothing else — retry exactly the
+transient conditions. Deterministic budgets (timeout, row cap) are
+`ClientError` **on purpose**: a re-run exceeds the same budget again, so
+auto-retrying them is a retry livelock. Bolt ≤ 5.4 has no GQLSTATUS on the
+wire (GQL-aware drivers show the `50N42` polyfill for every failure); the
+`gql_status` field in the HTTP body is the per-family status.
+
 ## Type mapping (JSON and Cypher)
 
 | Cypher `RuntimeValue` | JSON |

--- a/crates/namidb-server/src/bolt.rs
+++ b/crates/namidb-server/src/bolt.rs
@@ -1514,16 +1514,30 @@ fn map_exec_err(e: ExecError) -> BackendError {
         // A constraint violation has its own Neo4j error class so drivers
         // can distinguish it from an ordinary evaluation error.
         ExecError::Constraint(m) => BackendError::Constraint(m),
-        // The rest are opaque from outside the crate; format and bucket as
-        // either an eval or a storage error on a best-effort substring match.
-        other => {
-            let text = format!("{other}");
-            if text.contains("storage") || text.contains("manifest") {
-                BackendError::Storage(text)
-            } else {
-                BackendError::Eval(text)
-            }
+        // Deterministic budgets get their own ClientError classes: a driver
+        // must be able to tell "this query is too expensive" from "this
+        // query is malformed" without string-matching the message, and must
+        // NOT auto-retry either (a re-run exceeds the same budget again).
+        ExecError::Timeout => {
+            BackendError::Timeout("query exceeded the configured timeout".into())
         }
+        ExecError::RowCap(cap) => BackendError::ResourceLimit(format!(
+            "query exceeded the configured row cap of {cap}"
+        )),
+        ExecError::Storage(err) => match err {
+            // Deterministic search result caps: same query, same outcome —
+            // ClientError, not the auto-retried TransientError bucket.
+            namidb_storage::Error::SearchResultLimitExceeded { .. }
+            | namidb_storage::Error::SearchDocumentLimitExceeded { .. } => {
+                BackendError::ResourceLimit(format!("storage: {err}"))
+            }
+            // Genuinely transient conditions (cache/workspace pressure,
+            // backend unavailability) stay TransientError so official
+            // drivers auto-retry them.
+            other => BackendError::Storage(format!("storage: {other}")),
+        },
+        ExecError::Eval(err) => BackendError::Eval(err.to_string()),
+        ExecError::Runtime(m) => BackendError::Eval(format!("runtime: {m}")),
     }
 }
 

--- a/crates/namidb-server/src/lib.rs
+++ b/crates/namidb-server/src/lib.rs
@@ -1428,8 +1428,85 @@ fn exec_error_classification(
             (StatusCode::PAYLOAD_TOO_LARGE, Some("search_document_limit"))
         }
         other if other.is_unsupported() => (StatusCode::BAD_REQUEST, Some("unsupported")),
+        // A runtime evaluation error (division by zero, missing $parameter,
+        // type mismatch) is the caller's program being wrong, not a server
+        // fault — a 400, not a 500.
+        ExecError::Eval(_) => (StatusCode::BAD_REQUEST, Some("eval_error")),
         _ => (StatusCode::INTERNAL_SERVER_ERROR, None),
     }
+}
+
+/// Wire-stable error taxonomy for HTTP bodies, mirroring the Bolt FAILURE
+/// codes: a dotted Neo4j-shaped class (retry semantics live in the second
+/// segment — `TransientError` is safe to retry, `ClientError` is not) and a
+/// GQLSTATUS/SQLSTATE-class status per error family (42001 syntax, 42000
+/// semantic, 0A000 not supported, 22000 evaluation, 23000 constraint,
+/// 57014 timeout, 54000 result-limit, 53000 insufficient resources, 50N42
+/// unclassified). Bolt <= 5.4 cannot carry GQLSTATUS on the wire — GQL-aware
+/// drivers polyfill every FAILURE with 50N42 — so the HTTP body is where a
+/// client reads the per-family status today.
+fn exec_error_taxonomy(e: &namidb_query::exec::ExecError) -> (&'static str, &'static str) {
+    use namidb_query::exec::ExecError;
+    match e {
+        ExecError::Timeout => ("Neo.ClientError.Transaction.TransactionTimedOut", "57014"),
+        ExecError::RowCap(_) => ("Neo.ClientError.Statement.ResourceLimitExceeded", "54000"),
+        ExecError::Constraint(_) => {
+            ("Neo.ClientError.Schema.ConstraintValidationFailed", "23000")
+        }
+        ExecError::Storage(
+            namidb_storage::Error::SearchResultLimitExceeded { .. }
+            | namidb_storage::Error::SearchDocumentLimitExceeded { .. },
+        ) => ("Neo.ClientError.Statement.ResourceLimitExceeded", "54000"),
+        ExecError::Storage(_) => ("Neo.TransientError.General.DatabaseUnavailable", "53000"),
+        other if other.is_unsupported() => ("Neo.ClientError.Statement.NotSupported", "0A000"),
+        ExecError::Eval(_) => ("Neo.ClientError.Statement.ArgumentError", "22000"),
+        ExecError::Runtime(_) => ("Neo.DatabaseError.General.UnknownError", "50N42"),
+    }
+}
+
+/// 400 response for a statement rejected before execution (parse or plan),
+/// carrying the same machine-readable taxonomy fields as executor failures.
+fn statement_rejected_response(
+    error: String,
+    code: &'static str,
+    neo4j_code: &'static str,
+    gql_status: &'static str,
+) -> Response {
+    (
+        StatusCode::BAD_REQUEST,
+        Json(serde_json::json!({
+            "error": error,
+            "code": code,
+            "neo4j_code": neo4j_code,
+            "gql_status": gql_status,
+        })),
+    )
+        .into_response()
+}
+
+fn parse_error_response(error: String) -> Response {
+    statement_rejected_response(
+        error,
+        "parse_error",
+        "Neo.ClientError.Statement.SyntaxError",
+        "42001",
+    )
+}
+
+fn plan_error_response(e: &namidb_query::LowerError) -> Response {
+    let (code, neo4j_code, gql_status) = match e.kind {
+        namidb_query::LowerErrorKind::UnsupportedFeature => (
+            "unsupported",
+            "Neo.ClientError.Statement.NotSupported",
+            "0A000",
+        ),
+        _ => (
+            "plan_error",
+            "Neo.ClientError.Statement.SemanticError",
+            "42000",
+        ),
+    };
+    statement_rejected_response(format!("plan error: {e}"), code, neo4j_code, gql_status)
 }
 
 /// Build an HTTP error response from an executor failure, classifying it so a
@@ -1604,10 +1681,22 @@ fn collect_route_notes(
 
 fn exec_failure_response(prefix: &str, e: &namidb_query::exec::ExecError) -> Response {
     let (status, code) = exec_error_classification(e);
+    let (neo4j_code, gql_status) = exec_error_taxonomy(e);
     let error = format!("{prefix}: {e}");
+    // `code` stays absent on unclassified 500s (loose clients see no new
+    // requirement there); the taxonomy fields are additive everywhere.
     let body = match code {
-        Some(c) => Json(serde_json::json!({ "error": error, "code": c })),
-        None => Json(serde_json::json!({ "error": error })),
+        Some(c) => Json(serde_json::json!({
+            "error": error,
+            "code": c,
+            "neo4j_code": neo4j_code,
+            "gql_status": gql_status,
+        })),
+        None => Json(serde_json::json!({
+            "error": error,
+            "neo4j_code": neo4j_code,
+            "gql_status": gql_status,
+        })),
     };
     (status, body).into_response()
 }
@@ -2664,13 +2753,10 @@ async fn run_cypher(state: &AppState, req: &CypherRequest, principal: &Principal
                 kind: None,
                 ok: false,
                 elapsed: started.elapsed(),
-                response: (
-                    StatusCode::BAD_REQUEST,
-                    Json(ErrorBody {
-                        error: format!("parse error: {} at {}", first.message, first.span),
-                    }),
-                )
-                    .into_response(),
+                response: parse_error_response(format!(
+                    "parse error: {} at {}",
+                    first.message, first.span
+                )),
             };
         }
     };
@@ -2837,13 +2923,7 @@ async fn run_cypher(state: &AppState, req: &CypherRequest, principal: &Principal
                 kind: None,
                 ok: false,
                 elapsed: started.elapsed(),
-                response: (
-                    StatusCode::BAD_REQUEST,
-                    Json(ErrorBody {
-                        error: format!("plan error: {e}"),
-                    }),
-                )
-                    .into_response(),
+                response: plan_error_response(&e),
             };
         }
     };
@@ -3271,13 +3351,10 @@ async fn run_cypher_multi(
                 kind: None,
                 ok: false,
                 elapsed: started.elapsed(),
-                response: (
-                    StatusCode::BAD_REQUEST,
-                    Json(ErrorBody {
-                        error: format!("parse error: {} at {}", first.message, first.span),
-                    }),
-                )
-                    .into_response(),
+                response: parse_error_response(format!(
+                    "parse error: {} at {}",
+                    first.message, first.span
+                )),
             };
         }
     };
@@ -3445,13 +3522,7 @@ async fn run_cypher_multi(
                 kind: None,
                 ok: false,
                 elapsed: started.elapsed(),
-                response: (
-                    StatusCode::BAD_REQUEST,
-                    Json(ErrorBody {
-                        error: format!("plan error: {e}"),
-                    }),
-                )
-                    .into_response(),
+                response: plan_error_response(&e),
             };
         }
     };
@@ -4379,6 +4450,65 @@ mod tests {
         assert!(json["error"]
             .as_str()
             .is_some_and(|message| message.contains("NAMIDB_BM25_MAX_DOCUMENT_BYTES")));
+    }
+
+    /// NDB-03: resource exhaustion carries its own taxonomy — a client must
+    /// be able to tell "too expensive" from "malformed" without string
+    /// matching, on both the `code` and the Neo4j/GQL-shaped fields.
+    #[tokio::test]
+    async fn timeout_response_exposes_taxonomy_fields() {
+        let response =
+            exec_failure_response("read execution failed", &namidb_query::exec::ExecError::Timeout);
+        assert_eq!(response.status(), StatusCode::GATEWAY_TIMEOUT);
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["code"], "timeout");
+        assert_eq!(
+            json["neo4j_code"],
+            "Neo.ClientError.Transaction.TransactionTimedOut"
+        );
+        assert_eq!(json["gql_status"], "57014");
+
+        let response = exec_failure_response(
+            "read execution failed",
+            &namidb_query::exec::ExecError::RowCap(1_000_000),
+        );
+        assert_eq!(response.status(), StatusCode::PAYLOAD_TOO_LARGE);
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["code"], "row_cap");
+        assert_eq!(
+            json["neo4j_code"],
+            "Neo.ClientError.Statement.ResourceLimitExceeded"
+        );
+        assert_eq!(json["gql_status"], "54000");
+    }
+
+    /// NDB-03: a runtime evaluation error is the caller's program being
+    /// wrong — a 400 with the argument-error taxonomy, not a bare 500.
+    #[tokio::test]
+    async fn division_by_zero_is_a_client_error_with_taxonomy() {
+        let app = fixture(None).await;
+        let response = post_cypher(&app, None, "RETURN 1/0 AS x").await;
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["code"], "eval_error");
+        assert_eq!(json["neo4j_code"], "Neo.ClientError.Statement.ArgumentError");
+        assert_eq!(json["gql_status"], "22000");
+    }
+
+    /// NDB-03: parse errors carry the syntax taxonomy in the HTTP body.
+    #[tokio::test]
+    async fn parse_error_carries_syntax_taxonomy() {
+        let app = fixture(None).await;
+        let response = post_cypher(&app, None, "MATCH (").await;
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["code"], "parse_error");
+        assert_eq!(json["neo4j_code"], "Neo.ClientError.Statement.SyntaxError");
+        assert_eq!(json["gql_status"], "42001");
     }
 
     /// Router for namespace `ns` whose auth is loaded from `tokens_json` (the

--- a/crates/namidb-server/tests/bolt_integration.rs
+++ b/crates/namidb-server/tests/bolt_integration.rs
@@ -321,6 +321,21 @@ async fn boot_bolt_full(
     .await
 }
 
+/// Like [`boot_bolt`] but with a finite query row cap.
+async fn boot_bolt_row_cap(
+    ns: &str,
+    query_row_cap: usize,
+) -> (std::net::SocketAddr, tokio::task::JoinHandle<()>) {
+    boot_bolt_config(
+        ns,
+        Duration::ZERO,
+        Duration::ZERO,
+        DEFAULT_POST_AUTH_MESSAGE_BYTES,
+        query_row_cap,
+    )
+    .await
+}
+
 /// Like [`boot_bolt_full`] with an explicit authenticated-message ceiling.
 /// Keeping the limit in `Config` makes the test deterministic without mutating
 /// process-global environment variables while the integration suite runs in
@@ -330,6 +345,17 @@ async fn boot_bolt_with_message_limit(
     tx_timeout: Duration,
     query_timeout: Duration,
     bolt_max_message_bytes: usize,
+) -> (std::net::SocketAddr, tokio::task::JoinHandle<()>) {
+    boot_bolt_config(ns, tx_timeout, query_timeout, bolt_max_message_bytes, 0).await
+}
+
+/// Bottom-level boot: every knob the taxonomy/limit tests need.
+async fn boot_bolt_config(
+    ns: &str,
+    tx_timeout: Duration,
+    query_timeout: Duration,
+    bolt_max_message_bytes: usize,
+    query_row_cap: usize,
 ) -> (std::net::SocketAddr, tokio::task::JoinHandle<()>) {
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
     let bolt_addr = listener.local_addr().unwrap();
@@ -357,7 +383,7 @@ async fn boot_bolt_with_message_limit(
         bolt_tx_timeout: tx_timeout,
         query_timeout,
         write_timeout: query_timeout,
-        query_row_cap: 0,
+        query_row_cap,
         compaction_l0_trigger: 0,
         write_stall_l0: 0,
         write_stall_delay: Duration::ZERO,
@@ -1255,12 +1281,66 @@ async fn bolt_read_query_times_out() {
     };
     send_msg(&mut stream, &pack(&run)).await;
     let resp = recv_msg(&mut stream).await;
-    assert!(
-        matches!(resp, Response::Failure(_)),
-        "a read past its 1ns budget must fail, got {resp:?}"
+    let meta = match resp {
+        Response::Failure(meta) => meta,
+        other => panic!("a read past its 1ns budget must fail, got {other:?}"),
+    };
+    // The typed taxonomy: a timeout is its own ClientError class (a re-run
+    // would time out again, so drivers must NOT auto-retry it), never the
+    // Statement.ArgumentError bucket a malformed query gets.
+    assert_eq!(
+        meta.get("code"),
+        Some(&Value::String(
+            "Neo.ClientError.Transaction.TransactionTimedOut".into()
+        )),
+        "timeout FAILURE code: {meta:?}"
     );
 
     // Session is FAILED after the error; just drop the connection.
+    stream.shutdown().await.ok();
+    task.abort();
+}
+
+#[tokio::test]
+async fn bolt_row_cap_failure_has_resource_limit_code() {
+    // Row cap 1: any two-row read exceeds it deterministically.
+    let (bolt_addr, task) = boot_bolt_row_cap("bolt-rowcap", 1).await;
+    let mut stream = TcpStream::connect(bolt_addr).await.expect("connect bolt");
+    handshake(&mut stream).await;
+    hello_and_logon(&mut stream, "test-token").await;
+
+    for query in ["CREATE (:Person {name: 'Ada'})", "CREATE (:Person {name: 'Bo'})"] {
+        pull_all(&mut stream, query).await;
+    }
+
+    let run = Value::Struct {
+        tag: struct_tag::RUN,
+        fields: vec![
+            Value::String("MATCH (p:Person) RETURN p.name AS name".into()),
+            Value::Map(BTreeMap::new()),
+            Value::Map(BTreeMap::new()),
+        ],
+    };
+    send_msg(&mut stream, &pack(&run)).await;
+    let resp = recv_msg(&mut stream).await;
+    let meta = match resp {
+        Response::Failure(meta) => meta,
+        other => panic!("a read past the row cap must fail, got {other:?}"),
+    };
+    assert_eq!(
+        meta.get("code"),
+        Some(&Value::String(
+            "Neo.ClientError.Statement.ResourceLimitExceeded".into()
+        )),
+        "row-cap FAILURE code: {meta:?}"
+    );
+    match meta.get("message") {
+        Some(Value::String(message)) => {
+            assert!(message.contains("row cap"), "message: {message}")
+        }
+        other => panic!("FAILURE missing message: {other:?}"),
+    }
+
     stream.shutdown().await.ok();
     task.abort();
 }


### PR DESCRIPTION
NDB-03 from the second field report. Recon corrected two details of the claim before fixing: `50N42` never comes from our code (Bolt ≤5.4 carries no GQLSTATUS; GQL-aware drivers polyfill it), and HTTP already distinguished timeout (504) from row cap (413). The real defect was Bolt-only: `map_exec_err` routed every non-constraint `ExecError` through a substring match, landing `Timeout` and `RowCap` in `Statement.ArgumentError` — the field team's client retried timeouts five times by message-sniffing.

- `BackendError` gains `Timeout` / `ResourceLimit` variants and `#[non_exhaustive]`; `map_exec_err` is an exhaustive typed match. Both new classes are `ClientError` deliberately — official drivers auto-retry `Neo.TransientError.*` only, and a deterministic budget re-run fails identically (retry livelock).
- Deterministic search caps (`SearchResultLimitExceeded`, `SearchDocumentLimitExceeded`) move out of the auto-retried `TransientError` bucket over Bolt (behavior change, release-noted). Genuinely transient pressure (cache/workspace, writer busy, memory, persistence-degraded) stays `TransientError`.
- HTTP bodies now carry `neo4j_code` + `gql_status` on every statement failure, per family (`42001`/`42000`/`0A000`/`22000`/`23000`/`57014`/`54000`/`53000`/`50N42`); parse/plan rejections get typed bodies too, and runtime evaluation errors (division by zero, missing `$param`) become 400 `eval_error` instead of a bare 500. Table documented in the server README.
- Bolt ≥5.7 GQLSTATUS-on-the-wire is a sized roadmap item, not needed for driver retry correctness.

Tests: Bolt FAILURE codes asserted for timeout and row cap; HTTP taxonomy asserted for timeout/row-cap/eval/parse bodies. Existing classification/`bolt_integration` suites green.