### PR TITLE
feat: GQLSTATUS on the Bolt wire (protocol 5.7)

### DIFF
--- a/crates/namidb-bolt/src/handshake.rs
+++ b/crates/namidb-bolt/src/handshake.rs
@@ -55,8 +55,18 @@ impl std::fmt::Display for Version {
 
 /// Versions the server is willing to negotiate, highest preference
 /// first. Insertion order maps to preference order during matching.
-pub const SUPPORTED_VERSIONS: &[Version] =
-    &[Version::new(5, 4), Version::new(5, 0), Version::new(4, 4)];
+///
+/// 5.7 is the GQLSTATUS boundary: FAILURE metadata gains
+/// `gql_status`/`description`/`diagnostic_record` (see
+/// [`crate::message::Response::failure_with_gql`]). The other 5.5–5.7
+/// obligations are already met — TELEMETRY (5.5) is accepted and
+/// acknowledged, and unknown HELLO/RUN extra keys are ignored.
+pub const SUPPORTED_VERSIONS: &[Version] = &[
+    Version::new(5, 7),
+    Version::new(5, 4),
+    Version::new(5, 0),
+    Version::new(4, 4),
+];
 
 /// One client offer. `range` lets a client say "any minor between
 /// `minor - range` and `minor`" of `major`.

--- a/crates/namidb-bolt/src/message.rs
+++ b/crates/namidb-bolt/src/message.rs
@@ -287,9 +287,67 @@ impl Response {
         Response::Failure(m)
     }
 
+    /// Bolt >= 5.7: `FAILURE` additionally carries the GQL error fields —
+    /// `gql_status` (per-family, from [`gql_status_for_code`]),
+    /// `description`, and a `diagnostic_record` with the spec's default
+    /// keys. GQL-aware drivers (5.23+) surface these instead of the 50N42
+    /// polyfill they apply to older protocol versions.
+    pub fn failure_with_gql(code: &str, message: impl Into<String>) -> Self {
+        let message = message.into();
+        let mut m = BTreeMap::new();
+        // 5.7 renamed the FAILURE code key to `neo4j_code` — official
+        // drivers on a >= 5.7 session read ONLY that key and fall back to
+        // UnknownError when it is absent (observed with the Python driver).
+        // Keep `code` too: harmless, and raw-protocol consumers that
+        // negotiated 5.7 but read the old key keep working.
+        m.insert("neo4j_code".into(), Value::String(code.into()));
+        m.insert("code".into(), Value::String(code.into()));
+        m.insert("message".into(), Value::String(message.clone()));
+        m.insert(
+            "gql_status".into(),
+            Value::String(gql_status_for_code(code).into()),
+        );
+        m.insert(
+            "description".into(),
+            Value::String(format!("error: {message}")),
+        );
+        let mut diag = BTreeMap::new();
+        diag.insert("OPERATION".into(), Value::String(String::new()));
+        diag.insert("OPERATION_CODE".into(), Value::String("0".into()));
+        diag.insert("CURRENT_SCHEMA".into(), Value::String("/".into()));
+        m.insert("diagnostic_record".into(), Value::Map(diag));
+        Response::Failure(m)
+    }
+
     /// Convenience: build an empty `SUCCESS {}`.
     pub fn success_empty() -> Self {
         Response::Success(BTreeMap::new())
+    }
+}
+
+/// GQLSTATUS for a dotted Neo4j-shaped failure code (Bolt >= 5.7).
+/// Class-accurate GQL/SQLSTATE families, mirroring the HTTP body taxonomy:
+/// 42001 syntax, 42000 semantic, 0A000 not supported, 22000 evaluation,
+/// 23000 constraint, 57014 timeout, 54000 deterministic result limits,
+/// 53000 transient resource pressure, 28000 unauthenticated, 42501
+/// insufficient privilege, 08000 protocol misuse — and 50N42 for anything
+/// unclassified, the same value GQL-aware drivers polyfill on older
+/// protocol versions.
+pub fn gql_status_for_code(code: &str) -> &'static str {
+    match code {
+        "Neo.ClientError.Statement.SyntaxError" => "42001",
+        "Neo.ClientError.Statement.SemanticError" => "42000",
+        "Neo.ClientError.Statement.NotSupported" => "0A000",
+        "Neo.ClientError.Statement.ArgumentError" => "22000",
+        "Neo.ClientError.Schema.ConstraintValidationFailed" => "23000",
+        "Neo.ClientError.Transaction.TransactionTimedOut" => "57014",
+        "Neo.ClientError.Statement.ResourceLimitExceeded" => "54000",
+        "Neo.TransientError.General.DatabaseUnavailable"
+        | "Neo.TransientError.Transaction.LockClientStopped" => "53000",
+        "Neo.ClientError.Security.Unauthorized" => "28000",
+        "Neo.ClientError.Security.Forbidden" => "42501",
+        "Neo.ClientError.Request.Invalid" => "08000",
+        _ => "50N42",
     }
 }
 

