### PR TITLE
perf: seed-grouped shortestPath BFS; fix nodes(p) intermediate values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,30 @@ crates.io release will establish and document that API explicitly.
 
 ## [Unreleased]
 
+**Added**
+- `POST /v0/admin/backup`: copy a live, point-in-time snapshot of the
+  namespace to an operator-allowlisted destination (retention-pin lease;
+  no writer pause). Disabled unless `--backup-target-uri` /
+  `NAMIDB_BACKUP_TARGET_URI` allowlists destinations — the server's
+  ambient cloud credentials write wherever the request says, so the
+  allowlist is the security boundary. Restore stays CLI-only (offline
+  destination required). Single-tenant only.
+- GQLSTATUS on the Bolt wire: protocol 5.7 is negotiated, and FAILURE
+  metadata carries `gql_status` (per-family, mirroring the HTTP
+  taxonomy), `description`, `diagnostic_record`, and `neo4j_code`.
+  GQL-aware drivers now show e.g. `57014` for a timeout instead of the
+  `50N42` polyfill. Older protocol versions keep the exact legacy
+  FAILURE shape.
+- `shortestPath` seed grouping: consecutive seed rows sharing a source
+  (the all-pairs `MATCH (a), (b)` shape) run one multi-target BFS
+  instead of one identical BFS per row.
+
+**Fixed**
+- `nodes(p)` on a `shortestPath` binding returned the endpoint value at
+  every intermediate hop (a 2-hop path came back as
+  `["n0", "n2", "n2"]`). The trail now carries the node actually
+  reached at each hop.
+
 ## [2.2.1] - 2026-08-28
 
 Found smoke-testing the released 2.2.0 artifacts against a dense graph.

