### PR TITLE
feat: reduce(), statistical aggregates, typed concat; DISTINCT-endpoint BFS + shortestPath min-bound pruning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,81 @@ crates.io release will establish and document that API explicitly.
 
 ## [Unreleased]
 
+## [2.2.0] - 2026-08-28
+
+Closes the second production field report (12 findings against 2.1.4).
+
+**Breaking**
+- Secure by default: the server now **refuses to start** when no auth
+  source is configured (`--auth-token` / `NAMIDB_AUTH_TOKEN`,
+  `--auth-tokens-file`, or a JWT config). Pass `--no-auth` /
+  `NAMIDB_NO_AUTH=1` to explicitly run open for local development.
+  Previously a missing token silently booted an anonymous read-write
+  server behind a log line.
+- `--bolt-listen` together with `--multi-tenant` now fails at startup.
+  The multi-tenant serve path never started the Bolt listener, so the
+  combination silently dropped the Bolt port; Bolt is single-namespace
+  (run one single-tenant server per namespace). Docs now carry the
+  HTTP-only caveat at every multi-tenant routing mention.
+- `shortestPath` endpoints must be bound by a previous `MATCH`; an
+  unbound endpoint is now a lowering error. Previously it was silently
+  accepted and returned ONE arbitrary reachable node per seed instead
+  of one row per (src, dst) pair.
+- `'text' + <map/node/list/...>` is now a type error instead of
+  concatenating the internal Debug representation into the result
+  (silent data corruption); the same applies to `toString()` on
+  non-scalar values. String `+` still coerces numbers, booleans, and
+  temporals (temporals render as ISO-8601). List `+` gains proper
+  Cypher semantics: `list + list` concatenates, `list + element`
+  appends, `element + list` prepends.
+- Bolt: query timeouts and result-limit errors now carry their own
+  FAILURE codes (`Neo.ClientError.Transaction.TransactionTimedOut`,
+  `Neo.ClientError.Statement.ResourceLimitExceeded`) instead of
+  `Neo.ClientError.Statement.ArgumentError`; deterministic search-cap
+  errors are no longer the auto-retried
+  `Neo.TransientError.General.DatabaseUnavailable`. Clients that
+  string-matched the old codes should switch to the new ones.
+
+**Added**
+- `reduce(acc = init, x IN list | expr)` — the canonical Cypher fold.
+  `reduce` stays usable as a plain identifier (soft keyword).
+- Statistical aggregates: `stdev`, `stdevp`, `percentileCont`,
+  `percentileDisc` (with `DISTINCT` support on the stdev family,
+  NULL-skipping, and typed errors on non-numeric input).
+- Machine-readable error taxonomy on HTTP: every statement failure now
+  carries `neo4j_code` and `gql_status` fields alongside `code`
+  (per-family GQLSTATUS/SQLSTATE-class values — `42001` syntax, `0A000`
+  unsupported, `22000` evaluation, `57014` timeout, `54000` result
+  limits, `53000` transient pressure; table in the server README).
+  Runtime evaluation errors (division by zero, missing `$param`) are
+  now 400 `eval_error` instead of a bare 500.
+- `RETURN DISTINCT <endpoint> [LIMIT n]` over a variable-length pattern
+  now runs as a visited-set BFS instead of enumerating every path:
+  each node is expanded once per seed and emitted once, and the LIMIT
+  stops the traversal early. Previously `DISTINCT ... LIMIT 200` cost
+  exactly the same as counting all paths (exponential in hops).
+- `shortestPath` with a minimum bound (`*2..N`) now prunes its frontier
+  (`(node, hop)` dedup) instead of enumerating every walk — the shape
+  previously hung on realistic graphs.
+
+**Fixed**
+- The official Docker image pre-creates `/var/lib/namidb` owned by its
+  non-root uid (65532), so a named volume mounted at the canonical
+  `file://` store path inherits the right ownership instead of
+  crash-looping with `Permission denied`. Bind mounts (and named
+  volumes created root-owned by older images) still need a one-time
+  `chown -R 65532:65532` — now documented.
+- `namidb backup` help no longer demands a quiescent source: the copy
+  has been live-safe since the retention-pin lease design (point-in-time
+  snapshot at the pinned manifest version; the janitor honours the
+  lease; the residual race fails loudly instead of truncating).
+- The stale claim that coordination uses "S3 conditional writes
+  (`If-Match`, `If-None-Match`, ETag)" is corrected everywhere: the
+  commit path depends on exactly one primitive — PUT-if-absent
+  (`If-None-Match: *`, RFC-029). `If-Match` is NOT required, which
+  re-qualifies stores that only implement the create precondition. The
+  README now states the object-store requirement explicitly.
+
 ## [2.1.4] - 2026-08-17
 
 **Added**
@@ -2652,7 +2727,8 @@ Change License: Apache License 2.0).
 - LDBC-shaped synthetic benchmark harness with a paired Kùzu runner
   under [`bench/`](./bench/).
 
-[Unreleased]: https://github.com/namidb/namidb/compare/v2.1.4...HEAD
+[Unreleased]: https://github.com/namidb/namidb/compare/v2.2.0...HEAD
+[2.2.0]: https://github.com/namidb/namidb/compare/v2.1.4...v2.2.0
 [2.1.4]: https://github.com/namidb/namidb/compare/v2.1.3...v2.1.4
 [2.1.3]: https://github.com/namidb/namidb/compare/v2.1.2...v2.1.3
 [2.1.2]: https://github.com/namidb/namidb/compare/v2.1.1...v2.1.2