--- a/crates/namidb-bolt/src/session.rs
+++ b/crates/namidb-bolt/src/session.rs
@@ -1671,7 +1671,16 @@ impl<S: AsyncReadExt + AsyncWriteExt + Unpin> Session<S> {
     }
 
     async fn write_failure(&mut self, code: &str, message: impl Into<String>) -> Result<()> {
-        self.write_response(Response::failure(code, message)).await
+        // Every FAILURE funnels through here, so the negotiated-version
+        // check upgrades all of them at once: >= 5.7 carries the GQL error
+        // fields, older protocols keep the exact two-key shape.
+        let supports_gql = self.version.is_some_and(|v| (v.major, v.minor) >= (5, 7));
+        let resp = if supports_gql {
+            Response::failure_with_gql(code, message)
+        } else {
+            Response::failure(code, message)
+        };
+        self.write_response(resp).await
     }
 
     async fn write_response(&mut self, resp: Response) -> Result<()> {

--- a/crates/namidb-server/tests/bolt_integration.rs
+++ b/crates/namidb-server/tests/bolt_integration.rs
@@ -148,6 +148,21 @@ async fn handshake(stream: &mut TcpStream) {
     assert_eq!(reply, [0, 0, 4, 5], "expected Bolt 5.4 negotiated");
 }
 
+/// Handshake offering Bolt 5.7 (the GQLSTATUS boundary).
+async fn handshake_v57(stream: &mut TcpStream) {
+    let bytes = [
+        0x60, 0x60, 0xB0, 0x17, // magic
+        0x00, 0x00, 0x07, 0x05, // 5.7
+        0x00, 0x00, 0x00, 0x00, //
+        0x00, 0x00, 0x00, 0x00, //
+        0x00, 0x00, 0x00, 0x00, //
+    ];
+    stream.write_all(&bytes).await.expect("handshake send");
+    let mut reply = [0u8; 4];
+    stream.read_exact(&mut reply).await.expect("handshake read");
+    assert_eq!(reply, [0, 0, 7, 5], "expected Bolt 5.7 negotiated");
+}
+
 async fn hello_and_logon(stream: &mut TcpStream, token: &str) {
     // HELLO {} (v5 carries no auth here)
     let hello = Value::Struct {
@@ -1347,6 +1362,66 @@ async fn bolt_row_cap_failure_has_resource_limit_code() {
             assert!(message.contains("row cap"), "message: {message}")
         }
         other => panic!("FAILURE missing message: {other:?}"),
+    }
+
+    stream.shutdown().await.ok();
+    task.abort();
+}
+
+/// Bolt >= 5.7: FAILURE carries real GQL fields per family instead of the
+/// driver-side 50N42 polyfill; <= 5.4 keeps the exact two-key shape (the
+/// other tests in this file pin 5.4 and assert that implicitly).
+#[tokio::test]
+async fn bolt_57_failure_carries_gql_status() {
+    let (bolt_addr, task) = boot_bolt_row_cap("bolt-gql", 1).await;
+    let mut stream = TcpStream::connect(bolt_addr).await.expect("connect bolt");
+    handshake_v57(&mut stream).await;
+    hello_and_logon(&mut stream, "test-token").await;
+
+    for query in [
+        "CREATE (:Person {name: 'Ada'})",
+        "CREATE (:Person {name: 'Bo'})",
+    ] {
+        pull_all(&mut stream, query).await;
+    }
+    let run = Value::Struct {
+        tag: struct_tag::RUN,
+        fields: vec![
+            Value::String("MATCH (p:Person) RETURN p.name AS name".into()),
+            Value::Map(BTreeMap::new()),
+            Value::Map(BTreeMap::new()),
+        ],
+    };
+    send_msg(&mut stream, &pack(&run)).await;
+    let meta = match recv_msg(&mut stream).await {
+        Response::Failure(meta) => meta,
+        other => panic!("expected FAILURE, got {other:?}"),
+    };
+    // 5.7 renamed the code key; official drivers read `neo4j_code` only.
+    for key in ["neo4j_code", "code"] {
+        assert_eq!(
+            meta.get(key),
+            Some(&Value::String(
+                "Neo.ClientError.Statement.ResourceLimitExceeded".into()
+            )),
+            "{key} missing: {meta:?}"
+        );
+    }
+    assert_eq!(
+        meta.get("gql_status"),
+        Some(&Value::String("54000".into())),
+        "row cap must map to the result-limit GQL family: {meta:?}"
+    );
+    assert!(
+        matches!(meta.get("description"), Some(Value::String(d)) if d.starts_with("error: ")),
+        "description missing: {meta:?}"
+    );
+    match meta.get("diagnostic_record") {
+        Some(Value::Map(diag)) => {
+            assert!(diag.contains_key("OPERATION"), "{diag:?}");
+            assert!(diag.contains_key("CURRENT_SCHEMA"), "{diag:?}");
+        }
+        other => panic!("diagnostic_record missing: {other:?}"),
     }
 
     stream.shutdown().await.ok();


### PR DESCRIPTION
Closes the last piece of NDB-03. Bolt 5.7 negotiated (5.4/5.0/4.4 kept); on ≥5.7 sessions every FAILURE carries `gql_status` (per-family, mirroring the HTTP taxonomy), `description`, `diagnostic_record`, and `neo4j_code` — 5.7 renamed the code key, and the official Python driver reads only the new name (found by live-testing: without it the driver reported `UnknownError`). Older protocols keep the exact two-key FAILURE shape.

All failures funnel through `write_failure`, so a single negotiated-version check upgrades every emission site. TELEMETRY (5.5) was already accepted; unknown HELLO/RUN extra keys were already ignored.

Live validation with the official Neo4j Python driver: timeout → `Neo.ClientError.Transaction.TransactionTimedOut` + `gql_status: 57014`, non-retriable (previously the 50N42 polyfill). Integration test does a raw 5.7 handshake and asserts the full metadata; 5.4-pinned tests assert the legacy shape implicitly.