### PR TITLE
feat: group commit for multi-tenant namespaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,12 @@ crates.io release will establish and document that API explicitly.
 
 ## [Unreleased]
 
+**Added**
+- Group commit now covers multi-tenant namespaces: the registry spawns
+  one committer per namespace (cancelled on eviction, stragglers failed
+  rather than hung), `--group-commit-window` applies to the multi-tenant
+  HTTP and Bolt write paths, and grouping stays per-namespace.
+
 **Fixed**
 - A manifest pointer-CAS transport failure could falsify a negative ACK:
   the client was told the write failed, but the dangling WAL segment +

--- a/crates/namidb-server/src/lib.rs
+++ b/crates/namidb-server/src/lib.rs
@@ -400,6 +400,28 @@ impl AppState {
         self
     }
 
+    /// Spawn this state's [`group_committer_loop`] (no-op when group commit
+    /// is disabled). The cancel sender lives inside the task, so the loop
+    /// runs until process exit — single-tenant lifetime.
+    pub(crate) fn spawn_group_committer(&self) {
+        let Some(group) = self.group_commit.clone() else {
+            return;
+        };
+        let handles = CommitterHandles {
+            writer: self.writer.clone(),
+            snapshot: self.snapshot.clone(),
+            writer_health: self.writer_health.clone(),
+            namespace: self.namespace.clone(),
+            group,
+            memtable_bytes_gauge: Some(self.memtable_bytes_gauge.clone()),
+        };
+        let (cancel_tx, cancel_rx) = tokio::sync::watch::channel(false);
+        tokio::spawn(async move {
+            let _keep_alive = cancel_tx;
+            group_committer_loop(handles, cancel_rx).await;
+        });
+    }
+
     /// Assemble a single-namespace view over a multi-tenant namespace: the
     /// per-namespace handles come from the registry's
     /// [`crate::registry::NamespaceState`], the process-wide config from
@@ -433,10 +455,10 @@ impl AppState {
             metrics: shared.metrics.clone(),
             authz: shared.authz.clone(),
             writer_health: ns.writer_health.clone(),
-            // Group commit needs a per-namespace committer task; wiring that
-            // through the registry is a follow-up, so multi-tenant views
-            // stay on inline commits.
-            group_commit: None,
+            // The registry owns the per-namespace coordinator (and its
+            // committer task, cancelled on eviction); views share it so the
+            // Bolt multi-tenant path groups too.
+            group_commit: ns.group_commit.clone(),
             backup: None,
         }
     }