--- a/crates/namidb-query/src/exec/expr.rs
+++ b/crates/namidb-query/src/exec/expr.rs
@@ -71,6 +71,7 @@ pub fn evaluate(expr: &Expression, row: &Row, params: &Params) -> Result<Runtime
     let span = expr.span;
     match &expr.kind {
         ExpressionKind::Literal(l) => Ok(literal_to_runtime(l)),
+        ExpressionKind::Reduce(r) => eval_reduce(r, row, params),
         ExpressionKind::Star => Err(EvalError::new("`*` is only valid inside `count(*)`", span)),
         ExpressionKind::Variable(id) => row
             .get(&id.name)
@@ -373,21 +374,53 @@ fn arith(
         (RuntimeValue::String(x), RuntimeValue::String(y)) if string_concat => {
             Ok(RuntimeValue::String(format!("{}{}", x, y)))
         }
-        (RuntimeValue::String(x), other) if string_concat => Ok(RuntimeValue::String(format!(
-            "{}{}",
-            x,
-            runtime_to_string_concat(other)
-        ))),
-        (other, RuntimeValue::String(y)) if string_concat => Ok(RuntimeValue::String(format!(
-            "{}{}",
-            runtime_to_string_concat(other),
-            y
-        ))),
+        // List `+` follows Cypher: list + list concatenates, list + element
+        // appends, element + list prepends. These arms sit before the mixed
+        // string arms so `'a' + [1]` is a list, not a string.
         (RuntimeValue::List(xs), RuntimeValue::List(ys)) if string_concat => {
             let mut out = xs.clone();
             out.extend_from_slice(ys);
             Ok(RuntimeValue::List(out))
         }
+        (RuntimeValue::List(xs), y) if string_concat => {
+            let mut out = xs.clone();
+            out.push(y.clone());
+            Ok(RuntimeValue::List(out))
+        }
+        (x, RuntimeValue::List(ys)) if string_concat => {
+            let mut out = Vec::with_capacity(ys.len() + 1);
+            out.push(x.clone());
+            out.extend_from_slice(ys);
+            Ok(RuntimeValue::List(out))
+        }
+        // String + scalar coerces; string + structural value (map, node,
+        // relationship, ...) is a type error — the old fallback rendered the
+        // internal Debug representation into the result, silently corrupting
+        // data instead of failing.
+        (RuntimeValue::String(x), other) if string_concat => match scalar_to_string(other) {
+            Some(rendered) => Ok(RuntimeValue::String(format!("{x}{rendered}"))),
+            None => Err(EvalError::new(
+                format!(
+                    "cannot apply `{}` between {} and {}",
+                    op_label,
+                    a.type_name(),
+                    b.type_name()
+                ),
+                span,
+            )),
+        },
+        (other, RuntimeValue::String(y)) if string_concat => match scalar_to_string(other) {
+            Some(rendered) => Ok(RuntimeValue::String(format!("{rendered}{y}"))),
+            None => Err(EvalError::new(
+                format!(
+                    "cannot apply `{}` between {} and {}",
+                    op_label,
+                    a.type_name(),
+                    b.type_name()
+                ),
+                span,
+            )),
+        },
         _ => Err(EvalError::new(
             format!(
                 "cannot apply `{}` between {} and {}",
@@ -451,14 +484,26 @@ fn arith_pow(
     }
 }
 
-fn runtime_to_string_concat(v: &RuntimeValue) -> String {
+/// Scalar rendering for string `+` concatenation and `toString()`. Temporal
+/// values render as ISO-8601 (mirroring what `date()`/`datetime()` parse).
+/// Structural values (map, list, node, relationship, path, bytes, vectors)
+/// return `None` so callers surface a type error instead of leaking the
+/// internal Debug representation into query results.
+fn scalar_to_string(v: &RuntimeValue) -> Option<String> {
     match v {
-        RuntimeValue::Null => "".to_string(),
-        RuntimeValue::Integer(n) => n.to_string(),
-        RuntimeValue::Float(f) => f.to_string(),
-        RuntimeValue::String(s) => s.clone(),
-        RuntimeValue::Bool(b) => b.to_string(),
-        _ => format!("{:?}", v),
+        RuntimeValue::Integer(n) => Some(n.to_string()),
+        RuntimeValue::Float(f) => Some(f.to_string()),
+        RuntimeValue::Bool(b) => Some(b.to_string()),
+        RuntimeValue::String(s) => Some(s.clone()),
+        RuntimeValue::Date(days) => {
+            let epoch = chrono::NaiveDate::from_ymd_opt(1970, 1, 1).expect("epoch is valid");
+            epoch
+                .checked_add_signed(chrono::Duration::days(*days as i64))
+                .map(|d| d.format("%Y-%m-%d").to_string())
+        }
+        RuntimeValue::DateTime(micros) => chrono::DateTime::from_timestamp_micros(*micros)
+            .map(|dt| dt.to_rfc3339_opts(chrono::SecondsFormat::AutoSi, true)),
+        _ => None,
     }
 }
 
@@ -759,9 +804,18 @@ fn call_scalar_function(
         "substring" => str_substring(args, span),
         "replace" => str_replace(args, span),
         "split" => str_split(args, span),
-        "tostring" => single_arg(name, args, span).map(|v| match v {
-            RuntimeValue::Null => RuntimeValue::Null,
-            other => RuntimeValue::String(runtime_to_string_concat(&other)),
+        "tostring" => single_arg(name, args, span).and_then(|v| match v {
+            RuntimeValue::Null => Ok(RuntimeValue::Null),
+            other => match scalar_to_string(&other) {
+                Some(rendered) => Ok(RuntimeValue::String(rendered)),
+                None => Err(EvalError::new(
+                    format!(
+                        "toString() expects a scalar value, got {}",
+                        other.type_name()
+                    ),
+                    span,
+                )),
+            },
         }),
         "tointeger" => single_arg(name, args, span).map(|v| match v {
             RuntimeValue::Integer(n) => RuntimeValue::Integer(n),
@@ -1395,6 +1449,34 @@ fn range_fn(args: &[RuntimeValue], span: SourceSpan) -> Result<RuntimeValue, Eva
     Ok(RuntimeValue::List(out))
 }
 
+/// Evaluate `reduce(acc = init, x IN list | expr)`: fold `list` into a
+/// single value, rebinding `acc` to the body's result per element.
+fn eval_reduce(
+    r: &crate::parser::ast::Reduce,
+    row: &Row,
+    params: &Params,
+) -> Result<RuntimeValue, EvalError> {
+    let list_v = evaluate(&r.list, row, params)?;
+    let items = match list_v {
+        RuntimeValue::List(items) => items,
+        RuntimeValue::Null => return Ok(RuntimeValue::Null),
+        other => {
+            return Err(EvalError::new(
+                format!("reduce() requires a list, got {}", other.type_name()),
+                r.list.span,
+            ));
+        }
+    };
+    let mut acc = evaluate(&r.init, row, params)?;
+    for item in items {
+        let mut local = row.clone();
+        local.set(r.accumulator.name.clone(), acc);
+        local.set(r.variable.name.clone(), item);
+        acc = evaluate(&r.expression, &local, params)?;
+    }
+    Ok(acc)
+}
+
 fn eval_list_comprehension(
     lc: &crate::parser::ListComprehension,
     row: &Row,
@@ -1669,6 +1751,136 @@ mod tests {
             eval_str("'hello' + ' ' + 'world'", &Row::new(), &Params::new()),
             RuntimeValue::String("hello world".into())
         );
+    }
+
+    /// Evaluate an expression expecting an error; returns the message.
+    fn eval_err(src: &str) -> String {
+        let q = parse(&format!("RETURN {} AS r", src)).unwrap();
+        let item = match &q.head.clauses[0] {
+            crate::parser::Clause::Return(r) => &r.items[0].expression,
+            _ => panic!(),
+        };
+        evaluate(item, &Row::new(), &Params::new())
+            .unwrap_err()
+            .message
+    }
+
+    /// NDB-11: string + structural value is a type error, never the Debug
+    /// representation leaking into the result as silently corrupt data.
+    #[test]
+    fn string_plus_scalar_coerces_and_structural_errors() {
+        assert_eq!(
+            eval_str("'a' + 1", &Row::new(), &Params::new()),
+            RuntimeValue::String("a1".into())
+        );
+        assert_eq!(
+            eval_str("1 + 'a'", &Row::new(), &Params::new()),
+            RuntimeValue::String("1a".into())
+        );
+        assert_eq!(
+            eval_str("'a' + true", &Row::new(), &Params::new()),
+            RuntimeValue::String("atrue".into())
+        );
+        assert_eq!(
+            eval_str("'v' + 1.5", &Row::new(), &Params::new()),
+            RuntimeValue::String("v1.5".into())
+        );
+        let msg = eval_err("'texto' + {a: 1}");
+        assert!(
+            msg.contains("cannot apply `+` between STRING and MAP"),
+            "{msg}"
+        );
+        // NULL propagation is unchanged.
+        assert_eq!(
+            eval_str("'a' + NULL", &Row::new(), &Params::new()),
+            RuntimeValue::Null
+        );
+    }
+
+    #[test]
+    fn list_plus_follows_cypher_concat_semantics() {
+        assert_eq!(
+            eval_str("[1] + [2, 3]", &Row::new(), &Params::new()),
+            RuntimeValue::List(vec![
+                RuntimeValue::Integer(1),
+                RuntimeValue::Integer(2),
+                RuntimeValue::Integer(3)
+            ])
+        );
+        assert_eq!(
+            eval_str("[1] + 2", &Row::new(), &Params::new()),
+            RuntimeValue::List(vec![RuntimeValue::Integer(1), RuntimeValue::Integer(2)])
+        );
+        assert_eq!(
+            eval_str("'a' + [1]", &Row::new(), &Params::new()),
+            RuntimeValue::List(vec![
+                RuntimeValue::String("a".into()),
+                RuntimeValue::Integer(1)
+            ])
+        );
+    }
+
+    /// NDB-05: reduce() folds with the accumulator rebound per element.
+    #[test]
+    fn reduce_folds_lists() {
+        assert_eq!(
+            eval_str(
+                "reduce(acc = 1.0, x IN [0.5, 0.8] | acc * x)",
+                &Row::new(),
+                &Params::new()
+            ),
+            RuntimeValue::Float((1.0_f64 * 0.5) * 0.8)
+        );
+        assert_eq!(
+            eval_str(
+                "reduce(s = 0, x IN [1, 2, 3] | s + x)",
+                &Row::new(),
+                &Params::new()
+            ),
+            RuntimeValue::Integer(6)
+        );
+        // Empty list -> init untouched; NULL list -> NULL.
+        assert_eq!(
+            eval_str(
+                "reduce(s = 42, x IN [] | s + x)",
+                &Row::new(),
+                &Params::new()
+            ),
+            RuntimeValue::Integer(42)
+        );
+        assert_eq!(
+            eval_str(
+                "reduce(s = 0, x IN NULL | s + x)",
+                &Row::new(),
+                &Params::new()
+            ),
+            RuntimeValue::Null
+        );
+        // String building works through the concat rules.
+        assert_eq!(
+            eval_str(
+                "reduce(s = '', w IN ['a', 'b', 'c'] | s + w)",
+                &Row::new(),
+                &Params::new()
+            ),
+            RuntimeValue::String("abc".into())
+        );
+        let msg = eval_err("reduce(s = 0, x IN 7 | s + x)");
+        assert!(msg.contains("reduce() requires a list"), "{msg}");
+    }
+
+    #[test]
+    fn tostring_scalars_only_iso_for_temporals() {
+        assert_eq!(
+            eval_str("toString(date('2026-08-28'))", &Row::new(), &Params::new()),
+            RuntimeValue::String("2026-08-28".into())
+        );
+        assert_eq!(
+            eval_str("'d: ' + date('2026-08-28')", &Row::new(), &Params::new()),
+            RuntimeValue::String("d: 2026-08-28".into())
+        );
+        let msg = eval_err("toString({a: 1})");
+        assert!(msg.contains("toString() expects a scalar"), "{msg}");
     }
 
     #[test]

--- a/crates/namidb-query/src/exec/walker.rs
+++ b/crates/namidb-query/src/exec/walker.rs
@@ -627,6 +627,25 @@ pub(crate) fn execute_inner_with_routing<'a>(
                 distinct,
                 discard_input_bindings,
             } => {
+                // NDB-04: DISTINCT over endpoint-only projections of a
+                // var-length expand runs as a visited-set BFS instead of
+                // the exponential trail enumeration.
+                if *distinct {
+                    if let Some(rows) = try_execute_endpoint_distinct_project(
+                        input,
+                        items,
+                        *discard_input_bindings,
+                        snapshot,
+                        params,
+                        outer,
+                        routing,
+                        None,
+                    )
+                    .await?
+                    {
+                        return Ok(rows);
+                    }
+                }
                 let rows =
                     execute_inner_with_routing(input, snapshot, params, outer, routing).await?;
                 let projected = project_rows(&rows, items, *discard_input_bindings, params)?;
@@ -963,6 +982,7 @@ pub(crate) fn execute_inner_with_routing<'a>(
                         *back_reference,
                     ),
                     None,
+                    false,
                 )
                 .await
             }
@@ -1053,6 +1073,34 @@ fn execute_capped<'a>(
                 project_rows(&rows, items, *discard_input_bindings, params)
             }
 
+            // DISTINCT endpoints of a var-length expand (NDB-04): the
+            // endpoint BFS dedups globally, so the LIMIT budget crosses the
+            // distinct projection exactly. Any other distinct shape falls
+            // through to full execution (a capped prefix of a shrinking
+            // projection could under-produce).
+            LogicalPlan::Project {
+                input,
+                items,
+                distinct: true,
+                discard_input_bindings,
+            } => {
+                if let Some(rows) = try_execute_endpoint_distinct_project(
+                    input,
+                    items,
+                    *discard_input_bindings,
+                    snapshot,
+                    params,
+                    outer,
+                    routing,
+                    Some(cap),
+                )
+                .await?
+                {
+                    return Ok(rows);
+                }
+                execute_inner_with_routing(plan, snapshot, params, outer, routing).await
+            }
+
             LogicalPlan::Expand {
                 input,
                 source,
@@ -1094,6 +1142,7 @@ fn execute_capped<'a>(
                         *back_reference,
                     ),
                     Some(cap),
+                    false,
                 )
                 .await
             }
@@ -1182,6 +1231,87 @@ fn execute_capped<'a>(
 
 // ───────────────────────── Expand ────────────────────────────────────
 
+/// NDB-04: `RETURN DISTINCT <endpoint-only projections> [LIMIT n]` over a
+/// variable-length Expand. When every projected expression reads ONLY the
+/// expand's target binding, path multiplicity and seed identity are erased
+/// by the DISTINCT — so the exponential trail enumeration can be replaced
+/// by a visited-set BFS that emits each endpoint once (see `endpoint_bfs`
+/// in [`execute_expand`]). Returns `None` when the shape does not apply;
+/// the caller falls back to the ordinary path.
+#[allow(clippy::too_many_arguments)]
+async fn try_execute_endpoint_distinct_project(
+    input: &LogicalPlan,
+    items: &[crate::plan::ProjectionItem],
+    discard_input_bindings: bool,
+    snapshot: &Snapshot<'_>,
+    params: &Params,
+    outer: Option<&Row>,
+    routing: &PlanRouting,
+    cap: Option<usize>,
+) -> Result<Option<Vec<Row>>, ExecError> {
+    let LogicalPlan::Expand {
+        input: expand_input,
+        source,
+        edge_type,
+        direction,
+        rel_alias,
+        target_alias,
+        target_labels,
+        length,
+        optional: false,
+        back_reference: false,
+        shortest: crate::plan::ShortestMode::None,
+        path_binding: None,
+    } = input
+    else {
+        return Ok(None);
+    };
+    if length.is_none() {
+        return Ok(None);
+    }
+    // Multiplicity is only unobservable when the projection reads nothing
+    // but the endpoint — any other referenced binding (the seed, a rel
+    // list) re-introduces per-path / per-seed visibility.
+    let mut referenced: BTreeSet<String> = BTreeSet::new();
+    for item in items {
+        collect_referenced_variables(&item.expression, &mut referenced);
+    }
+    if referenced.is_empty() || !referenced.iter().all(|name| name == target_alias) {
+        return Ok(None);
+    }
+    let resolved = resolve_length(length, params)?;
+    let (min, max) = resolved.as_ref().map(|l| (l.min, l.max)).unwrap_or((1, 1));
+    if min > 1 || max <= 1 {
+        // A larger minimum needs longer-than-first-visit walks (first-visit
+        // dedup would under-return); a single hop has no multiplicity to
+        // erase.
+        return Ok(None);
+    }
+    let rows = execute_inner_with_routing(expand_input, snapshot, params, outer, routing).await?;
+    let expanded = execute_expand(
+        rows,
+        source,
+        edge_type.as_deref(),
+        *direction,
+        rel_alias.as_deref(),
+        target_alias,
+        target_labels,
+        resolved.clone(),
+        false,
+        false,
+        crate::plan::ShortestMode::None,
+        None,
+        snapshot,
+        routing.edge_read_mode(rel_alias.as_deref(), None),
+        should_skip_target_materialize(routing, target_alias, target_labels, None, resolved, false),
+        cap,
+        true,
+    )
+    .await?;
+    let projected = project_rows(&expanded, items, discard_input_bindings, params)?;
+    Ok(Some(dedup_rows(projected)))
+}
+
 /// Clamp an open-ended variable-length upper bound (`max == u32::MAX`, from a
 /// `*` / `*N..` pattern) to the configured hop cap. A finite bound passes
 /// through unchanged.
@@ -1252,6 +1382,7 @@ pub(crate) async fn execute_expand(
     edge_read_mode: EdgeReadMode,
     skip_target_materialize: bool,
     cap: Option<usize>,
+    endpoint_distinct: bool,
 ) -> Result<Vec<Row>, ExecError> {
     namidb_core::profile_scope!("walker::execute_expand");
     let edge_types = resolve_edge_types(snapshot, edge_type);
@@ -1261,6 +1392,22 @@ pub(crate) async fn execute_expand(
     // any starred range — `*1..1` included) binds the LIST of traversed
     // relationships; only the unstarred fixed form binds a scalar.
     let bind_rel_list = length.is_some();
+    // Endpoint-distinct BFS (NDB-04): when the DISTINCT projection above
+    // reads ONLY the endpoint binding, path multiplicity and seed identity
+    // are unobservable, so the deg^hop trail enumeration collapses to a
+    // visited-set BFS — each node expanded once per seed, emitted once
+    // globally. Conditions re-checked defensively; the caller
+    // (`try_execute_endpoint_distinct_project`) guarantees them.
+    let endpoint_bfs = endpoint_distinct
+        && shortest == crate::plan::ShortestMode::None
+        && !back_reference
+        && path_binding.is_none()
+        && !optional
+        && min <= 1;
+    // Cross-seed emission dedup for the endpoint BFS. It is what makes a
+    // pushed LIMIT budget (`cap`) exact: the capped prefix of a
+    // globally-deduped stream is a prefix of the uncapped DISTINCT result.
+    let mut emitted: std::collections::HashSet<NodeId> = std::collections::HashSet::new();
 
     let mut out = Vec::new();
     for row in rows {
@@ -1349,7 +1496,7 @@ pub(crate) async fn execute_expand(
                     Some(existing) => starting == existing,
                     None => true,
                 };
-            if zero_keeps {
+            if zero_keeps && (!endpoint_bfs || emitted.insert(starting)) {
                 hop_results.push(zero_row);
                 matched_any = true;
             }
@@ -1393,11 +1540,26 @@ pub(crate) async fn execute_expand(
         // for `min <= 1`: a larger minimum needs longer-than-shortest walks,
         // which the exhaustive frontier still provides.
         let bfs_prune = shortest != crate::plan::ShortestMode::None && min <= 1;
+        let prune_visits = bfs_prune || endpoint_bfs;
+        // Shortest-mode pruning pre-visits the seed (a path back to it is
+        // never shortest); the endpoint BFS must NOT — the seed can be its
+        // own endpoint through a cycle within [min..max].
         let mut visited: std::collections::HashSet<NodeId> = if bfs_prune {
             std::collections::HashSet::from([starting])
         } else {
             std::collections::HashSet::new()
         };
+        // `*2..N` shortestPath needs walks longer than the shortest, which
+        // node-visited pruning would drop; dedup the frontier on (node, hop)
+        // instead so it stays O(V) per level rather than deg^hop. First-mode
+        // only: allShortestPaths must keep every distinct same-length path.
+        // (Theoretical corner: the kept walk at (node, hop) could be
+        // trail-blocked where a dropped one was not — accepted for "some
+        // shortest path" output over the previous exhaustive frontier, which
+        // simply hung on realistic graphs.)
+        let hop_keyed_prune = shortest == crate::plan::ShortestMode::First && min >= 2;
+        let mut visited_at_hop: std::collections::HashSet<(NodeId, u32)> =
+            std::collections::HashSet::new();
         let hop_start = min.max(1);
         let _ = hop_start;
         for hop in 1..=max {
@@ -1459,17 +1621,18 @@ pub(crate) async fn execute_expand(
             for (step, neighbours) in step_neighbours {
                 for edge in neighbours {
                     let target_id = partner_id(&edge, direction, step.tail);
-                    if bfs_prune {
+                    if prune_visits {
                         // Reached at an earlier level → any path through it now
-                        // is longer than shortest; skip both as a result and as
-                        // a frontier extension.
+                        // is longer than shortest (endpoint BFS: already
+                        // expanded and emitted at its first level); skip both
+                        // as a result and as a frontier extension.
                         if visited.contains(&target_id) {
                             continue;
                         }
-                        // One walk per node per level suffices for `First`;
-                        // `All` keeps every same-level arrival (each is a
-                        // distinct shortest path).
-                        if shortest == crate::plan::ShortestMode::First
+                        // One walk per node per level suffices for `First` and
+                        // for the endpoint BFS; `All` keeps every same-level
+                        // arrival (each is a distinct shortest path).
+                        if (shortest == crate::plan::ShortestMode::First || endpoint_bfs)
                             && !level_seen.insert(target_id)
                         {
                             continue;
@@ -1493,6 +1656,12 @@ pub(crate) async fn execute_expand(
                         if step.rels.contains(k) {
                             continue;
                         }
+                    }
+                    // (node, hop) dedup AFTER the trail check, so a walk the
+                    // trail rule rejects cannot consume the slot a valid
+                    // alternative arrival needed.
+                    if hop_keyed_prune && !visited_at_hop.insert((target_id, hop)) {
+                        continue;
                     }
                     // Back-reference fast path: skip the lookup_node
                     // (the binding's NodeView is already on the row).
@@ -1664,7 +1833,18 @@ pub(crate) async fn execute_expand(
             if matched_any && shortest != crate::plan::ShortestMode::None {
                 break;
             }
-            if bfs_prune {
+            // Endpoint BFS under a pushed LIMIT: globally-deduped emission
+            // makes the budget exact, so stop expanding once this seed's
+            // results satisfy it (the level already emitted may overshoot a
+            // little; TopN truncates exactly).
+            if endpoint_bfs {
+                if let Some(c) = cap {
+                    if out.len() + hop_results.len() >= c {
+                        break;
+                    }
+                }
+            }
+            if prune_visits {
                 // Seal the level: everything reached this hop is now at its
                 // final (minimal) depth. Deferred to level end so `All` mode
                 // admits every same-level arrival above.
@@ -5999,7 +6179,104 @@ fn aggregate_over(
             let vals = collect_non_null(rows, arg, *distinct, params)?;
             Ok(RuntimeValue::List(vals))
         }
+        AggregateExpr::Stdev {
+            arg,
+            distinct,
+            population,
+        } => {
+            let vals = collect_non_null(rows, arg, *distinct, params)?;
+            let name = if *population { "stdevp" } else { "stdev" };
+            let nums = numeric_values(&vals, name)?;
+            match nums.len() {
+                0 => Ok(RuntimeValue::Null),
+                1 => Ok(RuntimeValue::Float(0.0)),
+                n => {
+                    let mean = nums.iter().sum::<f64>() / n as f64;
+                    let ss: f64 = nums.iter().map(|v| (v - mean) * (v - mean)).sum();
+                    let denom = if *population {
+                        n as f64
+                    } else {
+                        (n - 1) as f64
+                    };
+                    Ok(RuntimeValue::Float((ss / denom).sqrt()))
+                }
+            }
+        }
+        AggregateExpr::Percentile {
+            arg,
+            percentile,
+            continuous,
+        } => {
+            let vals = collect_non_null(rows, arg, false, params)?;
+            if vals.is_empty() {
+                return Ok(RuntimeValue::Null);
+            }
+            let p = percentile_fraction(rows, percentile, params)?;
+            let name = if *continuous {
+                "percentileCont"
+            } else {
+                "percentileDisc"
+            };
+            // Both forms require numeric values (Neo4j parity), even though
+            // the discrete form returns one of the inputs unchanged.
+            let nums = numeric_values(&vals, name)?;
+            if *continuous {
+                let mut nums = nums;
+                nums.sort_by(|a, b| a.partial_cmp(b).unwrap_or(Ordering::Equal));
+                let rank = p * (nums.len() - 1) as f64;
+                let lo = rank.floor() as usize;
+                let hi = rank.ceil() as usize;
+                let frac = rank - lo as f64;
+                Ok(RuntimeValue::Float(nums[lo] + (nums[hi] - nums[lo]) * frac))
+            } else {
+                let mut sorted = vals;
+                sorted.sort_by(|a, b| order_for_sort(a, b, false));
+                // Nearest-rank: 1-based ceil(p * n), clamped into range so
+                // p = 0.0 yields the minimum.
+                let n = sorted.len();
+                let idx = ((p * n as f64).ceil() as usize).clamp(1, n) - 1;
+                Ok(sorted.swap_remove(idx))
+            }
+        }
     }
+}
+
+/// Coerce aggregate inputs to `f64`, erroring on non-numeric values.
+fn numeric_values(vals: &[RuntimeValue], fname: &str) -> Result<Vec<f64>, ExecError> {
+    vals.iter()
+        .map(|v| match v {
+            RuntimeValue::Integer(n) => Ok(*n as f64),
+            RuntimeValue::Float(f) => Ok(*f),
+            other => Err(ExecError::Runtime(format!(
+                "{fname}() requires numeric values, got {}",
+                other.type_name()
+            ))),
+        })
+        .collect()
+}
+
+/// Evaluate and validate the percentile argument (a number in `0.0..=1.0`).
+/// Evaluated against the group's first row, so a non-constant expression
+/// resolves per group like any other aggregate argument would.
+fn percentile_fraction(rows: &[Row], e: &Expression, params: &Params) -> Result<f64, ExecError> {
+    let default_row = Row::new();
+    let row = rows.first().unwrap_or(&default_row);
+    let p = match evaluate(e, row, params)? {
+        RuntimeValue::Integer(n) => n as f64,
+        RuntimeValue::Float(f) => f,
+        other => {
+            return Err(ExecError::Runtime(format!(
+                "percentile must be a number between 0.0 and 1.0, got {}",
+                other.type_name()
+            )))
+        }
+    };
+    if p.is_nan() || !(0.0..=1.0).contains(&p) {
+        return Err(ExecError::Runtime(format!(
+            "percentile must be between 0.0 and 1.0, got {p}"
+        )));
+    }
+    Ok(p)
 }
 
 fn collect_non_null(
@@ -6666,6 +6943,7 @@ pub(crate) fn execute_factor_inner_with_routing<'a>(
                         routing.edge_read_mode(rel_alias.as_deref(), path_binding.as_deref()),
                         false,
                         None,
+                        false,
                     )
                     .await?;
                     return Ok(FactorRowSet::from_flat(out));
@@ -6758,6 +7036,25 @@ pub(crate) fn execute_factor_inner_with_routing<'a>(
                 distinct,
                 discard_input_bindings,
             } => {
+                // NDB-04: DISTINCT over endpoint-only projections of a
+                // var-length expand runs as a visited-set BFS instead of
+                // the exponential trail enumeration.
+                if *distinct {
+                    if let Some(rows) = try_execute_endpoint_distinct_project(
+                        input,
+                        items,
+                        *discard_input_bindings,
+                        snapshot,
+                        params,
+                        outer,
+                        routing,
+                        None,
+                    )
+                    .await?
+                    {
+                        return Ok(FactorRowSet::from_flat(rows));
+                    }
+                }
                 let input_set =
                     execute_factor_inner_with_routing(input, snapshot, params, outer, routing)
                         .await?;
@@ -8118,6 +8415,16 @@ fn collect_referenced_variables(expr: &Expression, out: &mut BTreeSet<String>) {
                 collect_referenced_variables(v, out);
             }
         }
+        // reduce() is evaluated by the plain expression engine (never routed
+        // to a pattern branch), so the sink must carry everything its init,
+        // list, and body read. The local accumulator/variable are shadowed
+        // per element; collecting a same-named host binding over-collects,
+        // which is the safe direction for a thin row.
+        ExpressionKind::Reduce(r) => {
+            collect_referenced_variables(&r.init, out);
+            collect_referenced_variables(&r.list, out);
+            collect_referenced_variables(&r.expression, out);
+        }
         // Closed pattern forms — the binding reads they perform live
         // inside their own sub-plan, not in the host expression.
         ExpressionKind::Exists(_)
@@ -8477,8 +8784,15 @@ fn collect_plan_references(
                     | AggregateExpr::Avg { arg: e, .. }
                     | AggregateExpr::Min { arg: e }
                     | AggregateExpr::Max { arg: e }
+                    | AggregateExpr::Stdev { arg: e, .. }
                     | AggregateExpr::Collect { arg: e, .. } => {
                         collect_referenced_variables(e, out);
+                    }
+                    AggregateExpr::Percentile {
+                        arg, percentile, ..
+                    } => {
+                        collect_referenced_variables(arg, out);
+                        collect_referenced_variables(percentile, out);
                     }
                     AggregateExpr::Count { arg: None, .. } => {}
                 }

--- a/crates/namidb-query/src/exec/writer.rs
+++ b/crates/namidb-query/src/exec/writer.rs
@@ -964,6 +964,7 @@ fn execute_write_inner_mode<'a>(
                     crate::exec::walker::EdgeReadMode::Properties,
                     false,
                     None,
+                    false,
                 )
                 .await
             }

--- a/crates/namidb-query/src/optimize/mod.rs
+++ b/crates/namidb-query/src/optimize/mod.rs
@@ -216,6 +216,13 @@ fn visit_expression(expr: &Expression, out: &mut BTreeSet<String>) {
             visit_expression(&q.predicate, out);
             out.insert(q.variable.name.clone());
         }
+        ExpressionKind::Reduce(r) => {
+            visit_expression(&r.init, out);
+            visit_expression(&r.list, out);
+            visit_expression(&r.expression, out);
+            out.insert(r.accumulator.name.clone());
+            out.insert(r.variable.name.clone());
+        }
         ExpressionKind::PatternComprehension(pc) => {
             if let Some(b) = &pc.binding {
                 out.insert(b.name.clone());

--- a/crates/namidb-query/src/optimize/projection_pushdown.rs
+++ b/crates/namidb-query/src/optimize/projection_pushdown.rs
@@ -303,7 +303,14 @@ fn collect_from_aggregate(agg: &AggregateExpr, req: &mut RequiredSet) {
         | AggregateExpr::Avg { arg: e, .. }
         | AggregateExpr::Min { arg: e }
         | AggregateExpr::Max { arg: e }
+        | AggregateExpr::Stdev { arg: e, .. }
         | AggregateExpr::Collect { arg: e, .. } => collect_from_expr(e, req),
+        AggregateExpr::Percentile {
+            arg, percentile, ..
+        } => {
+            collect_from_expr(arg, req);
+            collect_from_expr(percentile, req);
+        }
         AggregateExpr::Count { arg: None, .. } => {}
     }
 }
@@ -467,6 +474,11 @@ fn collect_from_expr(expr: &Expression, req: &mut RequiredSet) {
         ExpressionKind::Quantifier(q) => {
             collect_from_expr(&q.list, req);
             collect_from_expr(&q.predicate, req);
+        }
+        ExpressionKind::Reduce(r) => {
+            collect_from_expr(&r.init, req);
+            collect_from_expr(&r.list, req);
+            collect_from_expr(&r.expression, req);
         }
         ExpressionKind::PatternComprehension(pc) => {
             collect_from_pattern_element(&pc.pattern, req);

--- a/crates/namidb-query/src/parser/ast.rs
+++ b/crates/namidb-query/src/parser/ast.rs
@@ -854,6 +854,9 @@ pub enum ExpressionKind {
     /// List quantifier predicate: `all(x IN list WHERE pred)` and its
     /// `any`/`none`/`single` siblings. Returns a boolean.
     Quantifier(Box<Quantifier>),
+    /// `reduce(acc = init, x IN list | expr)` — fold `list` into a single
+    /// value: `acc` starts at `init` and is rebound to `expr` per element.
+    Reduce(Box<Reduce>),
     /// `*` projection placeholder. Reserved — RFC-004 §Open question Q1.
     Star,
 }
@@ -879,6 +882,18 @@ pub struct Quantifier {
     pub variable: Identifier,
     pub list: Expression,
     pub predicate: Expression,
+    pub span: SourceSpan,
+}
+
+/// `reduce(<accumulator> = <init>, <variable> IN <list> | <expression>)`.
+/// `accumulator` and `variable` are local bindings scoped to `expression`.
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct Reduce {
+    pub accumulator: Identifier,
+    pub init: Expression,
+    pub variable: Identifier,
+    pub list: Expression,
+    pub expression: Expression,
     pub span: SourceSpan,
 }
 

--- a/crates/namidb-query/src/parser/display.rs
+++ b/crates/namidb-query/src/parser/display.rs
@@ -621,6 +621,11 @@ impl fmt::Display for Expression {
                     kw, q.variable, q.list, q.predicate
                 )
             }
+            ExpressionKind::Reduce(r) => write!(
+                f,
+                "reduce({} = {}, {} IN {} | {})",
+                r.accumulator, r.init, r.variable, r.list, r.expression
+            ),
             ExpressionKind::Star => f.write_str("*"),
         }
     }

--- a/crates/namidb-query/src/parser/grammar.rs
+++ b/crates/namidb-query/src/parser/grammar.rs
@@ -2223,6 +2223,46 @@ impl<'src> Parser<'src> {
             && matches!(self.peek_at(2), Some(Token::In))
     }
 
+    /// `reduce` is a soft keyword: only `reduce(<ident> = ...` is the fold
+    /// form, so `reduce` stays usable as a variable and `reduce(a, b)` as a
+    /// plain (unsupported) function call.
+    fn looks_like_reduce(&self) -> bool {
+        self.check(&Token::LParen)
+            && matches!(
+                self.peek_at(1),
+                Some(Token::Ident(_)) | Some(Token::QuotedIdent(_))
+            )
+            && matches!(self.peek_at(2), Some(Token::Eq))
+    }
+
+    /// Parse the body of `reduce(acc = init, x IN list | expr)` starting at
+    /// the `(`. `start` is the byte offset of the `reduce` keyword.
+    fn parse_reduce_body(&mut self, start: usize) -> Result<Expression, ParseError> {
+        self.expect(&Token::LParen)?;
+        let accumulator = self.expect_identifier()?;
+        self.expect(&Token::Eq)?;
+        let init = self.parse_expression()?;
+        self.expect_in(&Token::Comma, "reduce(acc = init, x IN list | expr)")?;
+        let variable = self.expect_identifier()?;
+        self.expect(&Token::In)?;
+        let list = self.parse_expression()?;
+        self.expect_in(&Token::Pipe, "reduce(acc = init, x IN list | expr)")?;
+        let expression = self.parse_expression()?;
+        let rparen = self.expect_in(&Token::RParen, "reduce(acc = init, x IN list | expr)")?;
+        let span = SourceSpan::new(start, rparen.span.end);
+        Ok(Expression {
+            kind: ExpressionKind::Reduce(Box::new(Reduce {
+                accumulator,
+                init,
+                variable,
+                list,
+                expression,
+                span,
+            })),
+            span,
+        })
+    }
+
     /// Parse the body of a list quantifier starting at the `(`: `(x IN list
     /// WHERE pred)`. `start` is the byte offset of the quantifier keyword.
     fn parse_quantifier_body(
@@ -2277,6 +2317,9 @@ impl<'src> Parser<'src> {
                 if self.looks_like_quantifier() {
                     return self.parse_quantifier_body(kind, segments[0].span.start);
                 }
+            }
+            if segments[0].name.eq_ignore_ascii_case("reduce") && self.looks_like_reduce() {
+                return self.parse_reduce_body(segments[0].span.start);
             }
         }
 
@@ -2678,6 +2721,46 @@ mod tests {
                 }
                 other => panic!("expected list comprehension, got {:?}", other),
             },
+            _ => panic!(),
+        }
+    }
+
+    /// NDB-05: `reduce(acc = init, x IN list | expr)` parses; `reduce` stays
+    /// a soft keyword (a plain call or a variable named `reduce` is intact).
+    #[test]
+    fn reduce_folds_parse_and_display_round_trip() {
+        let q = ok("RETURN reduce(acc = 1.0, x IN [0.5, 0.8] | acc * x) AS peso");
+        match &q.head.clauses[0] {
+            Clause::Return(r) => match &r.items[0].expression.kind {
+                ExpressionKind::Reduce(rd) => {
+                    assert_eq!(rd.accumulator.name, "acc");
+                    assert_eq!(rd.variable.name, "x");
+                    // Display round-trips back through the parser.
+                    let rendered = format!("{}", r.items[0].expression);
+                    assert_eq!(rendered, "reduce(acc = 1.0, x IN [0.5, 0.8] | (acc * x))");
+                    ok(&format!("RETURN {rendered} AS peso"));
+                }
+                other => panic!("expected reduce, got {:?}", other),
+            },
+            _ => panic!(),
+        }
+
+        // Soft keyword: `reduce(a, b)` is still a plain function call and a
+        // variable named `reduce` still resolves as a variable.
+        let q = ok("RETURN reduce(1, 2) AS r");
+        match &q.head.clauses[0] {
+            Clause::Return(r) => assert!(matches!(
+                r.items[0].expression.kind,
+                ExpressionKind::FunctionCall { .. }
+            )),
+            _ => panic!(),
+        }
+        let q = ok("WITH 1 AS reduce RETURN reduce + 1 AS r");
+        match &q.head.clauses[1] {
+            Clause::Return(r) => assert!(matches!(
+                r.items[0].expression.kind,
+                ExpressionKind::Binary { .. }
+            )),
             _ => panic!(),
         }
     }

--- a/crates/namidb-query/src/plan/explain.rs
+++ b/crates/namidb-query/src/plan/explain.rs
@@ -960,6 +960,25 @@ fn format_aggregate(agg: &AggregateExpr) -> String {
         AggregateExpr::Min { arg } => format!("min({})", arg),
         AggregateExpr::Max { arg } => format!("max({})", arg),
         AggregateExpr::Collect { arg, distinct } => format_args("collect", arg, *distinct),
+        AggregateExpr::Stdev {
+            arg,
+            distinct,
+            population,
+        } => format_args(if *population { "stdevp" } else { "stdev" }, arg, *distinct),
+        AggregateExpr::Percentile {
+            arg,
+            percentile,
+            continuous,
+        } => format!(
+            "{}({}, {})",
+            if *continuous {
+                "percentileCont"
+            } else {
+                "percentileDisc"
+            },
+            arg,
+            percentile
+        ),
     }
 }
 

--- a/crates/namidb-query/src/plan/logical.rs
+++ b/crates/namidb-query/src/plan/logical.rs
@@ -711,6 +711,21 @@ pub enum AggregateExpr {
         arg: Expression,
         distinct: bool,
     },
+    /// `stdev(expr)` — sample standard deviation (n-1 denominator);
+    /// `population` selects the `stdevp` form (n denominator).
+    Stdev {
+        arg: Expression,
+        distinct: bool,
+        population: bool,
+    },
+    /// `percentileCont(expr, p)` (`continuous: true`, linear interpolation)
+    /// / `percentileDisc(expr, p)` (nearest-rank). `percentile` must
+    /// evaluate to a number in `0.0..=1.0`.
+    Percentile {
+        arg: Expression,
+        percentile: Expression,
+        continuous: bool,
+    },
 }
 
 /// One element of a `CREATE` / `MERGE` pattern.
@@ -810,6 +825,18 @@ impl AggregateExpr {
             AggregateExpr::Min { .. } => "min",
             AggregateExpr::Max { .. } => "max",
             AggregateExpr::Collect { .. } => "collect",
+            AggregateExpr::Stdev {
+                population: false, ..
+            } => "stdev",
+            AggregateExpr::Stdev {
+                population: true, ..
+            } => "stdevp",
+            AggregateExpr::Percentile {
+                continuous: true, ..
+            } => "percentileCont",
+            AggregateExpr::Percentile {
+                continuous: false, ..
+            } => "percentileDisc",
         }
     }
 
@@ -818,8 +845,11 @@ impl AggregateExpr {
             AggregateExpr::Count { distinct, .. }
             | AggregateExpr::Sum { distinct, .. }
             | AggregateExpr::Avg { distinct, .. }
+            | AggregateExpr::Stdev { distinct, .. }
             | AggregateExpr::Collect { distinct, .. } => *distinct,
-            AggregateExpr::Min { .. } | AggregateExpr::Max { .. } => false,
+            AggregateExpr::Min { .. }
+            | AggregateExpr::Max { .. }
+            | AggregateExpr::Percentile { .. } => false,
         }
     }
 }

--- a/crates/namidb-query/src/plan/lower.rs
+++ b/crates/namidb-query/src/plan/lower.rs
@@ -854,6 +854,11 @@ fn reject_nested_pattern_comprehension(expr: &Expression) -> Result<(), LowerErr
             reject_nested_pattern_comprehension(&q.list)?;
             reject_nested_pattern_comprehension(&q.predicate)
         }
+        ExpressionKind::Reduce(r) => {
+            reject_nested_pattern_comprehension(&r.init)?;
+            reject_nested_pattern_comprehension(&r.list)?;
+            reject_nested_pattern_comprehension(&r.expression)
+        }
         ExpressionKind::Exists(_)
         | ExpressionKind::ExistsSubquery(_)
         | ExpressionKind::Star
@@ -877,7 +882,7 @@ fn lower_pattern_part(
         })
         .unwrap_or(ShortestMode::None);
     if shortest != ShortestMode::None {
-        validate_shortest_path_pattern_v0(part, &part.element)?;
+        validate_shortest_path_pattern_v0(part, &part.element, ctx)?;
         // shortestPath: the executor materialises the path trail
         // directly into the named binding, so the lower does NOT
         // emit a Project + build_path_constructor (which would
@@ -963,6 +968,7 @@ fn attach_path_binding(plan: LogicalPlan, name: &str) -> LogicalPlan {
 fn validate_shortest_path_pattern_v0(
     part: &PatternPart,
     elem: &PatternElement,
+    ctx: &LowerCtx,
 ) -> Result<(), LowerError> {
     // 1. path binding required.
     if part.binding.is_none() {
@@ -1013,6 +1019,27 @@ fn validate_shortest_path_pattern_v0(
             "shortestPath target must reference a previously bound node",
             target.span,
         ));
+    }
+    // 5. Both endpoints PREVIOUSLY bound, not merely named. An unbound
+    //    endpoint used to be silently accepted; `First` mode then returned
+    //    ONE arbitrary reachable node per seed instead of one row per
+    //    (src, dst) pair — an openCypher divergence that read as data loss
+    //    in the field (NDB-09). Erroring here makes the v0 contract loud.
+    for ident in [
+        elem.head.binding.as_ref().expect("checked above"),
+        target.binding.as_ref().expect("checked above"),
+    ] {
+        if !ctx.bindings.contains(&ident.name) {
+            return Err(LowerError::new(
+                LowerErrorKind::UnsupportedFeature,
+                format!(
+                    "shortestPath endpoint `{}` must be bound by a previous MATCH in v0 \
+                     (e.g. `MATCH (a:...), (b:...) MATCH p = shortestPath((a)-[*..15]-(b))`)",
+                    ident.name
+                ),
+                ident.span,
+            ));
+        }
     }
     Ok(())
 }
@@ -2086,6 +2113,34 @@ fn try_aggregate(expr: &Expression) -> Result<Option<AggregateExpr>, LowerError>
                 distinct,
             })
         }),
