### PR TITLE
fix: resolve indeterminate pointer-CAS outcomes; shared-fate fault-injection test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,21 @@ crates.io release will establish and document that API explicitly.
 
 ## [Unreleased]
 
+**Fixed**
+- A manifest pointer-CAS transport failure could falsify a negative ACK:
+  the client was told the write failed, but the dangling WAL segment +
+  manifest body were later (correctly, by crash semantics) published by
+  the stalled-commit repair — silently resurrecting rows the caller
+  believed rejected. The writer now RESOLVES the indeterminate outcome
+  before reporting: if the pointer landed (proven by version + fence
+  writer id + the segment's content hash) the commit is adopted and
+  ACKed as success; if definitively absent, the orphan body and WAL
+  segment are deleted first so the negative ACK stays true forever; only
+  when the store keeps failing does the session poison, with an error
+  message that explicitly says the write may become durable after
+  recovery. Found by the new RFC-034 shared-fate fault-injection test;
+  the hazard predates group commit (the inline commit path had it too).
+
 ## [2.3.0] - 2026-08-28
 
 **Added**

--- a/crates/namidb-server/src/lib.rs
+++ b/crates/namidb-server/src/lib.rs
@@ -5935,6 +5935,183 @@ mod tests {
         );
     }
 
+    /// RFC-034 shared fate: when the group's pointer CAS fails, every
+    /// waiter receives the SAME error, none of the group's rows are
+    /// durable, and the writer keeps serving once the store heals.
+    #[derive(Debug)]
+    struct FailingCasStore {
+        inner: Arc<dyn object_store::ObjectStore>,
+        fail_cas: std::sync::atomic::AtomicBool,
+    }
+
+    impl std::fmt::Display for FailingCasStore {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "FailingCasStore({})", self.inner)
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl object_store::ObjectStore for FailingCasStore {
+        async fn put_opts(
+            &self,
+            location: &object_store::path::Path,
+            payload: object_store::PutPayload,
+            opts: object_store::PutOptions,
+        ) -> object_store::Result<object_store::PutResult> {
+            if self.fail_cas.load(std::sync::atomic::Ordering::SeqCst)
+                && location.as_ref().contains("pointer/")
+            {
+                return Err(object_store::Error::Generic {
+                    store: "FailingCasStore",
+                    source: "injected pointer CAS failure".into(),
+                });
+            }
+            self.inner.put_opts(location, payload, opts).await
+        }
+
+        async fn put_multipart_opts(
+            &self,
+            location: &object_store::path::Path,
+            opts: object_store::PutMultipartOptions,
+        ) -> object_store::Result<Box<dyn object_store::MultipartUpload>> {
+            self.inner.put_multipart_opts(location, opts).await
+        }
+
+        async fn get_opts(
+            &self,
+            location: &object_store::path::Path,
+            options: object_store::GetOptions,
+        ) -> object_store::Result<object_store::GetResult> {
+            self.inner.get_opts(location, options).await
+        }
+
+        fn list(
+            &self,
+            prefix: Option<&object_store::path::Path>,
+        ) -> futures::stream::BoxStream<'static, object_store::Result<object_store::ObjectMeta>>
+        {
+            self.inner.list(prefix)
+        }
+
+        async fn list_with_delimiter(
+            &self,
+            prefix: Option<&object_store::path::Path>,
+        ) -> object_store::Result<object_store::ListResult> {
+            self.inner.list_with_delimiter(prefix).await
+        }
+
+        async fn copy_opts(
+            &self,
+            from: &object_store::path::Path,
+            to: &object_store::path::Path,
+            options: object_store::CopyOptions,
+        ) -> object_store::Result<()> {
+            self.inner.copy_opts(from, to, options).await
+        }
+
+        fn delete_stream(
+            &self,
+            locations: futures::stream::BoxStream<
+                'static,
+                object_store::Result<object_store::path::Path>,
+            >,
+        ) -> futures::stream::BoxStream<'static, object_store::Result<object_store::path::Path>>
+        {
+            self.inner.delete_stream(locations)
+        }
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn grouped_cas_failure_shares_fate_and_recovers() {
+        let failing = Arc::new(FailingCasStore {
+            inner: Arc::new(object_store::memory::InMemory::new()),
+            fail_cas: std::sync::atomic::AtomicBool::new(false),
+        });
+        let paths = namidb_storage::NamespacePaths::new(
+            "tenants",
+            namidb_core::id::NamespaceId::new("group-cas").unwrap(),
+        );
+        let writer =
+            WriterSession::open(failing.clone() as Arc<dyn object_store::ObjectStore>, paths)
+                .await
+                .unwrap();
+        let state = AppState::new(writer, Some("tok".into()), "group-cas".into())
+            .with_group_commit(Duration::from_millis(5));
+        tokio::spawn(group_committer_loop(state.clone()));
+        let app = build_router(state);
+
+        // Sanity: a grouped write commits while the store is healthy.
+        let ok = post_cypher(&app, Some("tok"), "CREATE (:S {phase: 'before'})").await;
+        let status = ok.status();
+        if status != StatusCode::OK {
+            panic!("sanity write failed: {status} {:?}", body_json(ok).await);
+        }
+
+        // Fail the pointer CAS: the whole group must fail together.
+        failing
+            .fail_cas
+            .store(true, std::sync::atomic::Ordering::SeqCst);
+        let w1 = post_cypher(&app, Some("tok"), "CREATE (:S {phase: 'doomed1'})");
+        let w2 = post_cypher(&app, Some("tok"), "CREATE (:S {phase: 'doomed2'})");
+        let (r1, r2) = tokio::join!(w1, w2);
+        assert!(!r1.status().is_success(), "shared fate: {:?}", r1.status());
+        assert!(!r2.status().is_success(), "shared fate: {:?}", r2.status());
+        let b1 = body_json(r1).await;
+        let b2 = body_json(r2).await;
+        assert_eq!(b1, b2, "every waiter must receive the SAME group error");
+        assert!(
+            b1["error"]
+                .as_str()
+                .unwrap()
+                .contains("injected pointer CAS failure"),
+            "{b1}"
+        );
+
+        // Nothing from the failed group is durable or visible.
+        let read = post_cypher(
+            &app,
+            Some("tok"),
+            "MATCH (s:S) RETURN s.phase AS phase ORDER BY phase",
+        )
+        .await;
+        let json = body_json(read).await;
+        assert_eq!(
+            json["rows"],
+            serde_json::json!([{ "phase": "before" }]),
+            "{json}"
+        );
+
+        // Heal the store: the namespace must SELF-heal — no restart. The
+        // committer's recovery (reopen attempts, degraded health) may still
+        // be settling right after the heal, so assert convergence within a
+        // bounded window rather than first-write success.
+        failing
+            .fail_cas
+            .store(false, std::sync::atomic::Ordering::SeqCst);
+        let mut healed = false;
+        for _ in 0..50 {
+            let ok = post_cypher(&app, Some("tok"), "CREATE (:S {phase: 'after'})").await;
+            if ok.status() == StatusCode::OK {
+                healed = true;
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(100)).await;
+        }
+        assert!(healed, "writes must recover after the store heals");
+        let read = post_cypher(
+            &app,
+            Some("tok"),
+            "MATCH (s:S) RETURN s.phase AS phase ORDER BY phase",
+        )
+        .await;
+        let json = body_json(read).await;
+        assert_eq!(
+            json["rows"],
+            serde_json::json!([{ "phase": "after" }, { "phase": "before" }]),
+            "the doomed group must stay gone after recovery: {json}"
+        );
+    }
+
     /// A read-only token may not trigger a backup (same gate as flush).
     #[tokio::test]
     async fn admin_backup_forbids_read_only_tokens() {

--- a/crates/namidb-storage/src/ingest.rs
+++ b/crates/namidb-storage/src/ingest.rs
@@ -1782,10 +1782,23 @@ impl WriterSession {
         let (committed_seq, new_current) = match wal_result {
             Ok(_) => {
                 let pointer = body_result?;
-                let new_current = self
+                let probe = PointerCasProbe::for_manifest(&next);
+                let new_current = match self
                     .manifest_store
                     .cas_pointer(&self.fence, &self.current, next, pointer)
-                    .await?;
+                    .await
+                {
+                    Ok(current) => current,
+                    // Determinate outcomes (a competitor took the version /
+                    // we are fenced) keep today's semantics.
+                    Err(err @ (Error::Fenced { .. } | Error::ManifestCommitCas { .. })) => {
+                        return Err(err)
+                    }
+                    Err(cas_err) => {
+                        self.resolve_failed_pointer_cas(probe, base_seq, cas_err)
+                            .await?
+                    }
+                };
                 (base_seq, new_current)
             }
             Err(Error::Precondition(_)) => {
@@ -1915,15 +1928,115 @@ impl WriterSession {
     /// case fails fast as `ManifestCommitCas` before we ever PUT a WAL
     /// segment, so a doomed retry mints no new orphan WAL at `fresh`.
     /// `self.pending.seq` must already point at the fresh seq.
-    async fn commit_body_first(&self, next: Manifest) -> Result<LoadedManifest> {
+    async fn commit_body_first(&mut self, next: Manifest) -> Result<LoadedManifest> {
         let pointer = self
             .manifest_store
             .put_body(&self.fence, &self.current, &next)
             .await?;
         self.wal_store.append_segment(&self.pending).await?;
-        self.manifest_store
+        let probe = PointerCasProbe::for_manifest(&next);
+        let seq = self.pending.seq;
+        match self
+            .manifest_store
             .cas_pointer(&self.fence, &self.current, next, pointer)
             .await
+        {
+            Ok(current) => Ok(current),
+            Err(err @ (Error::Fenced { .. } | Error::ManifestCommitCas { .. })) => Err(err),
+            Err(cas_err) => self.resolve_failed_pointer_cas(probe, seq, cas_err).await,
+        }
+    }
+
+    /// A pointer-CAS transport failure is INDETERMINATE: the create may have
+    /// landed with only the response lost. Resolve before reporting — a
+    /// blind failure report can be falsified later by
+    /// `repair_stalled_commit`, which (correctly, by crash semantics)
+    /// publishes a dangling body+WAL as an interrupted commit: the client
+    /// would hold a negative ACK for rows that then become durable. Found
+    /// by the RFC-034 shared-fate fault-injection test; the hazard predates
+    /// group commit (the inline path had it too).
+    ///
+    /// Outcomes:
+    /// - **Landed** (the durable manifest is provably THIS commit's —
+    ///   version + fence writer id + the pending segment's content hash):
+    ///   adopt it and return success; the caller drains and ACKs.
+    /// - **Definitively absent**: delete the orphan body and WAL segment so
+    ///   nothing dangles for the repair to adopt, then return the original
+    ///   error — the negative ACK stays true forever.
+    /// - **Unresolvable** (the store keeps failing): poison the session and
+    ///   return an explicitly indeterminate error whose message says the
+    ///   write may still become durable via repair after reopen.
+    async fn resolve_failed_pointer_cas(
+        &mut self,
+        probe: PointerCasProbe,
+        wal_seq: u64,
+        cas_err: Error,
+    ) -> Result<LoadedManifest> {
+        let reloaded = match self.manifest_store.load_current().await {
+            Ok(m) => m,
+            Err(read_err) => {
+                self.poisoned = true;
+                return Err(Error::precondition(format!(
+                    "commit outcome indeterminate: the manifest pointer CAS failed \
+                     ({cas_err}) and the pointer could not be re-read ({read_err}); \
+                     the session is poisoned and the write MAY become durable when \
+                     the interrupted commit is repaired on reopen"
+                )));
+            }
+        };
+        if reloaded.manifest.epoch > self.fence.epoch {
+            self.poisoned = true;
+            return Err(Error::Fenced {
+                mine: self.fence.epoch.as_u64(),
+                current: reloaded.manifest.epoch.as_u64(),
+            });
+        }
+        let ours = reloaded.manifest.version == probe.version
+            && reloaded.manifest.writer_id == self.fence.writer_id
+            && probe.wal_xxh3.is_some()
+            && reloaded
+                .manifest
+                .wal_segments
+                .iter()
+                .any(|segment| segment.seq == wal_seq && segment.xxh3 == probe.wal_xxh3);
+        if ours {
+            // The create LANDED; only the response was lost. This commit
+            // SUCCEEDED — adopt the durable state so the caller drains and
+            // ACKs truthfully.
+            tracing::warn!(
+                version = probe.version,
+                "pointer CAS response lost but the commit landed; adopting it"
+            );
+            return Ok(reloaded);
+        }
+        if reloaded.manifest.version >= probe.version {
+            return Err(Error::ManifestCommitCas {
+                expected: probe.version.saturating_sub(1),
+                found: reloaded.manifest.version,
+            });
+        }
+        // Definitively absent. Neutralize the orphans (body first: deleting
+        // it kills the repair's "body exists, pointer does not" signature
+        // immediately; a WAL-only orphan is inert and janitor-swept).
+        let body_path = self.manifest_store.paths().manifest_version(probe.version);
+        let wal_path = self.wal_store.paths().wal_segment(wal_seq);
+        for path in [&body_path, &wal_path] {
+            use object_store::ObjectStoreExt as _;
+            match self.manifest_store.store().delete(path).await {
+                Ok(()) => {}
+                Err(object_store::Error::NotFound { .. }) => {}
+                Err(delete_err) => {
+                    self.poisoned = true;
+                    return Err(Error::precondition(format!(
+                        "commit failed ({cas_err}) and orphan cleanup at {path} \
+                         failed too ({delete_err}); the session is poisoned and \
+                         the write MAY become durable when the interrupted \
+                         commit is repaired on reopen"
+                    )));
+                }
+            }
+        }
+        Err(cas_err)
     }
 
     /// Persist the current memtable to `paths.memtable_snapshot()` so
@@ -2885,6 +2998,23 @@ impl WriterSession {
         // operation while the WAL/pending_payloads keep the full history.
         self.staged_memtable.apply(key, lsn, op);
         Ok(())
+    }
+}
+
+/// What [`WriterSession::resolve_failed_pointer_cas`] needs to prove a
+/// durable manifest is THIS commit's: the target version plus the pending
+/// WAL segment's content hash (stamped by `build_next`).
+struct PointerCasProbe {
+    version: u64,
+    wal_xxh3: Option<u64>,
+}
+
+impl PointerCasProbe {
+    fn for_manifest(next: &Manifest) -> Self {
+        Self {
+            version: next.version,
+            wal_xxh3: next.wal_segments.last().and_then(|segment| segment.xxh3),
+        }
     }
 }
 

--- a/docs/testing/25tb-readiness.md
+++ b/docs/testing/25tb-readiness.md
@@ -710,6 +710,15 @@ isolation, solo rollback of a failed statement, Bolt-path ACK+RYOW. Fault-inject
 failure (shared fate) remains a test-harness follow-up; the error path reuses the
 inline path's discard+recover machinery.
 
+**Follow-up addendum — shared-fate test built, and it found a PRE-EXISTING
+durability bug.** Injecting a pointer-CAS transport failure showed NACKed rows
+RESURRECTING: the orphan WAL+body dangled, and repair_stalled_commit (correct for
+crashes) later published them. Fixed in storage: resolve_failed_pointer_cas —
+adopt-if-landed (version + fence writer_id + segment xxh3 ownership proof),
+delete-orphans-if-definitively-absent (the NACK stays true), poison-with-honest-
+indeterminate-message only when the store keeps failing. The inline commit path
+had the same hazard since forever; the group-commit test is what surfaced it.
+
 ### 53. [DONE — lands in 2.2.0] NDB-08: Docker image crash-loops on a named volume at /var/lib/namidb.
 
 Confirmed, with a nuance: /var/lib/namidb is not a coded default (--store is required)


### PR DESCRIPTION
The RFC-034 shared-fate test (inject a pointer-CAS transport failure into a grouped commit) found a **pre-existing durability bug**: NACKed writes resurrecting. The failed commit's WAL segment + manifest body dangled, and `repair_stalled_commit` — correct for crash semantics — later published them as an interrupted commit. The inline path has had this hazard forever; group commit made it testable.

`commit_batch` now resolves non-determinate pointer-CAS errors before reporting (`resolve_failed_pointer_cas`):
- **Landed** (ownership proven by version + fence `writer_id` + the segment's `xxh3`): adopt and ACK success — the response was lost, not the commit.
- **Definitively absent**: delete the orphan body (killing the repair's body-without-pointer signature) then the WAL segment, and only then return the error — the negative ACK stays true forever.
- **Unresolvable**: poison + an explicitly indeterminate message ("may become durable when the interrupted commit is repaired on reopen") — the only honest answer left.

Determinate outcomes (`Fenced`, `ManifestCommitCas`) unchanged; `commit_body_first` routes through the same resolver.

Test: `FailingCasStore` (delegating wrapper, injectable pointer-path PUT failure) drives healthy write → injected failure with two concurrent writes receiving the SAME error body → nothing visible from the doomed group → bounded-convergence self-heal with the doomed rows STAYING gone (the exact assertion that failed pre-fix). Full storage+query+server suites and clippy green.