@@ -971,6 +993,7 @@ pub async fn run_with_memory_max_bytes(
             sweep_min_age: config.sweep_min_age,
             sweep_delete: config.sweep_delete,
             compaction_l0_trigger: config.compaction_l0_trigger,
+            group_commit_window: config.group_commit_window,
         };
         let registry = NamespaceRegistry::new(
             store,
@@ -1074,8 +1097,7 @@ pub async fn run_with_memory_max_bytes(
             window_ms = config.group_commit_window.as_millis() as u64,
             "group commit enabled"
         );
-        let committer_state = state.clone();
-        tokio::spawn(group_committer_loop(committer_state));
+        state.spawn_group_committer();
     }
     let state = match backup_handles {
         Some((backup_store, backup_paths, prefix)) => {
@@ -1900,7 +1922,7 @@ impl WriteFailure {
 }
 
 impl GroupCommit {
-    fn new(window: Duration) -> Self {
+    pub(crate) fn new(window: Duration) -> Self {
         Self {
             window,
             notify: tokio::sync::Notify::new(),
@@ -1953,21 +1975,42 @@ impl GroupCommit {
     }
 }
 
-/// The per-namespace committer task. Runs while the server lives; exits
-/// with the process. Never spawned when the window is zero.
-pub(crate) async fn group_committer_loop(state: AppState) {
-    let Some(group) = state.group_commit.clone() else {
-        return;
-    };
+/// Everything the committer needs, decoupled from [`AppState`] so the
+/// multi-tenant registry can run one per [`crate::registry::NamespaceState`].
+pub(crate) struct CommitterHandles {
+    pub(crate) writer: Arc<Mutex<WriterSession>>,
+    pub(crate) snapshot: Arc<SnapshotCell>,
+    pub(crate) writer_health: Arc<WriterHealth>,
+    pub(crate) namespace: String,
+    pub(crate) group: Arc<GroupCommit>,
+    /// Single-tenant only; the multi-tenant health path reads the writer.
+    pub(crate) memtable_bytes_gauge: Option<Arc<std::sync::atomic::AtomicUsize>>,
+}
+
+/// The per-namespace committer task. Exits when `cancel` fires (namespace
+/// eviction) or its sender drops (process shutdown); any still-registered
+/// waiters are failed rather than left hanging.
+pub(crate) async fn group_committer_loop(
+    handles: CommitterHandles,
+    mut cancel: tokio::sync::watch::Receiver<bool>,
+) {
     loop {
-        group.notify.notified().await;
+        tokio::select! {
+            _ = handles.group.notify.notified() => {}
+            changed = cancel.changed() => {
+                if changed.is_err() || *cancel.borrow() {
+                    break;
+                }
+                continue;
+            }
+        }
         // Coalesce: writes arriving inside the window join this group. The
         // sleep happens OFF the writer lock, so stagers keep making
         // progress while the group accumulates.
-        if !group.window.is_zero() {
-            tokio::time::sleep(group.window).await;
+        if !handles.group.window.is_zero() {
+            tokio::time::sleep(handles.group.window).await;
         }
-        let mut writer = state.writer.lock().await;
+        let mut writer = handles.writer.lock().await;
         if writer.pending_len() == 0 {
             continue;
         }
@@ -1976,16 +2019,18 @@ pub(crate) async fn group_committer_loop(state: AppState) {
         };
         match writer.commit_batch().await {
             Ok(_) => {
-                state.writer_health.clear_persistence_degraded();
+                handles.writer_health.clear_persistence_degraded();
                 // ACK ordering (RFC-021): republish BEFORE waking, so a
                 // waiter's next read sees its committed rows.
-                state.snapshot.store(writer.owned_snapshot());
-                state.memtable_bytes_gauge.store(
-                    writer.memtable_bytes(),
-                    std::sync::atomic::Ordering::Relaxed,
-                );
+                handles.snapshot.store(writer.owned_snapshot());
+                if let Some(gauge) = &handles.memtable_bytes_gauge {
+                    gauge.store(
+                        writer.memtable_bytes(),
+                        std::sync::atomic::Ordering::Relaxed,
+                    );
+                }
                 drop(writer);
-                group.wake_committed(watermark);
+                handles.group.wake_committed(watermark);
             }
             Err(e) => {
                 // Shared fate: the merged batch failed as a unit. Discard it
@@ -1996,17 +2041,25 @@ pub(crate) async fn group_committer_loop(state: AppState) {
                 let error = namidb_query::exec::ExecError::Storage(e);
                 recovery::recover_after_write_error(
                     &mut writer,
-                    &state.snapshot,
-                    &state.writer_health,
-                    &state.namespace,
+                    &handles.snapshot,
+                    &handles.writer_health,
+                    &handles.namespace,
                     &error,
                 )
                 .await;
                 drop(writer);
-                group.wake_all_err(SharedCommitError(Arc::new(error)));
+                handles
+                    .group
+                    .wake_all_err(SharedCommitError(Arc::new(error)));
             }
         }
     }
+    // Eviction/shutdown: fail any straggler instead of hanging it.
+    handles.group.wake_all_err(SharedCommitError(Arc::new(
+        namidb_query::exec::ExecError::Runtime(
+            "group commit coordinator stopped (namespace evicted or shutting down)".into(),
+        ),
+    )));
 }
 
 /// How long the periodic flush loop waits after a local-persistence flush
@@ -4076,36 +4129,93 @@ async fn run_cypher_multi(
             drop(writer);
             return namespace_retired_observation(started);
         }
-        let result =
-            execute_write_with_deadline(&plan, &mut writer, &params, shared.write_deadline()).await;
-        let stall = match &result {
-            Ok(_) => {
-                ns_state.snapshot.store(writer.owned_snapshot());
-                let bytes = writer.memtable_bytes();
-                if shared.memtable_flush_bytes > 0 && bytes >= shared.memtable_flush_bytes {
-                    ns_state.flush_notify.notify_one();
+        let (result, stall) = if let Some(group) = ns_state.group_commit.clone() {
+            // RFC-034 grouped write, multi-tenant flavour: stage inside a
+            // request scope, register under the lock, and let this
+            // namespace's committer (spawned by the registry, cancelled on
+            // eviction) make the group durable with one commit.
+            let mark = writer.begin_staged_request();
+            match execute_write_staged_with_deadline(
+                &plan,
+                &mut writer,
+                &params,
+                shared.write_deadline(),
+            )
+            .await
+            {
+                Ok(outcome) => {
+                    writer.commit_staged_request();
+                    let lsn = writer.staged_last_lsn().unwrap_or(0);
+                    let ack = group.register(lsn);
+                    let bytes = writer.memtable_bytes();
+                    if shared.memtable_flush_bytes > 0 && bytes >= shared.memtable_flush_bytes {
+                        ns_state.flush_notify.notify_one();
+                    }
+                    let stall = shared.write_stall_for(writer.max_l0_bucket_len(), bytes);
+                    drop(writer);
+                    group.notify_committer();
+                    let result = match ack.await {
+                        Ok(Ok(())) => Ok(outcome),
+                        Ok(Err(shared_err)) => Err(WriteFailure::Shared(shared_err)),
+                        Err(_) => Err(WriteFailure::Own(namidb_query::exec::ExecError::Runtime(
+                            "group commit coordinator exited".into(),
+                        ))),
+                    };
+                    (result, stall)
                 }
-                shared.write_stall_for(writer.max_l0_bucket_len(), bytes)
+                Err(e) => {
+                    // Roll back ONLY this request; earlier group members'
+                    // staged rows survive. Never recover a retired
+                    // incarnation (see the inline arm).
+                    writer.rollback_staged_request(mark);
+                    if !ns_state.is_retired() {
+                        recovery::recover_after_write_error(
+                            &mut writer,
+                            &ns_state.snapshot,
+                            &ns_state.writer_health,
+                            &ns_state.namespace,
+                            &e,
+                        )
+                        .await;
+                    }
+                    drop(writer);
+                    (Err(WriteFailure::Own(e)), None)
+                }
             }
-            Err(e) => {
-                // Reopen a fenced/poisoned namespace writer in place, under
-                // the lock we already hold (mirrors the single-tenant path).
-                // Never recover a retired incarnation: doing so after
-                // eviction could claim a newer epoch and fence its successor.
-                if !ns_state.is_retired() {
-                    recovery::recover_after_write_error(
-                        &mut writer,
-                        &ns_state.snapshot,
-                        &ns_state.writer_health,
-                        &ns_state.namespace,
-                        e,
-                    )
+        } else {
+            let result =
+                execute_write_with_deadline(&plan, &mut writer, &params, shared.write_deadline())
                     .await;
+            let stall = match &result {
+                Ok(_) => {
+                    ns_state.snapshot.store(writer.owned_snapshot());
+                    let bytes = writer.memtable_bytes();
+                    if shared.memtable_flush_bytes > 0 && bytes >= shared.memtable_flush_bytes {
+                        ns_state.flush_notify.notify_one();
+                    }
+                    shared.write_stall_for(writer.max_l0_bucket_len(), bytes)
                 }
-                None
-            }
+                Err(e) => {
+                    // Reopen a fenced/poisoned namespace writer in place, under
+                    // the lock we already hold (mirrors the single-tenant path).
+                    // Never recover a retired incarnation: doing so after
+                    // eviction could claim a newer epoch and fence its successor.
+                    if !ns_state.is_retired() {
+                        recovery::recover_after_write_error(
+                            &mut writer,
+                            &ns_state.snapshot,
+                            &ns_state.writer_health,
+                            &ns_state.namespace,
+                            e,
+                        )
+                        .await;
+                    }
+                    None
+                }
+            };
+            drop(writer);
+            (result.map_err(WriteFailure::Own), stall)
         };
-        drop(writer);
         let elapsed = started.elapsed();
         if let Some(delay) = stall {
             tokio::time::sleep(delay).await;
@@ -4126,11 +4236,11 @@ async fn run_cypher_multi(
                     .into_response(),
                 }
             }
-            Err(e) => ObservedQuery {
+            Err(failure) => ObservedQuery {
                 kind: Some(QueryKind::Write),
                 ok: false,
                 elapsed,
-                response: exec_failure_response("write execution failed", &e),
+                response: exec_failure_response("write execution failed", failure.as_exec()),
             },
         }
     } else {
@@ -5848,7 +5958,7 @@ mod tests {
         let writer = WriterSession::open(store, paths).await.unwrap();
         let state = AppState::new(writer, Some("tok".into()), "group-commit".into())
             .with_group_commit(Duration::from_millis(5));
-        tokio::spawn(group_committer_loop(state.clone()));
+        state.spawn_group_committer();
         let app = build_router(state.clone());
 
         let v0 = state.snapshot.load().manifest().manifest.version;
@@ -5888,7 +5998,7 @@ mod tests {
         let writer = WriterSession::open(store, paths).await.unwrap();
         let state = AppState::new(writer, Some("tok".into()), "group-merge".into())
             .with_group_commit(Duration::from_millis(5));
-        tokio::spawn(group_committer_loop(state.clone()));
+        state.spawn_group_committer();
         let app = build_router(state);
 
         let merge = |app: Router| async move {
@@ -5911,7 +6021,7 @@ mod tests {
         let writer = WriterSession::open(store, paths).await.unwrap();
         let state = AppState::new(writer, Some("tok".into()), "group-fail".into())
             .with_group_commit(Duration::from_millis(5));
-        tokio::spawn(group_committer_loop(state.clone()));
+        state.spawn_group_committer();
         let app = build_router(state);
 
         let good = post_cypher(&app, Some("tok"), "CREATE (:F {ok: 1})");
@@ -6037,7 +6147,7 @@ mod tests {
                 .unwrap();
         let state = AppState::new(writer, Some("tok".into()), "group-cas".into())
             .with_group_commit(Duration::from_millis(5));
-        tokio::spawn(group_committer_loop(state.clone()));
+        state.spawn_group_committer();
         let app = build_router(state);
 
         // Sanity: a grouped write commits while the store is healthy.
@@ -6849,6 +6959,97 @@ mod tests {
             .await
             .unwrap()
             .status()
+    }
+
+    /// RFC-034 multi-tenant: the registry spawns one committer per
+    /// namespace; grouped writes coalesce per namespace (manifest-version
+    /// counting), RYOW holds, and a sibling namespace is untouched.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn multi_tenant_grouped_writes_coalesce_per_namespace() {
+        let (store, _) = namidb_storage::parse_uri("memory://mt-group").unwrap();
+        let metrics = Metrics::new(env!("CARGO_PKG_VERSION"), Duration::ZERO);
+        let registry = Arc::new(registry::NamespaceRegistry::new(
+            store,
+            String::new(),
+            0,
+            Duration::from_secs(3600),
+            metrics.clone(),
+            registry::MaintenanceConfig {
+                group_commit_window: Duration::from_millis(5),
+                ..Default::default()
+            },
+        ));
+        let shared = SharedAppState::new_with_memory(
+            registry.clone(),
+            Arc::new(AuthConfig::open()),
+            metrics,
+            Duration::ZERO,
+            Duration::ZERO,
+            0,
+            0,
+            Duration::ZERO,
+            0,
+            0,
+            Arc::new(memory::MemoryGovernor::new(0)),
+            Duration::ZERO,
+            "acme".to_string(),
+        );
+        let app = build_multi_tenant_router(shared);
+
+        let post_json = |app: Router, uri: &'static str, query: String| async move {
+            app.oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(uri)
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::to_vec(&serde_json::json!({ "query": query })).unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap()
+        };
+
+        let mut handles = Vec::new();
+        for i in 0..8 {
+            let app = app.clone();
+            handles.push(tokio::spawn(post_json(
+                app,
+                "/acme/v0/cypher",
+                format!("CREATE (:G {{i: {i}}})"),
+            )));
+        }
+        for handle in handles {
+            assert_eq!(handle.await.unwrap().status(), StatusCode::OK);
+        }
+        // RYOW after the last ACK.
+        let read = post_json(
+            app.clone(),
+            "/acme/v0/cypher",
+            "MATCH (g:G) RETURN count(g) AS c".to_string(),
+        )
+        .await;
+        assert_eq!(read.status(), StatusCode::OK);
+        let json = body_json(read).await;
+        assert_eq!(json["rows"][0]["c"], 8, "{json}");
+        // The sibling namespace has its own committer and its own data.
+        let read = post_json(
+            app.clone(),
+            "/globex/v0/cypher",
+            "MATCH (g:G) RETURN count(g) AS c".to_string(),
+        )
+        .await;
+        let json = body_json(read).await;
+        assert_eq!(json["rows"][0]["c"], 0, "{json}");
+        // Coalescing per namespace: fewer manifest commits than writes.
+        let acme = registry.get_if_open("acme").await.expect("acme open");
+        let version = acme.snapshot.load().manifest().manifest.version;
+        assert!(version > 0);
+        assert!(
+            (version as usize) < 8,
+            "8 writes must share commits under a 5 ms window, got {version}"
+        );
     }
 
     #[tokio::test]

--- a/crates/namidb-server/src/registry.rs
+++ b/crates/namidb-server/src/registry.rs
@@ -48,6 +48,9 @@ pub struct MaintenanceConfig {
     /// L0-count high-water mark per bucket that triggers a reactive
     /// compaction on flush. `0` disables it.
     pub compaction_l0_trigger: usize,
+    /// RFC-034 group-commit coalescing window per namespace. Zero (the
+    /// default) keeps inline per-request commits.
+    pub group_commit_window: Duration,
 }
 
 impl Default for MaintenanceConfig {
@@ -58,6 +61,7 @@ impl Default for MaintenanceConfig {
             sweep_min_age: Duration::ZERO,
             sweep_delete: false,
             compaction_l0_trigger: 0,
+            group_commit_window: Duration::ZERO,
         }
     }
 }
@@ -253,6 +257,11 @@ impl NamespaceRegistry {
             retired: std::sync::atomic::AtomicBool::new(false),
             writer_health: WriterHealth::new(),
             flush_notify: Arc::new(tokio::sync::Notify::new()),
+            group_commit: (!self.maintenance.group_commit_window.is_zero()).then(|| {
+                Arc::new(crate::GroupCommit::new(
+                    self.maintenance.group_commit_window,
+                ))
+            }),
         });
 
         // Spawn per-namespace background maintenance (flush / compaction /
@@ -282,6 +291,27 @@ impl NamespaceRegistry {
     fn spawn_maintenance(&self, state: Arc<NamespaceState>, paths: NamespacePaths) {
         let maint = self.maintenance;
         let maint_store = Arc::new(ManifestStore::new(self.store.clone(), paths));
+
+        // RFC-034 group committer: one per namespace, cancelled on eviction
+        // like the other maintenance loops (an in-flight commit finishes
+        // first; stragglers are failed, not hung).
+        if let Some(group) = state.group_commit.clone() {
+            let handles = crate::CommitterHandles {
+                writer: state.writer.clone(),
+                snapshot: state.snapshot.clone(),
+                writer_health: state.writer_health.clone(),
+                namespace: state.namespace.clone(),
+                group,
+                memtable_bytes_gauge: None,
+            };
+            let cancel = state.cancel_tx.subscribe();
+            let handle = tokio::spawn(crate::group_committer_loop(handles, cancel));
+            state
+                .maintenance_tasks
+                .lock()
+                .expect("maintenance tasks lock poisoned")
+                .push(handle);
+        }
 
         // Periodic flush (+ reactive compaction on L0 high-water).
         if maint.flush_interval > Duration::ZERO {
@@ -532,6 +562,10 @@ pub struct NamespaceState {
     /// Wakes this namespace's flush task early when a committed write
     /// crosses the memtable byte threshold (see `SharedAppState`).
     pub flush_notify: Arc<tokio::sync::Notify>,
+    /// RFC-034 group commit coordinator for this namespace. `None` =
+    /// inline commits; `Some` pairs with a committer task spawned by
+    /// `spawn_maintenance` and cancelled on eviction.
+    pub(crate) group_commit: Option<Arc<crate::GroupCommit>>,
 }
 
 impl NamespaceState {

--- a/crates/namidb-server/tests/bolt_integration.rs
+++ b/crates/namidb-server/tests/bolt_integration.rs
@@ -274,7 +274,9 @@ async fn boot_bolt_multi(
         auth_tokens_file: Some(tokens_path),
         no_auth: false,
         backup_target_uri: None,
-        group_commit_window: Duration::ZERO,
+        // Grouped on purpose: the multi-tenant Bolt test then exercises the
+        // registry-spawned per-namespace committers end to end.
+        group_commit_window: Duration::from_millis(2),
         #[cfg(feature = "jwt")]
         jwt: None,
         #[cfg(feature = "pdp")]

--- a/docs/rfc/034-writer-concurrency.md
+++ b/docs/rfc/034-writer-concurrency.md
@@ -9,8 +9,11 @@
 `--group-commit-window`, default `0s` = inline commits — storage request
 scopes `begin/commit/rollback_staged_request` + request-scoped unique-index
 undo layer, one committer task per namespace, waiter registration under the
-writer lock, ACK after republish; auto-commit paths only, single-tenant;
-multi-tenant registry wiring and pipelined commit remain proposed)
+writer lock, ACK after republish; auto-commit paths, single- AND
+multi-tenant (one committer per registry namespace, cancelled on eviction);
+the shared-fate fault-injection test shipped and surfaced the pre-existing
+indeterminate-pointer-CAS resurrection bug, fixed in ingest
+(`resolve_failed_pointer_cas`); pipelined commit remains proposed)
 **Back-refs:** RFC-001 §"Write path"/§"Epoch fencing", RFC-021, RFC-026, RFC-027, RFC-029
 
 ## Summary

--- a/docs/testing/25tb-readiness.md
+++ b/docs/testing/25tb-readiness.md
@@ -702,8 +702,10 @@ A-moves-tuple-then-B-touches-it case is regression-tested). The server runs one
 committer per namespace: requests stage under the writer lock, register a waiter keyed
 by their last staged LSN while still holding the lock (no stage/commit race), and ACK
 only after the merged commit is durable and the snapshot republished. Wired into the
-single-tenant HTTP and Bolt auto-commit paths; multi-tenant + a per-namespace committer
-in the registry is the sized follow-up. Default window 0s = inline commits, bit-for-bit
+single-tenant HTTP and Bolt auto-commit paths; the multi-tenant follow-up shipped next:
+the registry spawns one committer per namespace (cancelled on eviction), the window
+reaches MaintenanceConfig, and both the multi-tenant HTTP arm and the Bolt
+for_namespace views group. Default window 0s = inline commits, bit-for-bit
 today's behaviour — the knob is the rollout kill-switch RFC-034 asked for. Tests follow
 the RFC's plan: commit coalescing proven by manifest-version counting, concurrent-MERGE
 isolation, solo rollback of a failed statement, Bolt-path ACK+RYOW. Fault-injected CAS


### PR DESCRIPTION
RFC-034's sized multi-tenant follow-up (plan item 52 addendum).

- `group_committer_loop` decoupled from `AppState` into `CommitterHandles` and made cancel-aware; exiting fails any straggling waiters instead of hanging them.
- The registry spawns one committer per namespace with the other maintenance tasks (cancel on eviction; in-flight commit finishes first). `--group-commit-window` flows through `MaintenanceConfig`; `NamespaceState` owns the per-namespace coordinator.
- Multi-tenant HTTP write arm gains the grouped branch (request-scope staging, waiter registration under the writer lock, retired-incarnation rules preserved: no recovery of a retired incarnation, revalidation after lock acquisition unchanged).
- Bolt multi-tenant groups automatically: `AppState::for_namespace` shares the namespace's coordinator, so the existing `ServerBackend` grouped branch engages per delegate.

Tests: per-namespace coalescing via manifest-version counting over the multi-tenant router (8 concurrent writes → <8 commits, RYOW after last ACK, sibling namespace untouched); the multi-tenant Bolt integration test now boots with a 2 ms window, exercising registry-spawned committers end to end. Full storage+query+server suites and clippy green.