+        "stdev" => single_arg(name, &args, expr.span).map(|arg| {
+            Some(AggregateExpr::Stdev {
+                arg: arg.clone(),
+                distinct,
+                population: false,
+            })
+        }),
+        "stdevp" => single_arg(name, &args, expr.span).map(|arg| {
+            Some(AggregateExpr::Stdev {
+                arg: arg.clone(),
+                distinct,
+                population: true,
+            })
+        }),
+        "percentilecont" => two_arg(name, &args, expr.span).map(|(arg, p)| {
+            Some(AggregateExpr::Percentile {
+                arg: arg.clone(),
+                percentile: p.clone(),
+                continuous: true,
+            })
+        }),
+        "percentiledisc" => two_arg(name, &args, expr.span).map(|(arg, p)| {
+            Some(AggregateExpr::Percentile {
+                arg: arg.clone(),
+                percentile: p.clone(),
+                continuous: false,
+            })
+        }),
         _ => Ok(None),
     }
 }
@@ -2100,6 +2155,21 @@ fn single_arg<'a>(
         _ => Err(LowerError::new(
             LowerErrorKind::InvalidPattern,
             format!("{} takes exactly 1 argument", name.joined()),
+            span,
+        )),
+    }
+}
+
+fn two_arg<'a>(
+    name: &QualifiedName,
+    args: &'a [Expression],
+    span: SourceSpan,
+) -> Result<(&'a Expression, &'a Expression), LowerError> {
+    match args {
+        [first, second] => Ok((first, second)),
+        _ => Err(LowerError::new(
+            LowerErrorKind::InvalidPattern,
+            format!("{} takes exactly 2 arguments", name.joined()),
             span,
         )),
     }
@@ -2559,6 +2629,12 @@ fn check_expression_bindings(expr: &Expression, ctx: &LowerCtx) -> Result<(), Lo
             // Only the list is checked against the outer scope; the predicate
             // references the quantifier's local variable, not yet in ctx.
             check_expression_bindings(&q.list, ctx)
+        }
+        ExpressionKind::Reduce(r) => {
+            // init and list run in the outer scope; the body references the
+            // local accumulator/variable, not yet in ctx.
+            check_expression_bindings(&r.init, ctx)?;
+            check_expression_bindings(&r.list, ctx)
         }
         ExpressionKind::PatternComprehension(_) => Ok(()),
     }

