### PR TITLE
feat: group commit (RFC-034) — many stagers, one committer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,15 @@ crates.io release will establish and document that API explicitly.
 ## [Unreleased]
 
 **Added**
+- Group commit (RFC-034): `--group-commit-window` /
+  `NAMIDB_GROUP_COMMIT_WINDOW` (default `0s` = off, inline commits exactly
+  as before) coalesces concurrently arriving writes into one WAL append +
+  one manifest CAS. Writes ACK only after the group's commit is durable
+  and the snapshot republished (read-your-own-writes preserved); a
+  statement failure rolls back alone; grouped writes share fate on a
+  commit failure. Lifts the interactive write floor — previously ~1
+  commit-round-trip per request (~309 nodes/s at 3 ms RTT in the field
+  report) — to roughly group-size per round-trip. Single-tenant only.
 - Multi-tenant Bolt: with `--multi-tenant`, the Bolt listener now starts
   and statements route to the namespace named by the driver's
   `database=` session parameter (the Bolt `db` field of RUN/BEGIN),

--- a/crates/namidb-server/README.md
+++ b/crates/namidb-server/README.md
@@ -302,6 +302,20 @@ wire (GQL-aware drivers show the `50N42` polyfill for every failure); the
 | `Rel`                 | `{"_kind": "rel", "edge_type", "src", "dst", "properties"}` |
 | `Path`                | array of alternating node/rel objects |
 
+## Group commit (RFC-034)
+
+`--group-commit-window` / `NAMIDB_GROUP_COMMIT_WINDOW` (default `0s` =
+disabled) coalesces concurrently arriving auto-commit writes into one WAL
+append + one manifest CAS: requests stage under the writer lock, register a
+waiter, and are ACKed only after the group's single commit is durable and
+the snapshot republished — read-your-own-writes is preserved, and a
+statement failure rolls back alone. With the window at zero every write
+commits inline, exactly as before. On real object storage (5-15 ms per
+commit round-trip same-region) a `2ms`-`5ms` window lifts the interactive
+write floor from ~1/commit-RTT to roughly group-size/commit-RTT; grouped
+writes share fate on a commit failure (one merged WAL segment cannot be
+partially durable). Single-tenant only for now.
+
 ## Concurrency model
 
 `namidb-server` opens one `WriterSession` per process and serialises

