### PR TITLE
fix: DISTINCT+ORDER BY endpoint BFS eligibility; order-preserving dedup; in-loop expand budgets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,29 @@ crates.io release will establish and document that API explicitly.
 
 ## [Unreleased]
 
+## [2.2.1] - 2026-08-28
+
+Found smoke-testing the released 2.2.0 artifacts against a dense graph.
+
+**Fixed**
+- `RETURN DISTINCT <endpoint> ORDER BY <endpoint key>` over a
+  variable-length pattern hung: the bare-ORDER-BY lowering places the
+  sort between the distinct projection and the expand, so the 2.2.0
+  endpoint-BFS eligibility missed the shape and fell back to the
+  exponential path enumeration. The BFS now looks through that sandwich
+  and re-applies the sort to its output.
+- `RETURN DISTINCT x ORDER BY x` returned fingerprint order, not value
+  order (e.g. `[10, 1, 20, 2]` for ascending) — the DISTINCT dedup
+  silently re-sorted its input by an internal fingerprint whose
+  lexicographic order diverges from value order. Long-standing bug,
+  predates 2.2.0; dedup is now order-preserving (first occurrence).
+- The query deadline and row cap now fire INSIDE a single seed's
+  variable-length expansion (per hop and every few thousand edges, in
+  both executors). Previously both were probed only at seed boundaries,
+  so one seed's dense enumeration burned unbounded time and memory —
+  a 30 s query budget was simply ignored by a six-hop expansion over a
+  20-node complete graph.
+
 ## [2.2.0] - 2026-08-28
 
 Closes the second production field report (12 findings against 2.1.4).
@@ -2727,7 +2750,8 @@ Change License: Apache License 2.0).
 - LDBC-shaped synthetic benchmark harness with a paired Kùzu runner
   under [`bench/`](./bench/).
 
-[Unreleased]: https://github.com/namidb/namidb/compare/v2.2.0...HEAD
+[Unreleased]: https://github.com/namidb/namidb/compare/v2.2.1...HEAD
+[2.2.1]: https://github.com/namidb/namidb/compare/v2.2.0...v2.2.1
 [2.2.0]: https://github.com/namidb/namidb/compare/v2.1.4...v2.2.0
 [2.1.4]: https://github.com/namidb/namidb/compare/v2.1.3...v2.1.4
 [2.1.3]: https://github.com/namidb/namidb/compare/v2.1.2...v2.1.3