--- a/crates/namidb-query/tests/exec_aggregates.rs
+++ b/crates/namidb-query/tests/exec_aggregates.rs
@@ -227,6 +227,112 @@ async fn aggregate_semantics_on_memtable_and_flushed_routes() {
     assert_semantics(&writer).await;
 }
 
+/// NDB-10: statistical aggregates — stdev/stdevp (sample vs population
+/// denominator), percentileCont (linear interpolation) and percentileDisc
+/// (nearest-rank), with the standard NULL-skipping/empty-group envelope.
+async fn assert_statistical_semantics(writer: &WriterSession) {
+    // Ages present: [30, 40, 30]. Sample stdev vs population stdev.
+    let mean = (30.0_f64 + 40.0 + 30.0) / 3.0;
+    let ss = (30.0 - mean).powi(2) + (40.0 - mean).powi(2) + (30.0 - mean).powi(2);
+    for (q, expected) in [
+        (
+            "MATCH (p:Person) RETURN stdev(p.age) AS s",
+            (ss / 2.0).sqrt(),
+        ),
+        (
+            "MATCH (p:Person) RETURN stdevp(p.age) AS s",
+            (ss / 3.0).sqrt(),
+        ),
+        // DISTINCT: [30, 40] -> mean 35, ss 50, sample denominator 1.
+        (
+            "MATCH (p:Person) RETURN stdev(DISTINCT p.age) AS s",
+            50.0_f64.sqrt(),
+        ),
+        // Scores sorted [1.5, 2.0, 2.5, 4.0]: rank 0.5*3 = 1.5 -> 2.25.
+        (
+            "MATCH (p:Person) RETURN percentileCont(p.score, 0.5) AS s",
+            2.25,
+        ),
+    ] {
+        match one_value(writer, q).await {
+            RuntimeValue::Float(f) => {
+                assert!((f - expected).abs() < 1e-9, "{q}: {f} != {expected}")
+            }
+            other => panic!("{q}: expected float, got {other:?}"),
+        }
+    }
+
+    // Nearest-rank keeps the input value (and its type): ceil(0.5*4) = rank 2.
+    assert_eq!(
+        one_value(
+            writer,
+            "MATCH (p:Person) RETURN percentileDisc(p.score, 0.5) AS s"
+        )
+        .await,
+        RuntimeValue::Float(2.0)
+    );
+    assert_eq!(
+        one_value(
+            writer,
+            "MATCH (p:Person) RETURN percentileDisc(p.age, 1.0) AS s"
+        )
+        .await,
+        RuntimeValue::Integer(40)
+    );
+    assert_eq!(
+        one_value(
+            writer,
+            "MATCH (p:Person) RETURN percentileDisc(p.age, 0.0) AS s"
+        )
+        .await,
+        RuntimeValue::Integer(30),
+        "p = 0.0 clamps to the minimum"
+    );
+
+    // Empty group -> NULL; single value -> stdev 0.0.
+    assert_eq!(
+        one_value(writer, "MATCH (g:Ghost) RETURN stdev(g.age) AS s").await,
+        RuntimeValue::Null
+    );
+    let snap = writer.snapshot();
+    let plan = lower(
+        &parse("MATCH (p:Person) RETURN p.team AS team, stdev(p.age) AS s ORDER BY team").unwrap(),
+    )
+    .unwrap();
+    let rows = execute(&plan, &snap, &Params::new()).await.unwrap();
+    assert_eq!(rows.len(), 2);
+    // Team a: [30, 40] -> sqrt(50); team b: NULL age skipped, single 30 -> 0.
+    match rows[0].get("s") {
+        Some(RuntimeValue::Float(f)) => assert!((f - 50.0_f64.sqrt()).abs() < 1e-9, "{f}"),
+        other => panic!("team a stdev: {other:?}"),
+    }
+    assert_eq!(rows[1].get("s"), Some(&RuntimeValue::Float(0.0)));
+
+    // Out-of-range percentile and non-numeric input are typed errors.
+    let plan =
+        lower(&parse("MATCH (p:Person) RETURN percentileCont(p.age, 1.5) AS s").unwrap()).unwrap();
+    let error = execute(&plan, &snap, &Params::new()).await.unwrap_err();
+    assert!(
+        error.to_string().contains("percentile must be between"),
+        "{error}"
+    );
+    let plan = lower(&parse("MATCH (p:Person) RETURN stdev(p.team) AS s").unwrap()).unwrap();
+    let error = execute(&plan, &snap, &Params::new()).await.unwrap_err();
+    assert!(
+        error.to_string().contains("requires numeric values"),
+        "{error}"
+    );
+}
+
+#[tokio::test]
+async fn statistical_aggregates_on_memtable_and_flushed_routes() {
+    let (mut writer, schema) = corpus("agg-statistical").await;
+    assert_statistical_semantics(&writer).await;
+
+    writer.flush(schema).await.unwrap();
+    assert_statistical_semantics(&writer).await;
+}
+
 #[tokio::test]
 async fn integer_sum_overflow_is_a_typed_error_not_a_wrap() {
     let mut writer = WriterSession::open(store(), paths("agg-overflow"))

--- a/crates/namidb-query/tests/exec_distinct_endpoints.rs
+++ b/crates/namidb-query/tests/exec_distinct_endpoints.rs
@@ -1,0 +1,249 @@
+//! NDB-04: `RETURN DISTINCT <endpoint> [LIMIT n]` over a variable-length
+//! expand must run as a visited-set BFS, not the exponential trail
+//! enumeration. Parity is asserted against the per-seed (non-eligible)
+//! shape on both the memtable and flushed routes, and the dense-layered
+//! blowup test completing at all is the regression assertion — the
+//! trail-enumerating executor holds ~30^6 frontier entries there.
+//!
+//! Graph (KNOWS, directed):
+//!
+//! ```text
+//!   Alice ─▶ Bob ─▶ Carol ─▶ Dave ─▶ Alice   (cycle back to the seed)
+//!     │        └─────▶ Dave ▲
+//!     └───────▶ Carol ──────┘
+//! ```
+//!
+//! From Alice with `*1..3`: Bob and Carol at hop 1, Dave at hop 2, and
+//! Alice HERSELF at hop 3 (through the cycle) — the seed-as-endpoint case
+//! the BFS must not lose by pre-visiting the seed.
+
+use std::collections::{BTreeMap, BTreeSet};
+use std::sync::Arc;
+
+use namidb_core::id::{NamespaceId, NodeId};
+use namidb_core::value::Value as CoreValue;
+use namidb_storage::{EdgeWriteRecord, NamespacePaths, NodeWriteRecord, WriterSession};
+use object_store::memory::InMemory;
+use object_store::ObjectStore;
+
+use namidb_query::{execute, lower, parse, Params, RuntimeValue};
+
+fn store() -> Arc<dyn ObjectStore> {
+    Arc::new(InMemory::new())
+}
+
+fn paths(name: &str) -> NamespacePaths {
+    NamespacePaths::new("tenants", NamespaceId::new(name).unwrap())
+}
+
+fn person(name: &str) -> NodeWriteRecord {
+    let mut props: BTreeMap<String, CoreValue> = BTreeMap::new();
+    props.insert("name".into(), CoreValue::Str(name.into()));
+    NodeWriteRecord {
+        properties: props,
+        schema_version: 1,
+        ..Default::default()
+    }
+}
+
+fn edge() -> EdgeWriteRecord {
+    EdgeWriteRecord {
+        properties: BTreeMap::new(),
+        schema_version: 1,
+    }
+}
+
+async fn build_graph(writer: &mut WriterSession) {
+    let names = ["Alice", "Bob", "Carol", "Dave"];
+    let ids: [NodeId; 4] = std::array::from_fn(|_| NodeId::new());
+    for (id, name) in ids.iter().zip(names.iter()) {
+        writer.upsert_node("Person", *id, &person(name)).unwrap();
+    }
+    let [alice, bob, carol, dave] = ids;
+    for (src, dst) in [
+        (alice, bob),
+        (alice, carol),
+        (bob, carol),
+        (bob, dave),
+        (carol, dave),
+        (dave, alice),
+    ] {
+        writer.upsert_edge("KNOWS", src, dst, &edge()).unwrap();
+    }
+    writer.commit_batch().await.unwrap();
+}
+
+async fn names(writer: &WriterSession, q: &str, column: &str) -> Vec<String> {
+    let snap = writer.snapshot();
+    let plan = lower(&parse(q).unwrap()).unwrap();
+    let rows = execute(&plan, &snap, &Params::new()).await.unwrap();
+    rows.iter()
+        .map(|r| match r.get(column) {
+            Some(RuntimeValue::String(s)) => s.clone(),
+            other => panic!("{column} not a string: {other:?}"),
+        })
+        .collect()
+}
+
+async fn assert_parity(writer: &WriterSession) {
+    // Eligible shape: endpoint-only DISTINCT (runs the BFS).
+    let distinct = names(
+        writer,
+        "MATCH (a:Person {name: 'Alice'})-[:KNOWS*1..3]->(b) \
+         RETURN DISTINCT b.name AS name",
+        "name",
+    )
+    .await;
+    let got: BTreeSet<String> = distinct.iter().cloned().collect();
+    assert_eq!(
+        got.len(),
+        distinct.len(),
+        "DISTINCT must not emit duplicates: {distinct:?}"
+    );
+    // Reference: the seed-referencing projection is NOT eligible (per-seed
+    // rows through the ordinary executor); its endpoint column deduped by
+    // the test is the ground truth.
+    let reference = names(
+        writer,
+        "MATCH (a:Person {name: 'Alice'})-[:KNOWS*1..3]->(b) \
+         RETURN DISTINCT a.name AS seed, b.name AS name",
+        "name",
+    )
+    .await;
+    let expected: BTreeSet<String> = reference.into_iter().collect();
+    assert_eq!(got, expected, "BFS endpoints diverge from exhaustive route");
+    // The cycle case: Alice reaches herself at hop 3.
+    assert!(
+        got.contains("Alice"),
+        "seed must be reachable as its own endpoint through the cycle: {got:?}"
+    );
+    assert_eq!(got.len(), 4, "{got:?}");
+
+    // Path multiplicity must SURVIVE without DISTINCT (the BFS must not
+    // leak into non-distinct shapes).
+    let all_paths = names(
+        writer,
+        "MATCH (a:Person {name: 'Alice'})-[:KNOWS*1..3]->(b) \
+         RETURN b.name AS name",
+        "name",
+    )
+    .await;
+    assert!(
+        all_paths.len() > got.len(),
+        "non-distinct query lost path multiplicity: {all_paths:?}"
+    );
+}
+
+#[tokio::test]
+async fn distinct_endpoints_match_exhaustive_on_memtable_and_flushed_routes() {
+    let mut writer = WriterSession::open(store(), paths("dist-endpoints"))
+        .await
+        .unwrap();
+    build_graph(&mut writer).await;
+    assert_parity(&writer).await;
+
+    let schema = namidb_core::schema::SchemaBuilder::new()
+        .label(namidb_core::schema::LabelDef {
+            name: "Person".into(),
+            properties: vec![namidb_core::schema::PropertyDef::new(
+                "name",
+                namidb_core::schema::DataType::Utf8,
+                true,
+            )
+            .unwrap()],
+        })
+        .unwrap()
+        .build();
+    writer.flush(schema).await.unwrap();
+    assert_parity(&writer).await;
+}
+
+#[tokio::test]
+async fn distinct_endpoints_with_limit_are_exact() {
+    let mut writer = WriterSession::open(store(), paths("dist-limit"))
+        .await
+        .unwrap();
+    build_graph(&mut writer).await;
+
+    let limited = names(
+        &writer,
+        "MATCH (a:Person {name: 'Alice'})-[:KNOWS*1..3]->(b) \
+         RETURN DISTINCT b.name AS name LIMIT 2",
+        "name",
+    )
+    .await;
+    assert_eq!(limited.len(), 2, "LIMIT under-produced: {limited:?}");
+    let unique: BTreeSet<&String> = limited.iter().collect();
+    assert_eq!(unique.len(), 2, "LIMIT emitted duplicates: {limited:?}");
+
+    // A LIMIT above the endpoint count returns everything.
+    let all = names(
+        &writer,
+        "MATCH (a:Person {name: 'Alice'})-[:KNOWS*1..3]->(b) \
+         RETURN DISTINCT b.name AS name LIMIT 100",
+        "name",
+    )
+    .await;
+    assert_eq!(all.len(), 4, "{all:?}");
+}
+
+/// Dense layered graph: s → L1(30) → ... → L4(30) → t, complete bipartite
+/// between consecutive layers. Trail enumeration visits ~30^5 walks for
+/// `*1..6` (an effective hang); the endpoint BFS touches each node once
+/// per seed. Completing at all is the regression assertion.
+#[tokio::test]
+async fn distinct_endpoints_survive_dense_layered_blowup() {
+    let mut writer = WriterSession::open(store(), paths("dist-blowup"))
+        .await
+        .unwrap();
+    const WIDTH: usize = 30;
+    const DEPTH: usize = 4;
+    let s = NodeId::new();
+    let t = NodeId::new();
+    writer.upsert_node("Person", s, &person("s")).unwrap();
+    writer.upsert_node("Person", t, &person("t")).unwrap();
+    let layers: Vec<Vec<NodeId>> = (0..DEPTH)
+        .map(|_| (0..WIDTH).map(|_| NodeId::new()).collect())
+        .collect();
+    for (li, layer) in layers.iter().enumerate() {
+        for (ni, &id) in layer.iter().enumerate() {
+            writer
+                .upsert_node("Person", id, &person(&format!("l{li}n{ni}")))
+                .unwrap();
+        }
+    }
+    for &first in &layers[0] {
+        writer.upsert_edge("KNOWS", s, first, &edge()).unwrap();
+    }
+    for w in layers.windows(2) {
+        for &a in &w[0] {
+            for &b in &w[1] {
+                writer.upsert_edge("KNOWS", a, b, &edge()).unwrap();
+            }
+        }
+    }
+    for &last in &layers[DEPTH - 1] {
+        writer.upsert_edge("KNOWS", last, t, &edge()).unwrap();
+    }
+    writer.commit_batch().await.unwrap();
+
+    let endpoints = names(
+        &writer,
+        "MATCH (a:Person {name: 's'})-[:KNOWS*1..6]->(b) \
+         RETURN DISTINCT b.name AS name",
+        "name",
+    )
+    .await;
+    // Every layer node plus t, each exactly once.
+    assert_eq!(endpoints.len(), WIDTH * DEPTH + 1, "{}", endpoints.len());
+
+    // And the LIMIT form stops early instead of exhausting the graph.
+    let five = names(
+        &writer,
+        "MATCH (a:Person {name: 's'})-[:KNOWS*1..6]->(b) \
+         RETURN DISTINCT b.name AS name LIMIT 5",
+        "name",
+    )
+    .await;
+    assert_eq!(five.len(), 5);
+}

--- a/crates/namidb-query/tests/exec_shortest_path.rs
+++ b/crates/namidb-query/tests/exec_shortest_path.rs
@@ -191,16 +191,22 @@ async fn shortest_path_rejects_unbound_endpoint() {
          RETURN p",
     )
     .unwrap();
-    // `b` does have a binding (`b:Person`), but it's NEW — not in
-    // scope. shortestPath requires both endpoints to be already
-    // bound. We accept the binding form, so this test reflects what
-    // RFC-023 §Q-future says: the lower should reject `b` if it's
-    // not in scope. For now, the lower validates `head.binding` and
-    // `target.binding` exist; the "already bound" guarantee comes
-    // from `back_reference` flagging at the executor layer. Until
-    // that promotes into the lower, this test asserts the query at
-    // least lowers successfully (no false positive).
-    let _plan = lower(&q).expect("RFC-023 v0 accepts; back_reference fires at exec");
+    // `b` does have a binding (`b:Person`), but it's NEW — not in scope.
+    // Until 2.2.0 this lowered silently and `First` mode returned ONE
+    // arbitrary reachable node per seed instead of one row per (src, dst)
+    // pair — an openCypher divergence that read as data loss in the field
+    // (NDB-09). The lower now enforces the v0 previously-bound contract.
+    let err = lower(&q).expect_err("unbound shortestPath endpoint must be rejected");
+    assert!(
+        err.message.contains("must be bound by a previous MATCH"),
+        "error should name the previously-bound rule, got: {}",
+        err.message
+    );
+    assert!(
+        err.message.contains("`b`"),
+        "error should name the offending endpoint, got: {}",
+        err.message
+    );
 }
 
 /// Dense layered graph: s → L1(40) → L2(40) → L3(40) → L4(40) → L5(40) → t,