--- a/crates/namidb-server/src/bolt.rs
+++ b/crates/namidb-server/src/bolt.rs
@@ -813,6 +813,17 @@ impl ServerBackend {
             // below is deliberately NOT selected against cancellation — once
             // WAL/manifest publication starts it must run to a definite
             // outcome before this guard can be released.
+            // RFC-034: under group commit, a statement failure or a client
+            // disconnect rolls back ONLY this request's staged rows —
+            // `discard_batch` would take earlier group members' rows with it.
+            let group = self.state.group_commit.clone();
+            let mark = group.as_ref().map(|_| writer.begin_staged_request());
+            let discard_request = |writer: &mut namidb_storage::WriterSession| match mark {
+                Some(mark) => writer.rollback_staged_request(mark),
+                None => {
+                    writer.discard_batch();
+                }
+            };
             let staged = {
                 let apply = execute_write_staged_with_deadline(
                     &plan,
@@ -829,7 +840,7 @@ impl ServerBackend {
             let outcome = match staged {
                 Some(Ok(outcome)) => outcome,
                 Some(Err(error)) => {
-                    writer.discard_batch();
+                    discard_request(&mut writer);
                     crate::recovery::recover_after_write_error(
                         &mut writer,
                         &self.state.snapshot,
@@ -846,16 +857,57 @@ impl ServerBackend {
                     };
                 }
                 None => {
-                    writer.discard_batch();
+                    discard_request(&mut writer);
                     drop(writer);
                     return disconnected_observation(started, Some(QueryKind::Write));
                 }
             };
 
             if cancellation.is_cancelled() {
-                writer.discard_batch();
+                discard_request(&mut writer);
                 drop(writer);
                 return disconnected_observation(started, Some(QueryKind::Write));
+            }
+
+            if let Some(group) = group {
+                // Grouped durability: register while still holding the lock,
+                // release, and await the group's single commit. Once
+                // registered the rows belong to the group — a disconnect no
+                // longer revokes them, mirroring the inline path's
+                // non-cancellable commit tail.
+                writer.commit_staged_request();
+                let lsn = writer.staged_last_lsn().unwrap_or(0);
+                let ack = group.register(lsn);
+                let stall = self.state.after_commit_backpressure(&writer);
+                drop(writer);
+                group.notify_committer();
+                let acked = ack.await;
+                let elapsed = started.elapsed();
+                let result = match acked {
+                    Ok(Ok(())) => Ok(write_run_outcome(outcome)),
+                    Ok(Err(shared)) => Err(map_exec_err_ref(shared.0.as_ref())),
+                    Err(_) => Err(BackendError::Other(
+                        "group commit coordinator exited".into(),
+                    )),
+                };
+                if result.is_ok() {
+                    if let Some(delay) = stall {
+                        tokio::select! {
+                            _ = tokio::time::sleep(delay) => {}
+                            _ = cancellation.cancelled() => {
+                                return disconnected_observation(
+                                    started,
+                                    Some(QueryKind::Write),
+                                );
+                            }
+                        }
+                    }
+                }
+                return RunObservation {
+                    kind: Some(QueryKind::Write),
+                    elapsed,
+                    result,
+                };
             }
 
             match writer.commit_batch().await {
@@ -1502,6 +1554,12 @@ fn map_lower_err(e: LowerError) -> BackendError {
 }
 
 fn map_exec_err(e: ExecError) -> BackendError {
+    map_exec_err_ref(&e)
+}
+
+/// [`map_exec_err`] over a borrowed error — group commit hands every waiter
+/// the same `Arc`'d failure, which cannot be moved out.
+fn map_exec_err_ref(e: &ExecError) -> BackendError {
     // A deliberately-unsupported feature surfaces as the typed
     // `BackendError::Unsupported` (Neo.ClientError.Statement.NotSupported),
     // not a generic eval/storage bucket — so a driver can tell "not
@@ -1513,7 +1571,7 @@ fn map_exec_err(e: ExecError) -> BackendError {
     match e {
         // A constraint violation has its own Neo4j error class so drivers
         // can distinguish it from an ordinary evaluation error.
-        ExecError::Constraint(m) => BackendError::Constraint(m),
+        ExecError::Constraint(m) => BackendError::Constraint(m.clone()),
         // Deterministic budgets get their own ClientError classes: a driver
         // must be able to tell "this query is too expensive" from "this
         // query is malformed" without string-matching the message, and must

--- a/crates/namidb-server/src/lib.rs
+++ b/crates/namidb-server/src/lib.rs
@@ -42,8 +42,8 @@ use tokio::sync::Mutex;
 use tracing::{error, info, warn};
 
 use namidb_query::{
-    execute_with_limits, execute_write_with_deadline, parse as cypher_parse, plan as build_plan,
-    Params, RuntimeValue, StatsCatalog, WriteOutcome,
+    execute_with_limits, execute_write_staged_with_deadline, execute_write_with_deadline,
+    parse as cypher_parse, plan as build_plan, Params, RuntimeValue, StatsCatalog, WriteOutcome,
 };
 use namidb_storage::{sweep_orphans, Manifest, ManifestStore, SnapshotCell, WriterSession};
 
@@ -126,6 +126,14 @@ pub struct Config {
     /// configured fails instead of silently serving open — an unset
     /// `NAMIDB_AUTH_TOKEN` in production should be a crash, not a log line.
     pub no_auth: bool,
+    /// RFC-034 group commit coalescing window. Zero (the default) keeps
+    /// inline per-request commits — identical behaviour to every release
+    /// before it. A small window (1-5 ms) lets concurrently arriving writes
+    /// share one WAL append + manifest CAS, lifting the interactive write
+    /// floor (~1/commit-RTT) to roughly `group size / commit-RTT`, at the
+    /// cost of up to `window` extra latency for a lone write. Single-tenant
+    /// only for now.
+    pub group_commit_window: Duration,
     /// Destination-URI allowlist prefix for `POST /v0/admin/backup`
     /// (single-tenant only). `None` disables the endpoint: accepting a
     /// client-supplied destination without an operator-configured allowlist
@@ -318,6 +326,10 @@ pub struct AppState {
     /// automatic reopen ([`recovery`]) succeeds. Read lock-free by
     /// `/v0/health`.
     pub writer_health: Arc<WriterHealth>,
+    /// RFC-034 group commit coordinator. `None` = inline per-request
+    /// commits (the default, and always the case for multi-tenant
+    /// namespace views for now).
+    pub(crate) group_commit: Option<Arc<GroupCommit>>,
     /// Source handles + operator-configured destination allowlist for the
     /// admin backup endpoint. `None` = the endpoint is disabled — a
     /// client-supplied destination URI would otherwise let any read-write
@@ -372,8 +384,20 @@ impl AppState {
             metrics: Metrics::new(env!("CARGO_PKG_VERSION"), Duration::ZERO),
             authz: Arc::new(authz::NoOpAuthz),
             writer_health: WriterHealth::new(),
+            group_commit: None,
             backup: None,
         }
+    }
+
+    /// Enable RFC-034 group commit with the given coalescing window
+    /// (builder style). A zero window leaves inline commits in place. The
+    /// caller must also spawn [`group_committer_loop`] on the finished
+    /// state — without it, grouped writes would wait forever.
+    pub fn with_group_commit(mut self, window: Duration) -> Self {
+        if !window.is_zero() {
+            self.group_commit = Some(Arc::new(GroupCommit::new(window)));
+        }
+        self
     }
 
     /// Assemble a single-namespace view over a multi-tenant namespace: the
@@ -409,6 +433,10 @@ impl AppState {
             metrics: shared.metrics.clone(),
             authz: shared.authz.clone(),
             writer_health: ns.writer_health.clone(),
+            // Group commit needs a per-namespace committer task; wiring that
+            // through the registry is a follow-up, so multi-tenant views
+            // stay on inline commits.
+            group_commit: None,
             backup: None,
         }
     }
@@ -1039,7 +1067,16 @@ pub async fn run_with_memory_max_bytes(
         .with_memtable_thresholds(config.memtable_flush_bytes, config.memtable_stall_bytes)
         .with_memory_governor(memory)
         .with_writer_lock_timeout(config.writer_lock_timeout)
-        .with_slow_query_threshold(config.slow_query_threshold);
+        .with_slow_query_threshold(config.slow_query_threshold)
+        .with_group_commit(config.group_commit_window);
+    if state.group_commit.is_some() {
+        info!(
+            window_ms = config.group_commit_window.as_millis() as u64,
+            "group commit enabled"
+        );
+        let committer_state = state.clone();
+        tokio::spawn(group_committer_loop(committer_state));
+    }
     let state = match backup_handles {
         Some((backup_store, backup_paths, prefix)) => {
             info!(prefix = %prefix, "admin backup endpoint enabled");
@@ -1818,6 +1855,158 @@ pub(crate) async fn lock_writer_bounded(
         return Some(writer.lock().await);
     }
     tokio::time::timeout(timeout, writer.lock()).await.ok()
+}
+
+/// Group commit (RFC-034): one committer per namespace amortizes the
+/// two object-store round-trips of `commit_batch` across concurrently
+/// arriving writes. Requests stage under the writer lock inside a request
+/// scope (`begin_staged_request`), register a waiter keyed by their last
+/// staged LSN — still under the lock, so the committer cannot slip between
+/// staging and registration — and are ACKed only after the group's single
+/// commit is durable AND the snapshot republished (RFC-021/026 preserved).
+/// A `window` of zero disables the whole path: writes take today's inline
+/// stage+commit, which is the shipped default.
+pub(crate) struct GroupCommit {
+    pub(crate) window: Duration,
+    notify: tokio::sync::Notify,
+    #[allow(clippy::type_complexity)]
+    waiters: std::sync::Mutex<
+        Vec<(
+            u64,
+            tokio::sync::oneshot::Sender<Result<(), SharedCommitError>>,
+        )>,
+    >,
+}
+
+/// The one commit error a whole group shares (shared fate: a merged WAL
+/// segment cannot be partially durable).
+#[derive(Clone)]
+pub(crate) struct SharedCommitError(pub(crate) Arc<namidb_query::exec::ExecError>);
+
+/// A write's failure on either commit path: its own statement error, or the
+/// shared error of the group whose commit it joined.
+pub(crate) enum WriteFailure {
+    Own(namidb_query::exec::ExecError),
+    Shared(SharedCommitError),
+}
+
+impl WriteFailure {
+    pub(crate) fn as_exec(&self) -> &namidb_query::exec::ExecError {
+        match self {
+            WriteFailure::Own(e) => e,
+            WriteFailure::Shared(shared) => shared.0.as_ref(),
+        }
+    }
+}
+
+impl GroupCommit {
+    fn new(window: Duration) -> Self {
+        Self {
+            window,
+            notify: tokio::sync::Notify::new(),
+            waiters: std::sync::Mutex::new(Vec::new()),
+        }
+    }
+
+    /// Register a waiter for the staged rows up to `lsn`. MUST be called
+    /// while still holding the writer lock (see the struct docs).
+    pub(crate) fn register(
+        &self,
+        lsn: u64,
+    ) -> tokio::sync::oneshot::Receiver<Result<(), SharedCommitError>> {
+        let (tx, rx) = tokio::sync::oneshot::channel();
+        self.waiters
+            .lock()
+            .expect("group commit waiters lock poisoned")
+            .push((lsn, tx));
+        rx
+    }
+
+    pub(crate) fn notify_committer(&self) {
+        self.notify.notify_one();
+    }
+
+    fn wake_committed(&self, watermark: u64) {
+        let mut waiters = self
+            .waiters
+            .lock()
+            .expect("group commit waiters lock poisoned");
+        let mut keep = Vec::new();
+        for (lsn, tx) in waiters.drain(..) {
+            if lsn <= watermark {
+                let _ = tx.send(Ok(()));
+            } else {
+                keep.push((lsn, tx));
+            }
+        }
+        *waiters = keep;
+    }
+
+    fn wake_all_err(&self, error: SharedCommitError) {
+        let mut waiters = self
+            .waiters
+            .lock()
+            .expect("group commit waiters lock poisoned");
+        for (_, tx) in waiters.drain(..) {
+            let _ = tx.send(Err(error.clone()));
+        }
+    }
+}
+
+/// The per-namespace committer task. Runs while the server lives; exits
+/// with the process. Never spawned when the window is zero.
+pub(crate) async fn group_committer_loop(state: AppState) {
+    let Some(group) = state.group_commit.clone() else {
+        return;
+    };
+    loop {
+        group.notify.notified().await;
+        // Coalesce: writes arriving inside the window join this group. The
+        // sleep happens OFF the writer lock, so stagers keep making
+        // progress while the group accumulates.
+        if !group.window.is_zero() {
+            tokio::time::sleep(group.window).await;
+        }
+        let mut writer = state.writer.lock().await;
+        if writer.pending_len() == 0 {
+            continue;
+        }
+        let Some(watermark) = writer.staged_last_lsn() else {
+            continue;
+        };
+        match writer.commit_batch().await {
+            Ok(_) => {
+                state.writer_health.clear_persistence_degraded();
+                // ACK ordering (RFC-021): republish BEFORE waking, so a
+                // waiter's next read sees its committed rows.
+                state.snapshot.store(writer.owned_snapshot());
+                state.memtable_bytes_gauge.store(
+                    writer.memtable_bytes(),
+                    std::sync::atomic::Ordering::Relaxed,
+                );
+                drop(writer);
+                group.wake_committed(watermark);
+            }
+            Err(e) => {
+                // Shared fate: the merged batch failed as a unit. Discard it
+                // (nothing is durable until the pointer CAS), recover a
+                // fenced/poisoned session in place, and hand every waiter
+                // the same error.
+                writer.discard_batch();
+                let error = namidb_query::exec::ExecError::Storage(e);
+                recovery::recover_after_write_error(
+                    &mut writer,
+                    &state.snapshot,
+                    &state.writer_health,
+                    &state.namespace,
+                    &error,
+                )
+                .await;
+                drop(writer);
+                group.wake_all_err(SharedCommitError(Arc::new(error)));
+            }
+        }
+    }
 }
 
 /// How long the periodic flush loop waits after a local-persistence flush
@@ -3090,33 +3279,85 @@ async fn run_cypher(state: &AppState, req: &CypherRequest, principal: &Principal
                 response: writer_busy_response(),
             };
         };
-        let result =
-            execute_write_with_deadline(&plan, &mut writer, &params, state.write_deadline()).await;
-        // Sample the soft write-stall decision while still holding the lock
-        // (RFC-027 P5), then release it and sleep — backpressure applies to
-        // this request, not to the writer mutex other connections need.
-        let stall = match &result {
-            Ok(_) => {
-                // Refresh the published snapshot so subsequent reads see the
-                // just-committed records (RFC-021).
-                state.snapshot.store(writer.owned_snapshot());
-                state.after_commit_backpressure(&writer)
+        let (result, stall) = if let Some(group) = state.group_commit.clone() {
+            // RFC-034 group commit: stage inside a request scope and let the
+            // namespace committer make the whole group durable with ONE
+            // commit. The waiter registers while still holding the lock so
+            // the committer cannot slip between staging and registration;
+            // the ACK arrives only after the merged commit is durable and
+            // the snapshot republished (RFC-021 preserved).
+            let mark = writer.begin_staged_request();
+            match execute_write_staged_with_deadline(
+                &plan,
+                &mut writer,
+                &params,
+                state.write_deadline(),
+            )
+            .await
+            {
+                Ok(outcome) => {
+                    writer.commit_staged_request();
+                    let lsn = writer.staged_last_lsn().unwrap_or(0);
+                    let ack = group.register(lsn);
+                    let stall = state.after_commit_backpressure(&writer);
+                    drop(writer);
+                    group.notify_committer();
+                    let result = match ack.await {
+                        Ok(Ok(())) => Ok(outcome),
+                        Ok(Err(shared)) => Err(WriteFailure::Shared(shared)),
+                        Err(_) => Err(WriteFailure::Own(namidb_query::exec::ExecError::Runtime(
+                            "group commit coordinator exited".into(),
+                        ))),
+                    };
+                    (result, stall)
+                }
+                Err(e) => {
+                    // Roll back ONLY this request; earlier group members'
+                    // staged rows survive for their commit.
+                    writer.rollback_staged_request(mark);
+                    recovery::recover_after_write_error(
+                        &mut writer,
+                        &state.snapshot,
+                        &state.writer_health,
+                        &state.namespace,
+                        &e,
+                    )
+                    .await;
+                    drop(writer);
+                    (Err(WriteFailure::Own(e)), None)
+                }
             }
-            Err(e) => {
-                // A fenced/poisoned session would fail every later write;
-                // reopen it in place under the lock we already hold.
-                recovery::recover_after_write_error(
-                    &mut writer,
-                    &state.snapshot,
-                    &state.writer_health,
-                    &state.namespace,
-                    e,
-                )
-                .await;
-                None
-            }
+        } else {
+            let result =
+                execute_write_with_deadline(&plan, &mut writer, &params, state.write_deadline())
+                    .await;
+            // Sample the soft write-stall decision while still holding the lock
+            // (RFC-027 P5), then release it and sleep — backpressure applies to
+            // this request, not to the writer mutex other connections need.
+            let stall = match &result {
+                Ok(_) => {
+                    // Refresh the published snapshot so subsequent reads see the
+                    // just-committed records (RFC-021).
+                    state.snapshot.store(writer.owned_snapshot());
+                    state.after_commit_backpressure(&writer)
+                }
+                Err(e) => {
+                    // A fenced/poisoned session would fail every later write;
+                    // reopen it in place under the lock we already hold.
+                    recovery::recover_after_write_error(
+                        &mut writer,
+                        &state.snapshot,
+                        &state.writer_health,
+                        &state.namespace,
+                        e,
+                    )
+                    .await;
+                    None
+                }
+            };
+            drop(writer);
+            (result.map_err(WriteFailure::Own), stall)
         };
-        drop(writer);
         // Stop the clock before the backpressure sleep: the stall is
         // intentional throttling, not query cost, so it must not inflate the
         // latency histogram or trip the slow-query log.
@@ -3140,11 +3381,11 @@ async fn run_cypher(state: &AppState, req: &CypherRequest, principal: &Principal
                     .into_response(),
                 }
             }
-            Err(e) => ObservedQuery {
+            Err(failure) => ObservedQuery {
                 kind: Some(QueryKind::Write),
                 ok: false,
                 elapsed,
-                response: exec_failure_response("write execution failed", &e),
+                response: exec_failure_response("write execution failed", failure.as_exec()),
             },
         }
     } else {
@@ -5594,6 +5835,104 @@ mod tests {
         assert_eq!(response.status(), StatusCode::OK);
 
         std::fs::remove_dir_all(&scratch).ok();
+    }
+
+    /// RFC-034 group commit: N concurrent writes coalesce into fewer
+    /// manifest commits (each `commit_batch` bumps the manifest version by
+    /// exactly one — counting versions counts commits, no store
+    /// instrumentation needed), every write ACKs only after durability, and
+    /// an immediately following read sees all of them (RFC-021 RYOW).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn grouped_writes_coalesce_commits_and_stay_readable() {
+        let (store, paths) = namidb_storage::parse_uri("memory://group-commit").unwrap();
+        let writer = WriterSession::open(store, paths).await.unwrap();
+        let state = AppState::new(writer, Some("tok".into()), "group-commit".into())
+            .with_group_commit(Duration::from_millis(5));
+        tokio::spawn(group_committer_loop(state.clone()));
+        let app = build_router(state.clone());
+
+        let v0 = state.snapshot.load().manifest().manifest.version;
+        let mut handles = Vec::new();
+        for i in 0..8 {
+            let app = app.clone();
+            handles.push(tokio::spawn(async move {
+                post_cypher(&app, Some("tok"), &format!("CREATE (:G {{i: {i}}})")).await
+            }));
+        }
+        for handle in handles {
+            let response = handle.await.unwrap();
+            assert_eq!(response.status(), StatusCode::OK);
+        }
+        // RYOW across the group: a read AFTER the last ACK sees every row.
+        let response = post_cypher(&app, Some("tok"), "MATCH (g:G) RETURN count(g) AS c").await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["rows"][0]["c"], 8, "{json}");
+        // Coalescing: strictly fewer commits than writes.
+        let v1 = state.snapshot.load().manifest().manifest.version;
+        assert!(v1 > v0);
+        assert!(
+            v1 - v0 < 8,
+            "8 writes must share commits under a 5 ms window, got {} commits",
+            v1 - v0
+        );
+    }
+
+    /// RFC-034 isolation (RFC-026): concurrent MERGEs on the same value in
+    /// one group must yield exactly one node — the second stager's read
+    /// sub-plan sees the first's staged rows through the overlay.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn grouped_concurrent_merges_yield_one_node() {
+        let (store, paths) = namidb_storage::parse_uri("memory://group-merge").unwrap();
+        let writer = WriterSession::open(store, paths).await.unwrap();
+        let state = AppState::new(writer, Some("tok".into()), "group-merge".into())
+            .with_group_commit(Duration::from_millis(5));
+        tokio::spawn(group_committer_loop(state.clone()));
+        let app = build_router(state);
+
+        let merge = |app: Router| async move {
+            post_cypher(&app, Some("tok"), "MERGE (u:U {email: 'x@x'})").await
+        };
+        let (a, b) = tokio::join!(merge(app.clone()), merge(app.clone()));
+        assert_eq!(a.status(), StatusCode::OK);
+        assert_eq!(b.status(), StatusCode::OK);
+        let response = post_cypher(&app, Some("tok"), "MATCH (u:U) RETURN count(u) AS c").await;
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["rows"][0]["c"], 1, "{json}");
+    }
+
+    /// A statement failure under group commit rolls back alone: the failed
+    /// request's rows vanish, concurrent successful writes commit.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn grouped_statement_failure_rolls_back_alone() {
+        let (store, paths) = namidb_storage::parse_uri("memory://group-fail").unwrap();
+        let writer = WriterSession::open(store, paths).await.unwrap();
+        let state = AppState::new(writer, Some("tok".into()), "group-fail".into())
+            .with_group_commit(Duration::from_millis(5));
+        tokio::spawn(group_committer_loop(state.clone()));
+        let app = build_router(state);
+
+        let good = post_cypher(&app, Some("tok"), "CREATE (:F {ok: 1})");
+        // Stages a node, then fails evaluating 1/0 — the whole statement
+        // must roll back without touching the concurrent good write.
+        let bad = post_cypher(
+            &app,
+            Some("tok"),
+            "CREATE (:F {ok: 0}) WITH 1/0 AS x RETURN x",
+        );
+        let (good, bad) = tokio::join!(good, bad);
+        assert_eq!(good.status(), StatusCode::OK);
+        assert_eq!(bad.status(), StatusCode::BAD_REQUEST);
+        let response = post_cypher(&app, Some("tok"), "MATCH (f:F) RETURN f.ok AS ok").await;
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(
+            json["rows"],
+            serde_json::json!([{ "ok": 1 }]),
+            "only the good write may be durable: {json}"
+        );
     }
 
     /// A read-only token may not trigger a backup (same gate as flush).

--- a/crates/namidb-server/src/main.rs
+++ b/crates/namidb-server/src/main.rs
@@ -48,6 +48,19 @@ struct Cli {
     #[arg(long, env = "NAMIDB_NO_AUTH", default_value_t = false, action)]
     no_auth: bool,
 
+    /// Group-commit coalescing window (RFC-034): concurrently arriving
+    /// writes share one WAL append + manifest CAS, lifting the interactive
+    /// write floor at the cost of up to this much extra latency per lone
+    /// write. `0s` (the default) keeps inline per-request commits.
+    /// Recommended starting point on real object storage: `2ms`-`5ms`.
+    #[arg(
+        long,
+        env = "NAMIDB_GROUP_COMMIT_WINDOW",
+        default_value = "0s",
+        value_parser = humantime::parse_duration,
+    )]
+    group_commit_window: Duration,
+
     /// Enable `POST /v0/admin/backup` and restrict its destinations: the
     /// request's `to` URI must equal this prefix or extend it at a `/` (or
     /// `?ns=` query) boundary, e.g. `s3://backups-bucket/namidb`. Unset =
@@ -350,6 +363,7 @@ fn main() -> anyhow::Result<()> {
         auth_token: cli.auth_token,
         auth_tokens_file: cli.auth_tokens_file,
         no_auth: cli.no_auth,
+        group_commit_window: cli.group_commit_window,
         backup_target_uri: cli.backup_target_uri,
         #[cfg(feature = "jwt")]
         jwt: cli

--- a/crates/namidb-server/tests/bolt_integration.rs
+++ b/crates/namidb-server/tests/bolt_integration.rs
@@ -148,6 +148,112 @@ async fn handshake(stream: &mut TcpStream) {
     assert_eq!(reply, [0, 0, 4, 5], "expected Bolt 5.4 negotiated");
 }
 
+/// Boot with RFC-034 group commit enabled (2 ms window) — exercises the
+/// committer task `run()` spawns plus the Bolt grouped auto-commit path.
+async fn boot_bolt_grouped(ns: &str) -> (std::net::SocketAddr, tokio::task::JoinHandle<()>) {
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let bolt_addr = listener.local_addr().unwrap();
+    drop(listener);
+    let http_listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let http_addr = http_listener.local_addr().unwrap();
+    drop(http_listener);
+    let config = namidb_server::Config {
+        store_uri: format!("memory://{ns}"),
+        listen: http_addr,
+        auth_token: Some("test-token".into()),
+        auth_tokens_file: None,
+        no_auth: false,
+        backup_target_uri: None,
+        group_commit_window: Duration::from_millis(2),
+        #[cfg(feature = "jwt")]
+        jwt: None,
+        #[cfg(feature = "pdp")]
+        pdp_url: None,
+        flush_interval: Duration::ZERO,
+        compaction_interval: Duration::ZERO,
+        sweep_min_age: Duration::ZERO,
+        sweep_delete: false,
+        bolt_listen: Some(bolt_addr),
+        bolt_max_message_bytes: DEFAULT_POST_AUTH_MESSAGE_BYTES,
+        bolt_tx_timeout: Duration::ZERO,
+        query_timeout: Duration::from_secs(30),
+        write_timeout: Duration::from_secs(30),
+        query_row_cap: 0,
+        compaction_l0_trigger: 0,
+        write_stall_l0: 0,
+        write_stall_delay: Duration::ZERO,
+        memtable_flush_bytes: 0,
+        memtable_stall_bytes: 0,
+        writer_lock_timeout: Duration::from_secs(5),
+        tls_cert: None,
+        tls_key: None,
+        slow_query_threshold: Duration::ZERO,
+        multi_tenant: false,
+        default_namespace: ns.to_string(),
+        max_namespaces: 100,
+        namespace_idle_timeout: Duration::from_secs(3600),
+    };
+    let task = tokio::spawn(async move {
+        if let Err(e) = namidb_server::run(config).await {
+            eprintln!("server exited: {e}");
+        }
+    });
+    for _ in 0..50 {
+        if TcpStream::connect(bolt_addr).await.is_ok() {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+    (bolt_addr, task)
+}
+
+/// RFC-034 over Bolt: grouped auto-commit writes ACK durable and are
+/// immediately readable on the same connection; a failing statement rolls
+/// back alone and later writes keep working.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn bolt_grouped_writes_ack_and_stay_readable() {
+    let (bolt_addr, task) = boot_bolt_grouped("bolt-grouped").await;
+    let mut stream = TcpStream::connect(bolt_addr).await.expect("connect bolt");
+    handshake(&mut stream).await;
+    hello_and_logon(&mut stream, "test-token").await;
+
+    for i in 0..5 {
+        pull_all(&mut stream, &format!("CREATE (:G {{i: {i}}})")).await;
+    }
+    let (_, rows) = pull_all(&mut stream, "MATCH (g:G) RETURN count(g) AS c").await;
+    assert_eq!(rows[0].get("c"), Some(&Value::Int(5)), "{rows:?}");
+
+    // A failing statement (staged rows + eval error) rolls back alone.
+    let run = Value::Struct {
+        tag: struct_tag::RUN,
+        fields: vec![
+            Value::String("CREATE (:G {i: 99}) WITH 1/0 AS x RETURN x".into()),
+            Value::Map(BTreeMap::new()),
+            Value::Map(BTreeMap::new()),
+        ],
+    };
+    send_msg(&mut stream, &pack(&run)).await;
+    assert!(
+        matches!(recv_msg(&mut stream).await, Response::Failure(_)),
+        "the failing statement must FAIL"
+    );
+    let reset = Value::Struct {
+        tag: struct_tag::RESET,
+        fields: vec![],
+    };
+    send_msg(&mut stream, &pack(&reset)).await;
+    assert!(matches!(recv_msg(&mut stream).await, Response::Success(_)));
+    let (_, rows) = pull_all(&mut stream, "MATCH (g:G) RETURN count(g) AS c").await;
+    assert_eq!(
+        rows[0].get("c"),
+        Some(&Value::Int(5)),
+        "the failed statement's row must not be durable: {rows:?}"
+    );
+
+    stream.shutdown().await.ok();
+    task.abort();
+}
+
 /// Boot a MULTI-TENANT server with a Bolt listener and a tokens file.
 async fn boot_bolt_multi(
     ns_prefix: &str,
@@ -168,6 +274,7 @@ async fn boot_bolt_multi(
         auth_tokens_file: Some(tokens_path),
         no_auth: false,
         backup_target_uri: None,
+        group_commit_window: Duration::ZERO,
         #[cfg(feature = "jwt")]
         jwt: None,
         #[cfg(feature = "pdp")]
@@ -531,6 +638,7 @@ async fn boot_bolt_config(
         auth_tokens_file: None,
         no_auth: false,
         backup_target_uri: None,
+        group_commit_window: Duration::ZERO,
         #[cfg(feature = "jwt")]
         jwt: None,
         #[cfg(feature = "pdp")]
@@ -596,6 +704,7 @@ async fn boot_bolt_tokens(
         auth_tokens_file: Some(tokens_path),
         no_auth: false,
         backup_target_uri: None,
+        group_commit_window: Duration::ZERO,
         #[cfg(feature = "jwt")]
         jwt: None,
         #[cfg(feature = "pdp")]
@@ -850,6 +959,7 @@ async fn bolt_create_then_match_roundtrip() {
         auth_tokens_file: None,
         no_auth: false,
         backup_target_uri: None,
+        group_commit_window: Duration::ZERO,
         #[cfg(feature = "jwt")]
         jwt: None,
         #[cfg(feature = "pdp")]
@@ -942,6 +1052,7 @@ async fn bolt_bad_token_yields_failure() {
         auth_tokens_file: None,
         no_auth: false,
         backup_target_uri: None,
+        group_commit_window: Duration::ZERO,
         #[cfg(feature = "jwt")]
         jwt: None,
         #[cfg(feature = "pdp")]
@@ -1112,6 +1223,7 @@ async fn bolt_memgraph_introspection_populates_schema() {
         auth_tokens_file: None,
         no_auth: false,
         backup_target_uri: None,
+        group_commit_window: Duration::ZERO,
         #[cfg(feature = "jwt")]
         jwt: None,
         #[cfg(feature = "pdp")]

--- a/crates/namidb-server/tests/ddl_index_backfill.rs
+++ b/crates/namidb-server/tests/ddl_index_backfill.rs
@@ -29,6 +29,7 @@ async fn boot(store_uri: String) -> String {
         auth_tokens_file: None,
         no_auth: false,
         backup_target_uri: None,
+        group_commit_window: Duration::ZERO,
         #[cfg(feature = "jwt")]
         jwt: None,
         #[cfg(feature = "pdp")]

--- a/crates/namidb-server/tests/disk_full_degraded.rs
+++ b/crates/namidb-server/tests/disk_full_degraded.rs
@@ -31,6 +31,7 @@ async fn boot() -> String {
         auth_tokens_file: None,
         no_auth: false,
         backup_target_uri: None,
+        group_commit_window: Duration::ZERO,
         #[cfg(feature = "jwt")]
         jwt: None,
         #[cfg(feature = "pdp")]

--- a/crates/namidb-server/tests/explain_surface.rs
+++ b/crates/namidb-server/tests/explain_surface.rs
@@ -22,6 +22,7 @@ async fn boot() -> String {
         auth_tokens_file: None,
         no_auth: false,
         backup_target_uri: None,
+        group_commit_window: Duration::ZERO,
         #[cfg(feature = "jwt")]
         jwt: None,
         #[cfg(feature = "pdp")]

--- a/crates/namidb-server/tests/scan_gate.rs
+++ b/crates/namidb-server/tests/scan_gate.rs
@@ -24,6 +24,7 @@ async fn boot() -> String {
         auth_tokens_file: None,
         no_auth: false,
         backup_target_uri: None,
+        group_commit_window: Duration::ZERO,
         #[cfg(feature = "jwt")]
         jwt: None,
         #[cfg(feature = "pdp")]

--- a/crates/namidb-server/tests/startup_validation.rs
+++ b/crates/namidb-server/tests/startup_validation.rs
@@ -14,6 +14,7 @@ fn base_config(ns: &str) -> namidb_server::Config {
         auth_tokens_file: None,
         no_auth: false,
         backup_target_uri: None,
+        group_commit_window: Duration::ZERO,
         #[cfg(feature = "jwt")]
         jwt: None,
         #[cfg(feature = "pdp")]

--- a/crates/namidb-server/tests/tls_integration.rs
+++ b/crates/namidb-server/tests/tls_integration.rs
@@ -64,6 +64,7 @@ async fn serves_https_and_bolt_over_tls() {
         auth_token: None,
         no_auth: true,
         backup_target_uri: None,
+        group_commit_window: Duration::ZERO,
         auth_tokens_file: None,
         #[cfg(feature = "jwt")]
         jwt: None,

--- a/crates/namidb-storage/src/ingest.rs
+++ b/crates/namidb-storage/src/ingest.rs
@@ -1155,6 +1155,50 @@ impl WriterSession {
         self.pending.records.len()
     }
 
+    /// Open a request scope over the staged batch (group commit, RFC-034):
+    /// capture the batch position and start the unique index's request
+    /// journal, so a FAILED statement can be rolled back alone
+    /// ([`Self::rollback_staged_request`]) while earlier requests' staged
+    /// rows survive for the group's single [`Self::commit_batch`].
+    pub fn begin_staged_request(&mut self) -> StageMark {
+        self.unique_index.begin_request();
+        StageMark {
+            records: self.pending.records.len(),
+            payloads: self.pending_payloads.len(),
+            node_mutations: self.pending_node_mutations,
+        }
+    }
+
+    /// Close the request scope keeping its rows in the batch. The unique
+    /// index's request journal merges into the batch journal preserving
+    /// first-touch pre-batch values, so a later full [`Self::discard_batch`]
+    /// still restores committed state.
+    pub fn commit_staged_request(&mut self) {
+        self.unique_index.merge_request();
+    }
+
+    /// Roll back everything staged since `mark`, leaving earlier requests'
+    /// staged rows intact. The RYOW overlay memtable is rebuilt by replaying
+    /// the surviving payloads — it is a pure fold over them — and the unique
+    /// index restores the touched tuples to their at-request-start values.
+    pub fn rollback_staged_request(&mut self, mark: StageMark) {
+        self.pending.records.truncate(mark.records);
+        self.pending_payloads.truncate(mark.payloads);
+        self.pending_node_mutations = mark.node_mutations;
+        let mut rebuilt = Memtable::new();
+        for (key, lsn, op) in &self.pending_payloads {
+            rebuilt.apply(key.clone(), *lsn, op.clone());
+        }
+        self.staged_memtable = rebuilt;
+        self.unique_index.rollback_request();
+    }
+
+    /// Highest staged (not yet durable) LSN — the group-commit waiter
+    /// watermark. `None` when nothing is staged.
+    pub fn staged_last_lsn(&self) -> Option<u64> {
+        self.pending.records.last().map(|r| r.lsn)
+    }
+
     /// Distinct keys in the incrementally maintained RYOW overlay.
     ///
     /// Normally equal to `pending_len`; lower when a transaction rewrites the
@@ -2842,6 +2886,16 @@ impl WriterSession {
         self.staged_memtable.apply(key, lsn, op);
         Ok(())
     }
+}
+
+/// Staged-batch position at a request boundary (group commit, RFC-034).
+/// Returned by [`WriterSession::begin_staged_request`] and consumed by
+/// [`WriterSession::rollback_staged_request`].
+#[derive(Debug, Clone, Copy)]
+pub struct StageMark {
+    records: usize,
+    payloads: usize,
+    node_mutations: bool,
 }
 
 /// Convenience: the WAL payload bytes a `WalEntry` produces. Useful

--- a/crates/namidb-storage/src/lib.rs
+++ b/crates/namidb-storage/src/lib.rs
@@ -70,7 +70,7 @@ pub use error::{Error, Result};
 pub use fence::{Epoch, WriterFence};
 pub use flush::{flush, EdgeWriteRecord, FlushOutcome, NodeWriteRecord};
 pub use ingest::{
-    clear_shared_caches, prune_shared_caches, CommitOutcome, SessionCaches, StagedValue,
+    clear_shared_caches, prune_shared_caches, CommitOutcome, SessionCaches, StageMark, StagedValue,
     WriterSession,
 };
 pub use janitor::{sweep_orphans, JanitorReport};

--- a/crates/namidb-storage/src/unique_index.rs
+++ b/crates/namidb-storage/src/unique_index.rs
@@ -247,6 +247,33 @@ struct ConstraintUndo {
 struct IndexState {
     maps: HashMap<ConstraintId, ConstraintMap>,
     undo: HashMap<ConstraintId, ConstraintUndo>,
+    /// Group-commit request scope (RFC-034): while `Some`, staged
+    /// maintenance journals first-touch state HERE instead of `undo`, so a
+    /// FAILED statement can be rolled back to its request boundary — the
+    /// journaled values are the at-request-start (possibly already-staged)
+    /// tuples, not the pre-batch ones. On request success the layer merges
+    /// into `undo` keeping the OLDEST first-touch entry per node, which
+    /// preserves the pre-batch restore of a full [`discard`] later.
+    request_undo: Option<HashMap<ConstraintId, ConstraintUndo>>,
+}
+
+impl IndexState {
+    /// Split borrow: the maps plus whichever journal staged maintenance
+    /// must write (the request layer when a scope is open, else the batch
+    /// journal).
+    fn maps_and_journal(
+        &mut self,
+    ) -> (
+        &mut HashMap<ConstraintId, ConstraintMap>,
+        &mut HashMap<ConstraintId, ConstraintUndo>,
+    ) {
+        let IndexState {
+            maps,
+            undo,
+            request_undo,
+        } = self;
+        (maps, request_undo.as_mut().unwrap_or(undo))
+    }
 }
 
 /// The per-writer index: `(label, sorted property names) → ConstraintMap`.
@@ -368,12 +395,16 @@ impl UniqueConstraintIndex {
         let mut state = self.state.lock().expect("unique index lock");
         state.maps.insert(identity.clone(), map);
         if staged {
-            let undo = state.undo.entry(identity).or_default();
+            let (_, journal) = state.maps_and_journal();
+            let undo = journal.entry(identity).or_default();
             undo.created_in_batch = true;
             undo.by_node.clear();
             undo.known_misses.clear();
         } else {
             state.undo.remove(&identity);
+            if let Some(request) = state.request_undo.as_mut() {
+                request.remove(&identity);
+            }
         }
     }
 
@@ -397,7 +428,11 @@ impl UniqueConstraintIndex {
             return;
         }
         debug_assert!(
-            !state.undo.contains_key(&identity),
+            !state.undo.contains_key(&identity)
+                && !state
+                    .request_undo
+                    .as_ref()
+                    .is_some_and(|request| request.contains_key(&identity)),
             "committed key seeding must happen before staged mutations"
         );
         let map = state.maps.entry(identity).or_default();
@@ -439,7 +474,7 @@ impl UniqueConstraintIndex {
         }
 
         let created_in_batch = !state.maps.contains_key(&identity);
-        let IndexState { maps, undo } = &mut *state;
+        let (maps, undo) = state.maps_and_journal();
         let map = maps.entry(identity.clone()).or_default();
         let rollback = undo.entry(identity).or_default();
         if created_in_batch {
@@ -492,7 +527,7 @@ impl UniqueConstraintIndex {
         props: &BTreeMap<String, Value>,
     ) {
         let mut state = self.state.lock().expect("unique index lock");
-        let IndexState { maps, undo } = &mut *state;
+        let (maps, undo) = state.maps_and_journal();
         for (identity @ (clabel, cnames), map) in maps.iter_mut() {
             let rollback = undo.entry(identity.clone()).or_default();
             if !rollback.created_in_batch {
@@ -533,7 +568,7 @@ impl UniqueConstraintIndex {
     /// Maintain every populated map for a staged node tombstone.
     pub(crate) fn apply_tombstone(&self, id: NodeId) {
         let mut state = self.state.lock().expect("unique index lock");
-        let IndexState { maps, undo } = &mut *state;
+        let (maps, undo) = state.maps_and_journal();
         for (identity, map) in maps.iter_mut() {
             let rollback = undo.entry(identity.clone()).or_default();
             if !rollback.created_in_batch {
@@ -557,7 +592,61 @@ impl UniqueConstraintIndex {
     /// Promote the current staged view to committed state. The populated maps
     /// already contain those mutations, so only the rollback journal changes.
     pub(crate) fn commit_staged(&self) {
-        self.state.lock().expect("unique index lock").undo = HashMap::new();
+        let mut state = self.state.lock().expect("unique index lock");
+        state.undo = HashMap::new();
+        // A dangling request scope is a caller bug, but its journal is
+        // obsolete either way once the batch is durable.
+        state.request_undo = None;
+    }
+
+    /// Open a group-commit request scope (RFC-034): staged maintenance
+    /// journals into a request-local layer whose entries capture the
+    /// AT-REQUEST-START values, so a failed statement rolls back alone.
+    pub(crate) fn begin_request(&self) {
+        let mut state = self.state.lock().expect("unique index lock");
+        debug_assert!(state.request_undo.is_none(), "request scope already open");
+        state.request_undo = Some(HashMap::new());
+    }
+
+    /// Close the request scope keeping its mutations: merge the request
+    /// journal into the batch journal, keeping the OLDEST first-touch entry
+    /// per node/key so a later full [`Self::rollback_staged`] still restores
+    /// the pre-BATCH state.
+    pub(crate) fn merge_request(&self) {
+        let mut state = self.state.lock().expect("unique index lock");
+        let Some(request) = state.request_undo.take() else {
+            return;
+        };
+        for (identity, from_request) in request {
+            match state.undo.entry(identity) {
+                std::collections::hash_map::Entry::Vacant(slot) => {
+                    slot.insert(from_request);
+                }
+                std::collections::hash_map::Entry::Occupied(mut slot) => {
+                    // The batch entry predates this request, so its
+                    // created_in_batch flag and existing first-touch values
+                    // win; only genuinely new touches merge in.
+                    let batch = slot.get_mut();
+                    for (id, old_key) in from_request.by_node {
+                        batch.by_node.entry(id).or_insert(old_key);
+                    }
+                    for (key, was_known_miss) in from_request.known_misses {
+                        batch.known_misses.entry(key).or_insert(was_known_miss);
+                    }
+                }
+            }
+        }
+    }
+
+    /// Roll back ONLY the open request scope's mutations, restoring every
+    /// touched map to its at-request-start (possibly staged-by-earlier-
+    /// requests) state. Earlier requests in the batch survive.
+    pub(crate) fn rollback_request(&self) {
+        let mut state = self.state.lock().expect("unique index lock");
+        let Some(request) = state.request_undo.take() else {
+            return;
+        };
+        Self::restore(&mut state, request);
     }
 
     /// Restore every populated map to its pre-batch committed state without a
@@ -565,7 +654,16 @@ impl UniqueConstraintIndex {
     /// touched in the discarded batch, not to the stored graph size.
     pub(crate) fn rollback_staged(&self) {
         let mut state = self.state.lock().expect("unique index lock");
+        // A dangling request scope rolls back first (its journal holds the
+        // newest deltas), then the batch journal restores to pre-batch.
+        if let Some(request) = state.request_undo.take() {
+            Self::restore(&mut state, request);
+        }
         let undo = std::mem::take(&mut state.undo);
+        Self::restore(&mut state, undo);
+    }
+
+    fn restore(state: &mut IndexState, undo: HashMap<ConstraintId, ConstraintUndo>) {
         for (identity, rollback) in undo {
             if rollback.created_in_batch {
                 state.maps.remove(&identity);

--- a/crates/namidb-storage/tests/group_commit_staging.rs
+++ b/crates/namidb-storage/tests/group_commit_staging.rs
@@ -1,0 +1,150 @@
+//! RFC-034 group commit, storage layer: request scopes over the staged
+//! batch. A FAILED statement must roll back ALONE — earlier requests'
+//! staged rows, their RYOW overlay entries, and their unique-index tuples
+//! all survive for the group's single commit — while a later full
+//! `discard_batch` still restores the pre-batch committed state.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use namidb_core::id::{NamespaceId, NodeId};
+use namidb_core::value::Value;
+use namidb_storage::{NamespacePaths, NodeWriteRecord, UniqueProbe, WriterSession};
+use object_store::memory::InMemory;
+use object_store::ObjectStore;
+
+fn store() -> Arc<dyn ObjectStore> {
+    Arc::new(InMemory::new())
+}
+
+fn paths(name: &str) -> NamespacePaths {
+    NamespacePaths::new("tenants", NamespaceId::new(name).unwrap())
+}
+
+fn person(email: &str) -> NodeWriteRecord {
+    let mut props: BTreeMap<String, Value> = BTreeMap::new();
+    props.insert("email".into(), Value::Str(email.into()));
+    NodeWriteRecord {
+        properties: props,
+        schema_version: 1,
+        ..Default::default()
+    }
+}
+
+#[tokio::test]
+async fn failed_request_rolls_back_alone() {
+    let mut w = WriterSession::open(store(), paths("gc-alone"))
+        .await
+        .unwrap();
+    let a = NodeId::new();
+    let b = NodeId::new();
+
+    // Request 1 stages A and closes successfully.
+    let _m1 = w.begin_staged_request();
+    w.upsert_node("Person", a, &person("a@x")).unwrap();
+    w.commit_staged_request();
+    assert_eq!(w.pending_len(), 1);
+
+    // Request 2 stages B and REWRITES A, then fails: both of its
+    // mutations must vanish, request 1's A must survive with its value.
+    let m2 = w.begin_staged_request();
+    w.upsert_node("Person", b, &person("b@x")).unwrap();
+    w.upsert_node("Person", a, &person("a@changed")).unwrap();
+    assert_eq!(w.pending_len(), 3);
+    w.rollback_staged_request(m2);
+
+    assert_eq!(w.pending_len(), 1, "only request 1's row remains staged");
+    assert_eq!(w.staged_memtable_len(), 1, "overlay rebuilt to request 1");
+
+    // The group's single commit makes exactly request 1 durable.
+    w.commit_batch().await.unwrap();
+    let snap = w.snapshot();
+    let node = snap
+        .lookup_node("Person", a)
+        .await
+        .unwrap()
+        .expect("request 1's node must be durable");
+    assert_eq!(
+        node.properties.get("email"),
+        Some(&Value::Str("a@x".into())),
+        "request 2's rewrite of A must not survive its rollback"
+    );
+    assert!(
+        snap.lookup_node("Person", b).await.unwrap().is_none(),
+        "request 2's new node must not be durable"
+    );
+}
+
+/// The subtle case the request-scoped undo layer exists for: request 2
+/// touches a tuple request 1 ALREADY MOVED. Rolling request 2 back must
+/// restore request 1's staged value — not the committed pre-batch value —
+/// and a later full discard must still restore the committed one.
+#[tokio::test]
+async fn unique_index_restores_at_request_start_values() {
+    let mut w = WriterSession::open(store(), paths("gc-unique"))
+        .await
+        .unwrap();
+    let a = NodeId::new();
+    w.upsert_node("Person", a, &person("x@x")).unwrap();
+    w.commit_batch().await.unwrap();
+
+    // Populate the constraint map from committed state.
+    let probe = w
+        .unique_probe("Person", &[("email", &Value::Str("x@x".into()))], None)
+        .await
+        .unwrap();
+    assert_eq!(probe, UniqueProbe::Conflict(a));
+
+    // Request 1: move A's email x -> y (staged), close successfully.
+    let _m1 = w.begin_staged_request();
+    w.upsert_node("Person", a, &person("y@y")).unwrap();
+    w.commit_staged_request();
+
+    // Request 2: move it again y -> z, then FAIL.
+    let m2 = w.begin_staged_request();
+    w.upsert_node("Person", a, &person("z@z")).unwrap();
+    let probe = w
+        .unique_probe("Person", &[("email", &Value::Str("z@z".into()))], None)
+        .await
+        .unwrap();
+    assert_eq!(
+        probe,
+        UniqueProbe::Conflict(a),
+        "request 2 sees its own move"
+    );
+    w.rollback_staged_request(m2);
+
+    // At-request-start restore: A holds request 1's staged `y`, NOT the
+    // committed `x` (a pre-batch restore here would silently undo request 1).
+    let probe = w
+        .unique_probe("Person", &[("email", &Value::Str("y@y".into()))], None)
+        .await
+        .unwrap();
+    assert_eq!(
+        probe,
+        UniqueProbe::Conflict(a),
+        "rollback of request 2 must keep request 1's staged tuple"
+    );
+    let probe = w
+        .unique_probe("Person", &[("email", &Value::Str("z@z".into()))], None)
+        .await
+        .unwrap();
+    assert_eq!(probe, UniqueProbe::NoConflict);
+
+    // Full batch discard: back to the committed pre-batch state.
+    w.discard_batch();
+    let probe = w
+        .unique_probe("Person", &[("email", &Value::Str("x@x".into()))], None)
+        .await
+        .unwrap();
+    assert_eq!(
+        probe,
+        UniqueProbe::Conflict(a),
+        "full discard must restore the committed tuple"
+    );
+    let probe = w
+        .unique_probe("Person", &[("email", &Value::Str("y@y".into()))], None)
+        .await
+        .unwrap();
+    assert_eq!(probe, UniqueProbe::NoConflict);
+}

--- a/docs/rfc/034-writer-concurrency.md
+++ b/docs/rfc/034-writer-concurrency.md
@@ -1,10 +1,16 @@
 # RFC 034: Writer concurrency — the single-writer-per-namespace mutex
 
-**Status:** draft
+**Status:** partially implemented (2.3.0)
 **Author(s):** Matías Fonseca <info@namidb.com>
 **Created:** 2026-06-26
-**Updated:** 2026-06-26
-**Implements:** writer-lock-wait/held instrumentation (proposed, behaviour-preserving); group/pipelined commit (proposed)
+**Updated:** 2026-08-28
+**Implements:** writer-lock-wait instrumentation (shipped earlier as
+`namidb_writer_lock_wait_seconds`); group commit (shipped 2.3.0:
+`--group-commit-window`, default `0s` = inline commits — storage request
+scopes `begin/commit/rollback_staged_request` + request-scoped unique-index
+undo layer, one committer task per namespace, waiter registration under the
+writer lock, ACK after republish; auto-commit paths only, single-tenant;
+multi-tenant registry wiring and pipelined commit remain proposed)
 **Back-refs:** RFC-001 §"Write path"/§"Epoch fencing", RFC-021, RFC-026, RFC-027, RFC-029
 
 ## Summary

--- a/docs/testing/25tb-readiness.md
+++ b/docs/testing/25tb-readiness.md
@@ -679,17 +679,36 @@ STRING and MAP` type error; list `+` gains real Cypher semantics (list+list conc
 list+element append, element+list prepend — previously `'a' + [1]` produced garbage
 text); toString(non-scalar) errors. Behavior change, release-noted.
 
-### 51. [ROADMAP — group commit, RFC-034] NDB-06: explicit transactions hold the writer lock through think-time.
+### 51. [PARTIALLY ADDRESSED — auto-commit group commit in 2.3.0; explicit-tx lock unchanged by design] NDB-06: explicit transactions hold the writer lock through think-time.
 
 Accurate by design today (single writer per namespace; BEGIN holds it to COMMIT,
-NAMIDB_BOLT_MAX_TX_LIFETIME caps it). The fix is group commit (RFC-034) — staged
-batches + one commit pipeline — which also addresses item 52. Weeks, not this cycle.
+NAMIDB_BOLT_MAX_TX_LIFETIME caps it). RFC-034's own resolution for explicit
+transactions stands: they remain a serialized, think-time-bounded path on purpose —
+group commit targets the auto-commit paths (shipped in 2.3.0, see item 52). The
+per-tenant mitigation stays "keep transactions short / make the graph rebuildable",
+which the field team had already adopted.
 
-### 52. [ROADMAP — same RFC-034 work] NDB-07: serialized commit floor ~309 nodes/s at batch 1.
+### 52. [DONE — group commit lands in 2.3.0, opt-in window] NDB-07: serialized commit floor ~309 nodes/s at batch 1.
 
 Accurate: ~3 ms/commit = two object-store round trips, so throughput scales only with
 batch size (their own table shows 63.9k nodes/s at batch 5000). Not a defect of the
 ingest path (which batches by design); interactive single-row writes need group commit.
+
+**2.3.0 addendum — group commit shipped (RFC-034 "many stagers, one committer").**
+Storage grew request scopes over the staged batch (begin/commit/rollback_staged_request:
+mark-based truncation, RYOW-overlay rebuild by replay, and a request-scoped unique-index
+undo layer whose merge preserves first-touch pre-batch values — the subtle
+A-moves-tuple-then-B-touches-it case is regression-tested). The server runs one
+committer per namespace: requests stage under the writer lock, register a waiter keyed
+by their last staged LSN while still holding the lock (no stage/commit race), and ACK
+only after the merged commit is durable and the snapshot republished. Wired into the
+single-tenant HTTP and Bolt auto-commit paths; multi-tenant + a per-namespace committer
+in the registry is the sized follow-up. Default window 0s = inline commits, bit-for-bit
+today's behaviour — the knob is the rollout kill-switch RFC-034 asked for. Tests follow
+the RFC's plan: commit coalescing proven by manifest-version counting, concurrent-MERGE
+isolation, solo rollback of a failed statement, Bolt-path ACK+RYOW. Fault-injected CAS
+failure (shared fate) remains a test-harness follow-up; the error path reuses the
+inline path's discard+recover machinery.
 
 ### 53. [DONE — lands in 2.2.0] NDB-08: Docker image crash-loops on a named volume at /var/lib/namidb.
 


### PR DESCRIPTION
Closes the last open pair from the second field report (NDB-06/07, plan items 51/52).

**Storage**: request scopes over the staged batch — `begin/commit/rollback_staged_request`. A failed statement truncates WAL records/payloads to its mark, rebuilds the RYOW overlay by replay, and rolls back a request-scoped unique-index undo layer journaling **at-request-start** values; merging that layer keeps the oldest first-touch entry so a later full `discard_batch` still restores pre-batch state. The subtle A-moves-tuple-then-B-fails case is regression-tested.

**Server**: one committer task per namespace. Stagers register waiters keyed by last staged LSN **while holding the writer lock** (no stage/commit race) and ACK only after the merged commit is durable and the snapshot republished (RFC-021/026 preserved). Shared fate on commit failure (discard + in-place recovery + same error to every waiter). Wired into single-tenant HTTP and Bolt auto-commit — whose error/cancel `discard_batch` calls become request rollbacks under grouping.

**Default `0s` = inline commits, bit-for-bit today's behavior** — the rollout kill-switch RFC-034 specifies. Recommended `2ms`–`5ms` on real object storage. Multi-tenant committer wiring and fault-injected CAS shared-fate tests are sized follow-ups in the plan doc.

Tests per the RFC plan: coalescing via manifest-version counting (8 concurrent writes → <8 commits), concurrent MERGE isolation (1 node), solo rollback next to a successful concurrent write, Bolt ACK+RYOW through `run()`'s real committer. Full `namidb-storage`+`namidb-query`+`namidb-server` suites and clippy gate green.