--- a/crates/namidb-query/src/exec/walker.rs
+++ b/crates/namidb-query/src/exec/walker.rs
@@ -1436,6 +1436,32 @@ pub(crate) async fn execute_expand(
     // globally-deduped stream is a prefix of the uncapped DISTINCT result.
     let mut emitted: std::collections::HashSet<NodeId> = std::collections::HashSet::new();
 
+    // Seed-grouped shortest path (NDB-09 follow-up): consecutive seed rows
+    // sharing a source (the CrossProduct's row-major (a, b) pairs) run ONE
+    // multi-target BFS instead of one identical BFS per row — a 24k-pair
+    // workload previously redid the whole-graph BFS 24k times. Lowering
+    // guarantees back_reference for shortest mode; the uncapped requirement
+    // keeps the LIMIT-pushdown prefix semantics untouched.
+    if shortest != crate::plan::ShortestMode::None && back_reference && cap.is_none() {
+        return execute_expand_shortest_grouped(
+            rows,
+            source,
+            &edge_types,
+            direction,
+            rel_alias,
+            target_alias,
+            target_labels,
+            min,
+            max,
+            optional,
+            shortest,
+            path_binding,
+            snapshot,
+            edge_read_mode,
+        )
+        .await;
+    }
+
     let mut out = Vec::new();
     for row in rows {
         // Deadline + row-cap guards: a multi-seed (or variable-length)
@@ -1782,11 +1808,22 @@ pub(crate) async fn execute_expand(
                         if let Some(view) = target_view_opt.as_ref() {
                             Some(NodeValue::from(view.clone()))
                         } else if back_reference {
-                            // Back-reference uses the pre-bound NodeView from
-                            // the existing target_alias on the seed row.
-                            match row.get(target_alias) {
-                                Some(RuntimeValue::Node(n)) => Some(n.as_ref().clone()),
-                                _ => None,
+                            if materialise_trail && Some(target_id) != existing_target_id {
+                                // The trail must carry the node actually
+                                // reached at THIS hop. The pre-bound value is
+                                // only correct at the final target; reusing
+                                // it for intermediates made `nodes(p)` repeat
+                                // the endpoint (["n0", "n2", "n2"]).
+                                scan_node_for_id(snapshot, target_id)
+                                    .await?
+                                    .map(NodeValue::from)
+                            } else {
+                                // Back-reference uses the pre-bound NodeView
+                                // from the existing target_alias on the row.
+                                match row.get(target_alias) {
+                                    Some(RuntimeValue::Node(n)) => Some(n.as_ref().clone()),
+                                    _ => None,
+                                }
                             }
                         } else if skip_target_materialize {
                             Some(NodeValue {
@@ -1916,6 +1953,264 @@ pub(crate) async fn execute_expand(
             }
             out.push(empty);
         }
+    }
+    Ok(out)
+}
+
+/// Seed-grouped shortestPath/allShortestPaths execution: one pruned
+/// multi-target BFS per run of consecutive seed rows sharing a source node,
+/// serving every bound target of the run. Row order (and therefore output
+/// order) is preserved — hits are emitted per seed row in input order.
+///
+/// Semantics mirror the per-seed loop in [`execute_expand`]: `First` emits
+/// one row per (src, dst) at dst's first-reached level; `All` emits every
+/// arrival at dst's first-reached level; trail (`p`) and rel-list bindings
+/// are materialised per hit, with the trail carrying the ACTUAL node
+/// reached at each hop.
+#[allow(clippy::too_many_arguments)]
+async fn execute_expand_shortest_grouped(
+    rows: Vec<Row>,
+    source: &str,
+    edge_types: &[String],
+    direction: RelationshipDirection,
+    rel_alias: Option<&str>,
+    target_alias: &str,
+    target_labels: &[String],
+    min: u32,
+    max: u32,
+    optional: bool,
+    shortest: crate::plan::ShortestMode,
+    path_binding: Option<&str>,
+    snapshot: &Snapshot<'_>,
+    edge_read_mode: EdgeReadMode,
+) -> Result<Vec<Row>, ExecError> {
+    namidb_core::profile_scope!("walker::execute_expand_shortest_grouped");
+    use std::collections::{HashMap, HashSet};
+    let materialise_trail = path_binding.is_some();
+    // One emitted path per hit: its trail and its relationship list.
+    type PathHit = (Vec<RuntimeValue>, Vec<RuntimeValue>);
+    let mut out: Vec<Row> = Vec::new();
+    let mut i = 0usize;
+    while i < rows.len() {
+        crate::exec::limits::check_deadline()?;
+        crate::exec::limits::check_row_cap(out.len())?;
+        let starting = match rows[i].get(source) {
+            Some(RuntimeValue::Node(n)) => n.id,
+            _ => {
+                return Err(ExecError::Runtime(format!(
+                    "Expand source `{}` is not a Node",
+                    source
+                )))
+            }
+        };
+        let mut j = i + 1;
+        while j < rows.len() {
+            match rows[j].get(source) {
+                Some(RuntimeValue::Node(n)) if n.id == starting => j += 1,
+                _ => break,
+            }
+        }
+        let run = &rows[i..j];
+
+        // Per-row bound target, mirroring the ungrouped back-reference
+        // handling (NULL target = no match; label mismatch = no match).
+        let mut row_targets: Vec<Option<NodeId>> = Vec::with_capacity(run.len());
+        let mut remaining: HashSet<NodeId> = HashSet::new();
+        for row in run {
+            match row.get(target_alias) {
+                Some(RuntimeValue::Node(n)) => {
+                    if target_labels.iter().all(|l| n.labels.contains(l)) {
+                        remaining.insert(n.id);
+                        row_targets.push(Some(n.id));
+                    } else {
+                        row_targets.push(None);
+                    }
+                }
+                Some(RuntimeValue::Null) => row_targets.push(None),
+                other => {
+                    return Err(ExecError::Runtime(format!(
+                        "Expand back-reference target `{}` is not a Node (got {:?})",
+                        target_alias, other
+                    )))
+                }
+            }
+        }
+
+        // Hits per target: (trail, rel_values) per emitted path.
+        let mut hits: HashMap<NodeId, Vec<PathHit>> = HashMap::new();
+        let initial_trail = if materialise_trail {
+            match run[0].get(source) {
+                Some(RuntimeValue::Node(n)) => vec![RuntimeValue::Node(n.clone())],
+                _ => Vec::new(),
+            }
+        } else {
+            Vec::new()
+        };
+        // Zero hop: the source is its own (label-checked, since `remaining`
+        // only holds label-ok targets) endpoint. Its shortest length is 0,
+        // so it takes no longer hit.
+        if min == 0 && remaining.remove(&starting) {
+            hits.entry(starting)
+                .or_default()
+                .push((initial_trail.clone(), Vec::new()));
+        }
+
+        struct PathState {
+            tail: NodeId,
+            trail: Vec<RuntimeValue>,
+            rels: Vec<(String, NodeId, NodeId)>,
+            rel_values: Vec<RuntimeValue>,
+        }
+        let bfs_prune = min <= 1;
+        let hop_keyed_prune = shortest == crate::plan::ShortestMode::First && min >= 2;
+        let mut visited: HashSet<NodeId> = if bfs_prune {
+            HashSet::from([starting])
+        } else {
+            HashSet::new()
+        };
+        let mut visited_at_hop: HashSet<(NodeId, u32)> = HashSet::new();
+        let bind_rels = rel_alias.is_some();
+        let mut frontier: Vec<PathState> = vec![PathState {
+            tail: starting,
+            trail: initial_trail,
+            rels: Vec::new(),
+            rel_values: Vec::new(),
+        }];
+        for hop in 1..=max {
+            if remaining.is_empty() || frontier.is_empty() {
+                break;
+            }
+            crate::exec::limits::check_deadline()?;
+            crate::exec::limits::check_row_cap(out.len() + frontier.len())?;
+            let mut guard_tick: u32 = 0;
+            let mut next_frontier: Vec<PathState> = Vec::new();
+            let mut level_seen: HashSet<NodeId> = HashSet::new();
+            let mut level_hit: HashSet<NodeId> = HashSet::new();
+            let mut step_neighbours: Vec<(PathState, Vec<EdgeView>)> =
+                Vec::with_capacity(frontier.len());
+            for state in frontier.drain(..) {
+                crate::exec::limits::check_deadline()?;
+                let neighbours =
+                    neighbours_of_any(snapshot, edge_types, direction, state.tail, edge_read_mode)
+                        .await?;
+                step_neighbours.push((state, neighbours));
+            }
+            for (state, neighbours) in step_neighbours {
+                for edge in neighbours {
+                    guard_tick = guard_tick.wrapping_add(1);
+                    if guard_tick % 4096 == 0 {
+                        crate::exec::limits::check_deadline()?;
+                        crate::exec::limits::check_row_cap(out.len() + next_frontier.len())?;
+                    }
+                    let target_id = partner_id(&edge, direction, state.tail);
+                    // Trail semantics first, then the frontier dedups (same
+                    // ordering rationale as the per-seed loop).
+                    let edge_key = if max > 1 {
+                        Some((edge.edge_type.clone(), edge.src, edge.dst))
+                    } else {
+                        None
+                    };
+                    if let Some(k) = &edge_key {
+                        if state.rels.contains(k) {
+                            continue;
+                        }
+                    }
+                    if bfs_prune {
+                        if visited.contains(&target_id) {
+                            continue;
+                        }
+                        if shortest == crate::plan::ShortestMode::First
+                            && !level_seen.insert(target_id)
+                        {
+                            continue;
+                        }
+                    }
+                    if hop_keyed_prune && !visited_at_hop.insert((target_id, hop)) {
+                        continue;
+                    }
+                    let rel_value = RuntimeValue::Rel(Box::new(RelValue::from(edge)));
+                    let mut new_trail = state.trail.clone();
+                    if materialise_trail {
+                        new_trail.push(rel_value.clone());
+                        // The ACTUAL node reached at this hop (a pre-bound
+                        // endpoint value is only correct at the endpoint).
+                        match scan_node_for_id(snapshot, target_id).await? {
+                            Some(v) => {
+                                new_trail.push(RuntimeValue::Node(Box::new(NodeValue::from(v))))
+                            }
+                            None => new_trail.push(RuntimeValue::Null),
+                        }
+                    }
+                    let mut new_rel_values = state.rel_values.clone();
+                    if bind_rels {
+                        new_rel_values.push(rel_value);
+                    }
+                    let mut new_rels = state.rels.clone();
+                    if let Some(k) = edge_key {
+                        new_rels.push(k);
+                    }
+                    if hop >= min.max(1) && remaining.contains(&target_id) {
+                        hits.entry(target_id)
+                            .or_default()
+                            .push((new_trail.clone(), new_rel_values.clone()));
+                        level_hit.insert(target_id);
+                        if shortest == crate::plan::ShortestMode::First {
+                            // One path per (src, dst); later arrivals (even
+                            // same-level) are surplus.
+                            remaining.remove(&target_id);
+                        }
+                    }
+                    next_frontier.push(PathState {
+                        tail: target_id,
+                        trail: new_trail,
+                        rels: new_rels,
+                        rel_values: new_rel_values,
+                    });
+                }
+            }
+            if shortest == crate::plan::ShortestMode::All {
+                // Seal this level's finds: every arrival at the target's
+                // first-reached level was emitted; longer paths are not
+                // shortest.
+                for t in level_hit {
+                    remaining.remove(&t);
+                }
+            }
+            if bfs_prune {
+                for state in &next_frontier {
+                    visited.insert(state.tail);
+                }
+            }
+            frontier = next_frontier;
+        }
+
+        // Emit per seed row in input order.
+        for (row, target) in run.iter().zip(row_targets) {
+            let row_hits = target.and_then(|t| hits.get(&t));
+            match row_hits {
+                Some(list) if !list.is_empty() => {
+                    for (trail, rel_values) in list {
+                        let mut hit = row.clone();
+                        if let Some(name) = rel_alias {
+                            hit.set(name.to_string(), RuntimeValue::List(rel_values.clone()));
+                        }
+                        if let Some(name) = path_binding {
+                            hit.set(name.to_string(), RuntimeValue::Path(trail.clone()));
+                        }
+                        out.push(hit);
+                    }
+                }
+                _ if optional => {
+                    let mut empty = row.clone();
+                    if let Some(name) = rel_alias {
+                        empty.set(name, RuntimeValue::Null);
+                    }
+                    out.push(empty);
+                }
+                _ => {}
+            }
+        }
+        i = j;
     }
     Ok(out)
 }

--- a/crates/namidb-query/tests/exec_shortest_path.rs
+++ b/crates/namidb-query/tests/exec_shortest_path.rs
@@ -209,6 +209,123 @@ async fn shortest_path_rejects_unbound_endpoint() {
     );
 }
 
+/// RFC-023 trail correctness: `nodes(p)` must carry the ACTUAL intermediate
+/// nodes. The back-reference emission used to fill every hop with the
+/// pre-bound endpoint value, so a 2-hop path returned ["n0", "n2", "n2"].
+#[tokio::test]
+async fn shortest_path_trail_carries_intermediate_nodes() {
+    let mut writer = WriterSession::open(store(), paths("sp-trail"))
+        .await
+        .unwrap();
+    let ids: Vec<NodeId> = (0..3).map(|_| NodeId::new()).collect();
+    for (i, &id) in ids.iter().enumerate() {
+        writer
+            .upsert_node("Person", id, &person(&format!("n{i}")))
+            .unwrap();
+    }
+    for pair in ids.windows(2) {
+        writer
+            .upsert_edge("KNOWS", pair[0], pair[1], &edge())
+            .unwrap();
+    }
+    writer.commit_batch().await.unwrap();
+    let snapshot = writer.snapshot();
+    let q = parse(
+        "MATCH (a:Person {name: 'n0'}), (b:Person {name: 'n2'}) \
+         MATCH p = shortestPath((a)-[:KNOWS*..4]->(b)) \
+         RETURN [n IN nodes(p) | n.name] AS names",
+    )
+    .unwrap();
+    let rows = execute(&lower(&q).unwrap(), &snapshot, &Params::new())
+        .await
+        .unwrap();
+    assert_eq!(rows.len(), 1);
+    match rows[0].get("names") {
+        Some(RuntimeValue::List(items)) => {
+            let names: Vec<&str> = items
+                .iter()
+                .map(|v| match v {
+                    RuntimeValue::String(s) => s.as_str(),
+                    other => panic!("non-string name: {other:?}"),
+                })
+                .collect();
+            assert_eq!(names, ["n0", "n1", "n2"]);
+        }
+        other => panic!("names not a list: {other:?}"),
+    }
+}
+
+/// NDB-09 follow-up: many (src, dst) pairs sharing a source run ONE
+/// multi-target BFS. 40 bound targets over the layered graph — the per-seed
+/// executor redid the whole BFS 40 times; the grouped run answers each pair
+/// exactly once with its shortest length.
+#[tokio::test]
+async fn multi_pair_shortest_paths_answer_every_bound_target() {
+    let mut writer = WriterSession::open(store(), paths("sp-multipair"))
+        .await
+        .unwrap();
+    const WIDTH: usize = 20;
+    let s = NodeId::new();
+    writer.upsert_node("Person", s, &person("s")).unwrap();
+    let l0: Vec<NodeId> = (0..WIDTH).map(|_| NodeId::new()).collect();
+    let l1: Vec<NodeId> = (0..WIDTH).map(|_| NodeId::new()).collect();
+    for (ni, &id) in l0.iter().enumerate() {
+        writer
+            .upsert_node("Person", id, &person(&format!("a{ni}")))
+            .unwrap();
+    }
+    for (ni, &id) in l1.iter().enumerate() {
+        writer
+            .upsert_node("Person", id, &person(&format!("b{ni}")))
+            .unwrap();
+    }
+    for &a in &l0 {
+        writer.upsert_edge("KNOWS", s, a, &edge()).unwrap();
+        for &b in &l1 {
+            writer.upsert_edge("KNOWS", a, b, &edge()).unwrap();
+        }
+    }
+    writer.commit_batch().await.unwrap();
+    let snapshot = writer.snapshot();
+
+    // First mode: one row per (s, b*) pair, each at its shortest length (2).
+    let q = parse(
+        "MATCH (a:Person {name: 's'}) MATCH (b:Person) WHERE b.name STARTS WITH 'b' \
+         MATCH p = shortestPath((a)-[:KNOWS*..5]->(b)) \
+         RETURN b.name AS name, length(p) AS hops",
+    )
+    .unwrap();
+    let rows = execute(&lower(&q).unwrap(), &snapshot, &Params::new())
+        .await
+        .unwrap();
+    assert_eq!(rows.len(), WIDTH, "one row per bound target");
+    for row in &rows {
+        assert_eq!(
+            row.get("hops"),
+            Some(&RuntimeValue::Integer(2)),
+            "{:?}",
+            row.get("name")
+        );
+    }
+
+    // All mode: every same-length arrival, per target — WIDTH distinct
+    // 2-hop paths reach each b* (one through each a*).
+    let q = parse(
+        "MATCH (a:Person {name: 's'}) MATCH (b:Person {name: 'b0'}) \
+         MATCH p = allShortestPaths((a)-[:KNOWS*..5]->(b)) \
+         RETURN count(p) AS n",
+    )
+    .unwrap();
+    let rows = execute(&lower(&q).unwrap(), &snapshot, &Params::new())
+        .await
+        .unwrap();
+    assert_eq!(
+        rows[0].get("n"),
+        Some(&RuntimeValue::Integer(WIDTH as i64)),
+        "allShortestPaths must keep every same-level arrival"
+    );
+}
+
 /// Dense layered graph: s → L1(40) → L2(40) → L3(40) → L4(40) → L5(40) → t,
 /// complete bipartite between consecutive layers. The walk-enumerating
 /// frontier holds 40^k entries at hop k (~102M Row clones by hop 5 — an

--- a/docs/testing/25tb-readiness.md
+++ b/docs/testing/25tb-readiness.md
@@ -558,7 +558,7 @@ HTTP request and `AuthPolicy::Open` on Bolt. Fix: boot REFUSES to start with no 
 source unless `--no-auth` / `NAMIDB_NO_AUTH=1` is passed explicitly (check sits at the
 `is_open()` point so JWT-only configs keep booting). Breaking change, release-noted.
 
-### 45. [DONE — lands in 2.2.0] NDB-03: error taxonomy collapse.
+### 45. [DONE — taxonomy in 2.2.0; wire GQLSTATUS in 2.3.0] NDB-03: error taxonomy collapse.
 
 Recon corrected two details: `50N42` is a driver-side polyfill (Bolt ≤5.4 carries no
 GQLSTATUS; the string appears nowhere in the repo), and HTTP already distinguished
@@ -570,6 +570,14 @@ budget re-run fails identically); deterministic search caps moved out of the
 auto-retried TransientError bucket; HTTP bodies now carry `neo4j_code` + `gql_status`
 per family (table in the server README); eval errors are 400 not 500. Bolt ≥5.7
 GQLSTATUS-on-the-wire: roadmap (~2-3 days: negotiate 5.7, extend FAILURE metadata).
+
+**2.3.0 addendum:** Bolt 5.7 negotiated; on >= 5.7 sessions every FAILURE carries
+gql_status/description/diagnostic_record AND neo4j_code — 5.7 renamed the code key,
+and the official Python driver reads only the new name (found live-testing: without
+it the driver fell back to UnknownError). All failures funnel through write_failure,
+so one version check upgraded every site; TELEMETRY (5.5) was already handled.
+Live-validated with the official driver: timeout => TransactionTimedOut + gql 57014
+(previously the 50N42 polyfill), non-retriable.
 
 ### 46. [DONE — BFS in 2.2.0; ORDER BY sandwich + in-loop budgets in 2.2.1] NDB-04: var-length traversal enumerates all paths under DISTINCT+LIMIT.
 
@@ -604,7 +612,7 @@ and factor executors) — before, one seed's deg^hop enumeration ran unbounded p
 30 s budget because both guards only probed at seed boundaries. The
 exec_distinct_endpoints suite now runs every plan through `optimize()`.
 
-### 47. [PARTIALLY DONE — mechanism refuted; two real gaps fixed, one deferred] NDB-09: shortestPath blows the 1M row cap.
+### 47. [DONE — 2.2.0 gaps + 2.3.0 seed-grouping and trail fix] NDB-09: shortestPath blows the 1M row cap.
 
 The claimed mechanism ("expands then trims") is REFUTED on 2.1.4: shortestPath lowers
 onto the Expand with ShortestMode and the executor early-stops (BFS visited pruning
@@ -622,6 +630,16 @@ shortest path" output vs the previous effective hang); (b) unbound endpoints now
 at lowering with the previously-bound rule spelled out. Deferred (sized): seed-grouping
 (one BFS per distinct source serving all its bound targets, 1-2 days) and bidirectional
 meet-in-the-middle for single pairs.
+
+**2.3.0 addendum:** seed-grouping shipped — consecutive seed rows sharing a source
+(the CrossProduct's row-major pairs) run ONE multi-target BFS
+(execute_expand_shortest_grouped): per-target first-reached-level bookkeeping
+preserves First (one row per pair) and All (every same-level arrival) semantics,
+row order preserved, engaged only when uncapped so LIMIT-pushdown prefix semantics
+stay untouched. Implementing it surfaced ANOTHER pre-existing trail bug: nodes(p)
+filled every intermediate hop with the pre-bound endpoint value (a 2-hop path
+returned ["n0","n2","n2"]) — fixed in both the grouped and per-seed paths by looking
+up the node actually reached. Bidirectional meet-in-the-middle stays roadmap.
 
 ### 48. [DONE — lands in 2.2.0] NDB-05: reduce() does not parse.
 


### PR DESCRIPTION
NDB-09 follow-up (plan item 47, the deferred seed-grouping).

- **One multi-target BFS per source**: consecutive seed rows sharing a source (the CrossProduct's row-major `(a, b)` pairs) are served by a single pruned BFS (`execute_expand_shortest_grouped`) — a 24k-pair workload previously redid the whole-graph BFS 24k times. Per-target first-reached-level bookkeeping preserves First (one row per pair) and All (every same-level arrival) semantics; hits are emitted per seed row in input order so row order is unchanged; engaged only uncapped so LIMIT-pushdown prefix semantics stay untouched; same in-loop deadline/row-cap guards as the per-seed executor.
- **Trail correctness fix (pre-existing bug)**: the back-reference emission filled every intermediate hop with the pre-bound endpoint value — `nodes(p)` on a 2-hop path returned `["n0", "n2", "n2"]`. Both paths now look up the node actually reached at each hop.
- Tests: trail regression (`["n0","n1","n2"]`), 20-target multi-pair First (all at shortest length) + All (every same-level arrival counted), full shortest-path suite green through the grouped path, full `namidb-query`+`namidb-server` suites + clippy gate green locally.