--- a/crates/namidb-query/src/exec/walker.rs
+++ b/crates/namidb-query/src/exec/walker.rs
@@ -1249,6 +1249,25 @@ async fn try_execute_endpoint_distinct_project(
     routing: &PlanRouting,
     cap: Option<usize>,
 ) -> Result<Option<Vec<Row>>, ExecError> {
+    // The bare-ORDER-BY lowering places `TopN{keys}` BETWEEN the distinct
+    // projection and the Expand (project → order → dedupe; dedup_rows is
+    // order-preserving so the sort survives). Look through it when its keys
+    // also read only the endpoint — the sort is re-applied to the BFS
+    // output below. Defensive: only the no-skip/no-limit shape, which is
+    // all that layout is ever built for.
+    let empty_keys: &[crate::plan::OrderKey] = &[];
+    let (input, sort_keys) = match input {
+        LogicalPlan::TopN {
+            input: topn_input,
+            keys,
+            skip: crate::plan::RowCount::Const(0),
+            limit: crate::plan::RowCount::Const(u64::MAX),
+        } if !keys.is_empty() => (topn_input.as_ref(), keys.as_slice()),
+        other => (other, empty_keys),
+    };
+    if !sort_keys.is_empty() && cap.is_some() {
+        return Ok(None);
+    }
     let LogicalPlan::Expand {
         input: expand_input,
         source,
@@ -1269,12 +1288,16 @@ async fn try_execute_endpoint_distinct_project(
     if length.is_none() {
         return Ok(None);
     }
-    // Multiplicity is only unobservable when the projection reads nothing
-    // but the endpoint — any other referenced binding (the seed, a rel
-    // list) re-introduces per-path / per-seed visibility.
+    // Multiplicity is only unobservable when the projection (and any
+    // looked-through sort key) reads nothing but the endpoint — any other
+    // referenced binding (the seed, a rel list) re-introduces per-path /
+    // per-seed visibility.
     let mut referenced: BTreeSet<String> = BTreeSet::new();
     for item in items {
         collect_referenced_variables(&item.expression, &mut referenced);
+    }
+    for key in sort_keys {
+        collect_referenced_variables(&key.expression, &mut referenced);
     }
     if referenced.is_empty() || !referenced.iter().all(|name| name == target_alias) {
         return Ok(None);
@@ -1308,6 +1331,10 @@ async fn try_execute_endpoint_distinct_project(
         true,
     )
     .await?;
+    let mut expanded = expanded;
+    if !sort_keys.is_empty() {
+        sort_rows(&mut expanded, sort_keys, params)?;
+    }
     let projected = project_rows(&expanded, items, discard_input_bindings, params)?;
     Ok(Some(dedup_rows(projected)))
 }
@@ -1563,6 +1590,15 @@ pub(crate) async fn execute_expand(
         let hop_start = min.max(1);
         let _ = hop_start;
         for hop in 1..=max {
+            // A single seed's expansion can dwarf the whole result set (a
+            // dense 6-hop enumeration is millions of walks), so the deadline
+            // and row cap must fire INSIDE the traversal too — the
+            // seed-boundary checks alone let one seed burn unbounded time
+            // and memory before erroring (field-found: a K20 `*1..6`
+            // DISTINCT query hung past the 30 s budget).
+            crate::exec::limits::check_deadline()?;
+            crate::exec::limits::check_row_cap(out.len() + hop_results.len() + frontier.len())?;
+            let mut guard_tick: u32 = 0;
             let mut next_frontier = Vec::new();
             let mut level_seen: std::collections::HashSet<NodeId> =
                 std::collections::HashSet::new();
@@ -1620,6 +1656,16 @@ pub(crate) async fn execute_expand(
             .await?;
             for (step, neighbours) in step_neighbours {
                 for edge in neighbours {
+                    // Periodic in-loop guard: the (step × edge) space is the
+                    // deg^hop blowup itself, so probe the budgets every few
+                    // thousand edges rather than once per hop.
+                    guard_tick = guard_tick.wrapping_add(1);
+                    if guard_tick % 4096 == 0 {
+                        crate::exec::limits::check_deadline()?;
+                        crate::exec::limits::check_row_cap(
+                            out.len() + hop_results.len() + next_frontier.len(),
+                        )?;
+                    }
                     let target_id = partner_id(&edge, direction, step.tail);
                     if prune_visits {
                         // Reached at an earlier level → any path through it now
@@ -5905,13 +5951,19 @@ pub(crate) fn cross_product(left: Vec<Row>, right: Vec<Row>) -> Vec<Row> {
     out
 }
 
-pub(crate) fn dedup_rows(mut rows: Vec<Row>) -> Vec<Row> {
-    // For determinism we sort by canonical key first then dedup. Since
-    // RuntimeValue can hold Floats (which don't implement Ord), we use
-    // a String fingerprint computed by serialising the row.
-    rows.sort_by_key(row_fingerprint);
-    rows.dedup();
-    rows
+pub(crate) fn dedup_rows(rows: Vec<Row>) -> Vec<Row> {
+    // ORDER-PRESERVING first-occurrence dedup. The previous
+    // sort-by-fingerprint + dedup silently re-ordered its input, which
+    // broke the `RETURN DISTINCT x ORDER BY x` lowering (TopN under
+    // Project{distinct}): `[10, 2, 1, 20]` came back as `[10, 1, 20, 2]`
+    // because "I10;" < "I2;" lexicographically. Deduping on a fingerprint
+    // set keeps the incoming (deterministic) order and the same equality
+    // relation.
+    let mut seen: std::collections::HashSet<String> =
+        std::collections::HashSet::with_capacity(rows.len());
+    rows.into_iter()
+        .filter(|row| seen.insert(row_fingerprint(row)))
+        .collect()
 }
 
 fn row_fingerprint(row: &Row) -> String {
@@ -7591,6 +7643,14 @@ async fn execute_expand_factor(
         };
 
         for hop in 1..=max {
+            // In-loop budget guards, mirroring `execute_expand`: one seed's
+            // deg^hop enumeration must hit the deadline / row cap instead of
+            // burning unbounded time and memory before the per-seed check.
+            crate::exec::limits::check_deadline()?;
+            crate::exec::limits::check_row_cap(
+                out_leaves.len() + hop_outputs_for_this_input.len() + frontier.len(),
+            )?;
+            let mut guard_tick: u32 = 0;
             let mut next_frontier: Vec<FactorFrontierEntry> = Vec::new();
             // Phase 1: pre-collect neighbours per frontier entry so the
             // batch prewarm below can populate L1 with one SST decode
@@ -7639,6 +7699,15 @@ async fn execute_expand_factor(
             .await?;
             for ((cur_parent, tail, rels), neighbours) in step_neighbours {
                 for edge in neighbours {
+                    guard_tick = guard_tick.wrapping_add(1);
+                    if guard_tick % 4096 == 0 {
+                        crate::exec::limits::check_deadline()?;
+                        crate::exec::limits::check_row_cap(
+                            out_leaves.len()
+                                + hop_outputs_for_this_input.len()
+                                + next_frontier.len(),
+                        )?;
+                    }
                     let target_id = partner_id(&edge, direction, tail);
                     // Cypher relationship uniqueness (trail semantics): skip an
                     // edge already traversed on this path so `-[:R*2..2]-` can't

--- a/crates/namidb-query/tests/exec_distinct_endpoints.rs
+++ b/crates/namidb-query/tests/exec_distinct_endpoints.rs
@@ -26,7 +26,9 @@ use namidb_storage::{EdgeWriteRecord, NamespacePaths, NodeWriteRecord, WriterSes
 use object_store::memory::InMemory;
 use object_store::ObjectStore;
 
-use namidb_query::{execute, lower, parse, Params, RuntimeValue};
+use namidb_query::{
+    execute, execute_with_limits, lower, optimize, parse, Params, RuntimeValue, StatsCatalog,
+};
 
 fn store() -> Arc<dyn ObjectStore> {
     Arc::new(InMemory::new())
@@ -75,7 +77,10 @@ async fn build_graph(writer: &mut WriterSession) {
 
 async fn names(writer: &WriterSession, q: &str, column: &str) -> Vec<String> {
     let snap = writer.snapshot();
-    let plan = lower(&parse(q).unwrap()).unwrap();
+    // Through the OPTIMIZER, exactly as the server executes — the optimized
+    // plan shape is what the BFS eligibility must match (the ORDER BY
+    // sandwich regression was invisible to `lower()`-only tests).
+    let plan = optimize(lower(&parse(q).unwrap()).unwrap(), &StatsCatalog::default());
     let rows = execute(&plan, &snap, &Params::new()).await.unwrap();
     rows.iter()
         .map(|r| match r.get(column) {
@@ -246,4 +251,126 @@ async fn distinct_endpoints_survive_dense_layered_blowup() {
     )
     .await;
     assert_eq!(five.len(), 5);
+
+    // The bare-ORDER-BY lowering ("TopN keys under ProjectDistinct") — the
+    // exact shape that hung the 2.2.0 smoke test because the BFS
+    // eligibility only matched Project-directly-over-Expand. Must complete
+    // AND come back value-sorted (dedup_rows is order-preserving now).
+    let ordered = names(
+        &writer,
+        "MATCH (a:Person {name: 's'})-[:KNOWS*1..6]->(b) \
+         RETURN DISTINCT b.name AS name ORDER BY name",
+        "name",
+    )
+    .await;
+    assert_eq!(ordered.len(), WIDTH * DEPTH + 1);
+    let mut sorted = ordered.clone();
+    sorted.sort();
+    assert_eq!(ordered, sorted, "ORDER BY must survive the DISTINCT");
+}
+
+/// dedup_rows used to sort by fingerprint ("I10;" < "I2;"), so
+/// `RETURN DISTINCT x ORDER BY x` returned fingerprint order — a
+/// correctness bug independent of graphs. Now order-preserving.
+#[tokio::test]
+async fn distinct_order_by_returns_value_order() {
+    let writer = WriterSession::open(store(), paths("dist-order"))
+        .await
+        .unwrap();
+    let snap = writer.snapshot();
+    let plan = optimize(
+        lower(&parse("UNWIND [10, 2, 1, 20, 2] AS x RETURN DISTINCT x AS n ORDER BY n").unwrap())
+            .unwrap(),
+        &StatsCatalog::default(),
+    );
+    let rows = execute(&plan, &snap, &Params::new()).await.unwrap();
+    let got: Vec<i64> = rows
+        .iter()
+        .map(|r| match r.get("n") {
+            Some(RuntimeValue::Integer(n)) => *n,
+            other => panic!("{other:?}"),
+        })
+        .collect();
+    assert_eq!(got, vec![1, 2, 10, 20]);
+
+    // Descending too.
+    let plan = optimize(
+        lower(
+            &parse("UNWIND [10, 2, 1, 20, 2] AS x RETURN DISTINCT x AS n ORDER BY n DESC").unwrap(),
+        )
+        .unwrap(),
+        &StatsCatalog::default(),
+    );
+    let rows = execute(&plan, &snap, &Params::new()).await.unwrap();
+    let got: Vec<i64> = rows
+        .iter()
+        .map(|r| match r.get("n") {
+            Some(RuntimeValue::Integer(n)) => *n,
+            other => panic!("{other:?}"),
+        })
+        .collect();
+    assert_eq!(got, vec![20, 10, 2, 1]);
+}
+
+/// A shape the BFS must NOT take (the projection reads the seed) over a
+/// dense graph must hit the deadline / row cap INSIDE the traversal —
+/// before these in-loop guards, one seed enumerated millions of walks with
+/// no budget probe and the query hung past its 30 s budget.
+#[tokio::test]
+async fn ineligible_dense_expand_hits_budget_instead_of_hanging() {
+    let mut writer = WriterSession::open(store(), paths("dist-budget"))
+        .await
+        .unwrap();
+    // Complete digraph over 16 nodes: ~3.6M six-hop trails from one seed.
+    let ids: Vec<NodeId> = (0..16).map(|_| NodeId::new()).collect();
+    for (i, &id) in ids.iter().enumerate() {
+        writer
+            .upsert_node("Person", id, &person(&format!("n{i}")))
+            .unwrap();
+    }
+    for &a in &ids {
+        for &b in &ids {
+            if a != b {
+                writer.upsert_edge("KNOWS", a, b, &edge()).unwrap();
+            }
+        }
+    }
+    writer.commit_batch().await.unwrap();
+    let snap = writer.snapshot();
+    let plan = optimize(
+        lower(
+            &parse(
+                "MATCH (a:Person {name: 'n0'})-[:KNOWS*1..6]->(b) \
+                 RETURN DISTINCT a.name AS seed, b.name AS name",
+            )
+            .unwrap(),
+        )
+        .unwrap(),
+        &StatsCatalog::default(),
+    );
+
+    // Row cap: must fire mid-seed, typed.
+    let err = execute_with_limits(&plan, &snap, &Params::new(), None, Some(10_000))
+        .await
+        .expect_err("the dense expansion must hit the row cap");
+    assert!(
+        err.to_string().contains("row cap"),
+        "expected a row-cap error, got: {err}"
+    );
+
+    // Deadline: 200 ms budget must abort the same expansion promptly.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_millis(200);
+    let started = std::time::Instant::now();
+    let err = execute_with_limits(&plan, &snap, &Params::new(), Some(deadline), None)
+        .await
+        .expect_err("the dense expansion must hit the deadline");
+    assert!(
+        err.to_string().contains("timeout"),
+        "expected a timeout error, got: {err}"
+    );
+    assert!(
+        started.elapsed() < std::time::Duration::from_secs(10),
+        "deadline abort took {:?} — the in-loop guard is not firing",
+        started.elapsed()
+    );
 }

--- a/docs/testing/25tb-readiness.md
+++ b/docs/testing/25tb-readiness.md
@@ -571,7 +571,7 @@ auto-retried TransientError bucket; HTTP bodies now carry `neo4j_code` + `gql_st
 per family (table in the server README); eval errors are 400 not 500. Bolt ≥5.7
 GQLSTATUS-on-the-wire: roadmap (~2-3 days: negotiate 5.7, extend FAILURE metadata).
 
-### 46. [DONE — lands in 2.2.0] NDB-04: var-length traversal enumerates all paths under DISTINCT+LIMIT.
+### 46. [DONE — BFS in 2.2.0; ORDER BY sandwich + in-loop budgets in 2.2.1] NDB-04: var-length traversal enumerates all paths under DISTINCT+LIMIT.
 
 Confirmed end to end: only shortest-mode had visited pruning; `execute_capped`'s
 whitelist excluded `Project{distinct:true}`, so DISTINCT+LIMIT got zero pushdown; the
@@ -587,6 +587,22 @@ per-seed route asserted on memtable + flushed routes, including the seed-reachab
 through-a-cycle endpoint. Not covered (falls back to the exhaustive route, correct but
 slow): a Filter between Expand and DISTINCT, projections referencing the seed or rel
 list, `min >= 2`.
+
+**2.2.1 addendum (found smoke-testing the released 2.2.0 binaries).** The bare-ORDER-BY
+lowering places `TopN{keys}` BETWEEN the distinct projection and the Expand, so
+`RETURN DISTINCT b.x ORDER BY b.x` missed the BFS eligibility and hung on the released
+binary — invisible to the 2.2.0 tests because they executed `lower()` output while the
+server executes `optimize()` output (the same class of trap as the index-reachability
+rule: test the pipeline the server runs). Three fixes in 2.2.1: (a) eligibility looks
+through the no-skip/no-limit `TopN{keys}` sandwich when the keys also read only the
+endpoint, re-applying the sort to the BFS output; (b) `dedup_rows` is now
+order-preserving first-occurrence — the old sort-by-fingerprint dedup silently
+re-ordered its input ("I10;" < "I2;"), so `RETURN DISTINCT x ORDER BY x` returned
+fingerprint order, a correctness bug PREDATING this work; (c) the deadline and row cap
+now fire INSIDE a single seed's expansion (per-hop + every 4096 edges in both the flat
+and factor executors) — before, one seed's deg^hop enumeration ran unbounded past the
+30 s budget because both guards only probed at seed boundaries. The
+exec_distinct_endpoints suite now runs every plan through `optimize()`.
 
 ### 47. [PARTIALLY DONE — mechanism refuted; two real gaps fixed, one deferred] NDB-09: shortestPath blows the 1M row cap.
 


### PR DESCRIPTION
Smoke-testing the released 2.2.0 binaries against a K20 graph hung on `MATCH (s {seq:0})-[:KNOWS*1..6]->(b) RETURN DISTINCT b.seq ORDER BY b.seq` — the bare-ORDER-BY lowering puts `TopN{keys}` between `Project{distinct}` and the Expand, a shape the 2.2.0 BFS eligibility didn't match. Invisible to the 2.2.0 tests because they executed `lower()` output while the server executes `optimize()` output (same trap class as the index-reachability rule); the test harness now runs every plan through the optimizer.

1. **Eligibility looks through the sandwich**: no-skip/no-limit `TopN{keys}` whose keys also read only the endpoint; the sort is re-applied to the BFS output. Defensive fallbacks for any other shape.
2. **`dedup_rows` is order-preserving** (first-occurrence via fingerprint set). The old sort-by-fingerprint dedup re-ordered its input (`"I10;" < "I2;"`), so `RETURN DISTINCT x ORDER BY x` returned `[10, 1, 20, 2]` — a long-standing correctness bug predating the BFS work, now covered by `distinct_order_by_returns_value_order` (asc + desc).
3. **In-loop budgets**: deadline + row cap now fire inside a single seed's expansion (per hop and every 4096 edges, in both the flat and factor executors). Previously a single-seed dense enumeration ignored the 30 s query budget entirely — `ineligible_dense_expand_hits_budget_instead_of_hanging` proves both the typed row-cap error and a prompt deadline abort on a ~3.6M-walk graph.

Full `namidb-query` + `namidb-server` suites and the clippy gate green locally. Ships as 2.2.1.