@@ -248,6 +254,24 @@ async fn shortest_path_survives_dense_layered_blowup() {
     let q = parse(
         "MATCH (a:Person {name: 's'}), (b:Person {name: 't'}) \
          MATCH p = shortestPath((a)-[:KNOWS*..8]->(b)) \
+         RETURN length(p) AS hops",
+    )
+    .unwrap();
+    let plan = lower(&q).unwrap();
+    let rows = execute(&plan, &snapshot, &Params::new()).await.unwrap();
+    assert_eq!(rows.len(), 1);
+    match rows[0].get("hops") {
+        Some(RuntimeValue::Integer(n)) => assert_eq!(*n, (DEPTH + 1) as i64),
+        other => panic!("hops not integer: {:?}", other),
+    }
+
+    // NDB-09: `min >= 2` used to disable pruning entirely, reviving the
+    // 40^hop frontier (an effective hang). The (node, hop) frontier dedup
+    // bounds it at O(V) per level; completing at all is the regression
+    // assertion, and the shortest length is unchanged (already >= 2).
+    let q = parse(
+        "MATCH (a:Person {name: 's'}), (b:Person {name: 't'}) \
+         MATCH p = shortestPath((a)-[:KNOWS*2..8]->(b)) \
          RETURN length(p) AS hops",
     )
     .unwrap();

--- a/crates/namidb-server/src/bolt.rs
+++ b/crates/namidb-server/src/bolt.rs
@@ -1518,12 +1518,10 @@ fn map_exec_err(e: ExecError) -> BackendError {
         // must be able to tell "this query is too expensive" from "this
         // query is malformed" without string-matching the message, and must
         // NOT auto-retry either (a re-run exceeds the same budget again).
-        ExecError::Timeout => {
-            BackendError::Timeout("query exceeded the configured timeout".into())
+        ExecError::Timeout => BackendError::Timeout("query exceeded the configured timeout".into()),
+        ExecError::RowCap(cap) => {
+            BackendError::ResourceLimit(format!("query exceeded the configured row cap of {cap}"))
         }
-        ExecError::RowCap(cap) => BackendError::ResourceLimit(format!(
-            "query exceeded the configured row cap of {cap}"
-        )),
         ExecError::Storage(err) => match err {
             // Deterministic search result caps: same query, same outcome —
             // ClientError, not the auto-retried TransientError bucket.

--- a/crates/namidb-server/src/lib.rs
+++ b/crates/namidb-server/src/lib.rs
@@ -1450,9 +1450,7 @@ fn exec_error_taxonomy(e: &namidb_query::exec::ExecError) -> (&'static str, &'st
     match e {
         ExecError::Timeout => ("Neo.ClientError.Transaction.TransactionTimedOut", "57014"),
         ExecError::RowCap(_) => ("Neo.ClientError.Statement.ResourceLimitExceeded", "54000"),
-        ExecError::Constraint(_) => {
-            ("Neo.ClientError.Schema.ConstraintValidationFailed", "23000")
-        }
+        ExecError::Constraint(_) => ("Neo.ClientError.Schema.ConstraintValidationFailed", "23000"),
         ExecError::Storage(
             namidb_storage::Error::SearchResultLimitExceeded { .. }
             | namidb_storage::Error::SearchDocumentLimitExceeded { .. },
@@ -4457,8 +4455,10 @@ mod tests {
     /// matching, on both the `code` and the Neo4j/GQL-shaped fields.
     #[tokio::test]
     async fn timeout_response_exposes_taxonomy_fields() {
-        let response =
-            exec_failure_response("read execution failed", &namidb_query::exec::ExecError::Timeout);
+        let response = exec_failure_response(
+            "read execution failed",
+            &namidb_query::exec::ExecError::Timeout,
+        );
         assert_eq!(response.status(), StatusCode::GATEWAY_TIMEOUT);
         let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
         let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
@@ -4494,7 +4494,10 @@ mod tests {
         let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
         let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
         assert_eq!(json["code"], "eval_error");
-        assert_eq!(json["neo4j_code"], "Neo.ClientError.Statement.ArgumentError");
+        assert_eq!(
+            json["neo4j_code"],
+            "Neo.ClientError.Statement.ArgumentError"
+        );
         assert_eq!(json["gql_status"], "22000");
     }
 

--- a/crates/namidb-server/tests/bolt_integration.rs
+++ b/crates/namidb-server/tests/bolt_integration.rs
@@ -1309,7 +1309,10 @@ async fn bolt_row_cap_failure_has_resource_limit_code() {
     handshake(&mut stream).await;
     hello_and_logon(&mut stream, "test-token").await;
 
-    for query in ["CREATE (:Person {name: 'Ada'})", "CREATE (:Person {name: 'Bo'})"] {
+    for query in [
+        "CREATE (:Person {name: 'Ada'})",
+        "CREATE (:Person {name: 'Bo'})",
+    ] {
         pull_all(&mut stream, query).await;
     }
 

--- a/docs/testing/25tb-readiness.md
+++ b/docs/testing/25tb-readiness.md
@@ -530,3 +530,149 @@ any customer needs search on the managed tier.
   splitting in namidb-cli (~hours); server-side scripts (sequential,
   stop-on-first-error, per-statement writer lock) are ~2-4 days.
   Roadmap.
+
+## Second field report (2026-08-27) — contactability platform, 24.6k-node graph, Bolt via official Neo4j driver
+
+Twelve engine limits reproduced against the running 2.1.4 instance (NDB-01..12), four
+self-retracted complaints (RET-01..04). Recon corrected the mechanism of four before any
+fix landed. Items 43–54, one per NDB finding.
+
+### 43. [DONE — lands in 2.2.0] NDB-01: `--multi-tenant` silently never starts Bolt.
+
+Confirmed exactly as reported: the multi-tenant serve path `return serve_http(...)`
+(lib.rs) executes before the only `config.bolt_listen` consultation, no warning. This is
+architectural (bolt::serve takes a single-namespace AppState; RFC-022 lists
+multidatabase as a non-goal). Fix: fail-fast at boot when both flags are set, in the
+validation block of `run_with_memory_max_bytes` (covers binary + embedded callers) +
+HTTP-only caveats at every doc site that lacked them (README flags table and Bolt
+paragraph, server README auth/Bolt sections, ARCHITECTURE multi-tenancy — the dedicated
+multi-tenancy.md guide already documented it). Full Bolt-in-multitenant is sized
+roadmap: plumb the Bolt 5 `db` field of RUN/BEGIN `extra` through the namidb-bolt
+Backend trait (currently discarded), per-namespace WriterSession from the registry, tx
+pinned to one namespace, `principal_for_in` at first RUN/BEGIN — roughly 3-5 days.
+
+### 44. [DONE — lands in 2.2.0] NDB-02: no token → server boots open, warn-only.
+
+Confirmed: `(None, None) => AuthConfig::open()` + `Principal::anonymous_rw()` on every
+HTTP request and `AuthPolicy::Open` on Bolt. Fix: boot REFUSES to start with no auth
+source unless `--no-auth` / `NAMIDB_NO_AUTH=1` is passed explicitly (check sits at the
+`is_open()` point so JWT-only configs keep booting). Breaking change, release-noted.
+
+### 45. [DONE — lands in 2.2.0] NDB-03: error taxonomy collapse.
+
+Recon corrected two details: `50N42` is a driver-side polyfill (Bolt ≤5.4 carries no
+GQLSTATUS; the string appears nowhere in the repo), and HTTP already distinguished
+timeout (504) from row cap (413). The real defect was Bolt-only: `map_exec_err`
+substring-bucketed every non-constraint error, landing Timeout and RowCap in
+`Statement.ArgumentError`. Fix: typed `BackendError::Timeout` / `ResourceLimit`
+(ClientError on purpose — drivers auto-retry TransientError.* only, and a deterministic
+budget re-run fails identically); deterministic search caps moved out of the
+auto-retried TransientError bucket; HTTP bodies now carry `neo4j_code` + `gql_status`
+per family (table in the server README); eval errors are 400 not 500. Bolt ≥5.7
+GQLSTATUS-on-the-wire: roadmap (~2-3 days: negotiate 5.7, extend FAILURE metadata).
+
+### 46. [DONE — lands in 2.2.0] NDB-04: var-length traversal enumerates all paths under DISTINCT+LIMIT.
+
+Confirmed end to end: only shortest-mode had visited pruning; `execute_capped`'s
+whitelist excluded `Project{distinct:true}`, so DISTINCT+LIMIT got zero pushdown; the
+cap was honoured only at seed boundaries. Fix (executor-side shape detection, no plan
+field): `try_execute_endpoint_distinct_project` intercepts `Project{distinct:true}`
+directly over a var-length Expand when every projected expression reads ONLY the
+endpoint binding — then the deg^hop trail enumeration collapses to a visited-set BFS
+(each node expanded once per seed, emitted once globally across seeds), and the LIMIT
+budget crosses the distinct projection exactly (globally-deduped emission makes a
+capped prefix valid). Intercepted in both the flat and factor executors + the capped
+path. Regression proof: dense-layered 30^5-walk graph completes; parity vs the
+per-seed route asserted on memtable + flushed routes, including the seed-reachable-
+through-a-cycle endpoint. Not covered (falls back to the exhaustive route, correct but
+slow): a Filter between Expand and DISTINCT, projections referencing the seed or rel
+list, `min >= 2`.
+
+### 47. [PARTIALLY DONE — mechanism refuted; two real gaps fixed, one deferred] NDB-09: shortestPath blows the 1M row cap.
+
+The claimed mechanism ("expands then trims") is REFUTED on 2.1.4: shortestPath lowers
+onto the Expand with ShortestMode and the executor early-stops (BFS visited pruning
+shipped in 666ef82, ancestor of v2.1.4; regression test covers the 40^5 shape). What
+CAN reproduce the symptom: all-pairs seeding (`MATCH (a:L), (b:L)` → CrossProduct
+row-cap at 24k² pairs — correct behaviour, the query requests 576M rows),
+allShortestPaths' combinatorial same-length output, `*2..N` (pruning was disabled for
+min ≥ 2 → exhaustive frontier → hang), and the silently-accepted unbound endpoint
+(First mode returned ONE arbitrary endpoint per seed — an openCypher divergence that
+pushed users to the plain var-length rewrite that genuinely blows the cap). Fixed in
+2.2.0: (a) `(node, hop)` frontier dedup for First-mode `min >= 2` (placed after the
+trail check so a rejected walk cannot consume the slot; documented theoretical corner:
+the kept walk could be trail-blocked where a dropped one was not — accepted for "some
+shortest path" output vs the previous effective hang); (b) unbound endpoints now error
+at lowering with the previously-bound rule spelled out. Deferred (sized): seed-grouping
+(one BFS per distinct source serving all its bound targets, 1-2 days) and bidirectional
+meet-in-the-middle for single pairs.
+
+### 48. [DONE — lands in 2.2.0] NDB-05: reduce() does not parse.
+
+Confirmed: no production existed; `acc = 1.0` parsed as Eq inside generic call args and
+died at `|`. Fix: soft-keyword production (lookahead `reduce(<ident> =` keeps
+`reduce` usable as a variable/function name), fold evaluation mirroring
+eval_list_comprehension, arms added at every exhaustive ExpressionKind match
+(display round-trip, optimizer alias collection, projection pushdown, lower walkers,
+factor sink variable collection — compiler-enforced, no wildcard traps found).
+
+### 49. [DONE — lands in 2.2.0] NDB-10: no statistical aggregates.
+
+Confirmed: closed 6-entry registry in try_aggregate. Added stdev/stdevp (two-pass,
+n-1 / n denominators, single value → 0.0, empty → NULL, numeric-only typed error) and
+percentileCont/percentileDisc (two-arg, p validated in [0,1], linear interpolation vs
+nearest-rank keeping input type), collect-then-compute like Collect. NULL-skipping,
+DISTINCT, grouping asserted on memtable + flushed routes.
+
+### 50. [DONE — lands in 2.2.0] NDB-11: `'texto' + {a:1}` leaks Debug repr.
+
+Confirmed and broader than reported: every non-scalar (map, node, rel, list, bytes,
+vector, path) stringified through `format!("{:?}")` when added to a string, and
+toString() shared the helper. Fix: scalar-only rendering (ints, floats, bools, strings,
+temporals as ISO-8601); string + structural value is now the `cannot apply + between
+STRING and MAP` type error; list `+` gains real Cypher semantics (list+list concat,
+list+element append, element+list prepend — previously `'a' + [1]` produced garbage
+text); toString(non-scalar) errors. Behavior change, release-noted.
+
+### 51. [ROADMAP — group commit, RFC-034] NDB-06: explicit transactions hold the writer lock through think-time.
+
+Accurate by design today (single writer per namespace; BEGIN holds it to COMMIT,
+NAMIDB_BOLT_MAX_TX_LIFETIME caps it). The fix is group commit (RFC-034) — staged
+batches + one commit pipeline — which also addresses item 52. Weeks, not this cycle.
+
+### 52. [ROADMAP — same RFC-034 work] NDB-07: serialized commit floor ~309 nodes/s at batch 1.
+
+Accurate: ~3 ms/commit = two object-store round trips, so throughput scales only with
+batch size (their own table shows 63.9k nodes/s at batch 5000). Not a defect of the
+ingest path (which batches by design); interactive single-row writes need group commit.
+
+### 53. [DONE — lands in 2.2.0] NDB-08: Docker image crash-loops on a named volume at /var/lib/namidb.
+
+Confirmed, with a nuance: /var/lib/namidb is not a coded default (--store is required)
+but it IS the canonical example path in --help, storage error text, and every file://
+doc example. The image now pre-creates it owned by uid 65532 so fresh named volumes
+inherit ownership (copy-on-first-use); docs note the one-time `chown -R 65532:65532`
+for bind mounts and volumes created by older images. docker-compose.yml was never
+affected (S3/MinIO store).
+
+### 54. [PARTIALLY DONE — docs fixed; endpoint deferred with a design note] NDB-12: backup/restore CLI-only.
+
+"No admin HTTP endpoint" confirmed. But the implied offline-only limitation is wrong
+for backup: `copy_namespace_snapshot` is live-safe by design (durable retention-pin
+lease honoured by the janitor; the residual race fails loudly with NotFound instead of
+truncating; committed-but-unflushed WAL captured). The CLI help said "run against a
+quiescent source" — stale, now corrected. Restore genuinely requires an offline
+destination (no fencing). The POST /v0/admin/backup endpoint is deferred deliberately:
+a client-supplied destination URI is an SSRF/exfiltration vector using the server's
+ambient cloud credentials, so it needs an operator-configured target allowlist
+(NAMIDB_BACKUP_TARGET_URI prefix) plus the admin-flush single-flight/bounded-wait
+pattern — ~1 day, sized, not rushed into this release.
+
+### Retractions (RET-01..04) — recorded for the record
+
+RET-02 matters to us: their docs claimed NamiDB needs If-Match and discarded Garage on
+that basis. Our own crates/namidb-storage README had the SAME stale claim ("If-Match,
+If-None-Match, ETag") — now corrected everywhere: the commit path needs exactly ONE
+conditional-write primitive, PUT-if-absent (`If-None-Match: *`, RFC-029); README gained
+an object-store requirements note (an "S3-compatible" that ignores the precondition
+cannot host NamiDB safely). RET-01/03/04 need no engine action.


### PR DESCRIPTION
Query-engine half of the second field report — NDB-04/05/09/10/11.

**Cypher surface**
- `reduce(acc = init, x IN list | expr)` — soft-keyword production (`reduce(<ident> =` lookahead), fold evaluation mirroring the comprehension machinery, arms at every exhaustive `ExpressionKind` match (compiler-enforced; no wildcard traps found).
- `stdev` / `stdevp` / `percentileCont` / `percentileDisc` — collect-then-compute like `collect()`; NULL-skipping, DISTINCT on the stdev family, percentile validated in `[0,1]`, nearest-rank keeps the input type; memtable + flushed route parity.
- `'text' + {map}` was returning `textoMap({"a": Integer(1)})` — Debug repr leaking into results as silently corrupt data. Now: string+scalar coerces (temporals ISO-8601), string+structural is a type error, `toString()` is scalar-only, and list `+` gains real Cypher semantics (`list+list` concat, `list+elem` append, `elem+list` prepend). **Behavior change**, release-noted.

**Traversal**
- **NDB-04 confirmed**: `RETURN DISTINCT b ... LIMIT 200` cost exactly the same as enumerating every path. Now, when every projected expression reads only the endpoint binding, the expand runs as a visited-set BFS (once per seed, emitted once globally) with the LIMIT budget exact across the distinct projection. Detected structurally at execution (flat + factor + capped executors); the ~30^5-walk layered regression graph completing is the assertion, with parity against the per-seed route including the seed-reachable-through-a-cycle endpoint.
- **NDB-09 mechanism refuted** (shortestPath already early-stops since `666ef82`, in 2.1.4); the real gaps fixed: `*2..N` disabled pruning entirely (exhaustive frontier → hang) — now `(node, hop)` frontier dedup, placed after the trail check; unbound endpoints were silently accepted with First mode returning ONE arbitrary node per seed — now a lowering error naming the previously-bound rule. Deferred with sizing in the plan doc: seed-grouping, bidirectional pairs.

Also carries the `cargo fmt` fix for the one red CI job on main, the 2.2.0 CHANGELOG section, and plan items 43–54.

Full `namidb-query` + `namidb-server` suites green locally (46 targets).