### PR TITLE
feat: multi-tenant admin backup endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ crates.io release will establish and document that API explicitly.
 ## [Unreleased]
 
 **Added**
+- The admin backup endpoint now serves multi-tenant deployments:
+  `/:namespace/v0/admin/backup` (and the header-routed unprefixed form)
+  with the same destination allowlist, a process-wide single-flight,
+  namespace-scoped token enforcement, and per-namespace source paths
+  resolved without opening the namespace (cold namespaces stay cold).
 - `namidb run` accepts `;`-separated multi-statement scripts: statements
   split outside strings/backticks/comments, run sequentially against one
   session, and stop at the first error (reported with its position). The

--- a/crates/namidb-server/README.md
+++ b/crates/namidb-server/README.md
@@ -163,7 +163,7 @@ byte-identical to static-token-only). Build the server with, e.g.,
 | `GET`  | `/v0/metrics`      | public  | Prometheus metrics (text exposition) |
 | `POST` | `/v0/cypher`       | bearer  | Run a Cypher query (read or write) |
 | `POST` | `/v0/admin/flush`  | bearer  | Force a memtable -> L0 SST flush; remains available and globally serialized under RSS pressure |
-| `POST` | `/v0/admin/backup` | bearer (read-write) | Copy a point-in-time snapshot of the namespace to an allowlisted destination (single-tenant; disabled unless `--backup-target-uri` is set) |
+| `POST` | `/v0/admin/backup` | bearer (read-write) | Copy a point-in-time snapshot of the namespace to an allowlisted destination (disabled unless `--backup-target-uri` is set; multi-tenant: `/:namespace/v0/admin/backup`) |
 
 ### `POST /v0/admin/backup`
 
@@ -186,9 +186,13 @@ every copied object). Returns `{"source_version", "objects_copied",
 ambient cloud credentials write wherever `to` points, so the endpoint is
 disabled (403) until the operator sets `--backup-target-uri` /
 `NAMIDB_BACKUP_TARGET_URI`; `to` must equal that prefix or extend it at a
-`/` (or `?ns=`) boundary. One backup runs at a time (waiters get a 503
-after 30 s). Restore stays CLI-only on purpose: it requires an offline
-destination, and the serving process *is* the writer.
+`/` (or `?ns=`) boundary. One backup runs at a time — process-wide in
+multi-tenant mode, where `/:namespace/v0/admin/backup` resolves the
+namespace's committed state without opening it (cold namespaces stay
+cold) and namespace-scoped tokens are enforced by the auth middleware —
+with waiters getting a 503 after 30 s. Restore stays CLI-only on
+purpose: it requires an offline destination, and the serving process
+*is* the writer.
 
 ### `POST /v0/cypher`
 

--- a/crates/namidb-server/src/lib.rs
+++ b/crates/namidb-server/src/lib.rs
@@ -789,6 +789,8 @@ pub fn build_multi_tenant_router(shared: SharedAppState) -> Router {
     let namespace_maintenance = Router::new()
         .route("/:namespace/v0/admin/flush", post(admin_flush_multi))
         .route("/v0/admin/flush", post(admin_flush_multi_unprefixed))
+        .route("/:namespace/v0/admin/backup", post(admin_backup_multi))
+        .route("/v0/admin/backup", post(admin_backup_multi_unprefixed))
         .layer(middleware::from_fn_with_state(
             shared.clone(),
             require_auth_multi,
@@ -1019,7 +1021,11 @@ pub async fn run_with_memory_max_bytes(
             config.writer_lock_timeout,
             config.default_namespace.clone(),
         )
-        .with_authz(authz.clone());
+        .with_authz(authz.clone())
+        .with_backup_target(config.backup_target_uri.clone());
+        if shared.backup_target_prefix.is_some() {
+            info!("multi-tenant admin backup endpoint enabled");
+        }
         let app = build_multi_tenant_router(shared.clone());
 
         // TLS on the serving path.
@@ -3607,6 +3613,34 @@ async fn admin_backup(
         )
             .into_response();
     }
+    // Single-flight with a bounded wait: this route sits outside the request
+    // timeout, so unbounded waiters would pin global concurrency slots
+    // (item 40's slot economy).
+    let Ok(Ok(_permit)) = tokio::time::timeout(ADMIN_FLUSH_WAIT, backup.permit.acquire()).await
+    else {
+        return backup_busy_response();
+    };
+    run_backup_copy(backup.store.clone(), backup.paths.clone(), &req).await
+}
+
+fn backup_busy_response() -> Response {
+    (
+        StatusCode::SERVICE_UNAVAILABLE,
+        Json(ErrorBody {
+            error: "another backup is already running; retry shortly".into(),
+        }),
+    )
+        .into_response()
+}
+
+/// The copy itself plus its error mapping, shared by the single-tenant and
+/// multi-tenant handlers. Gating (role, allowlist, single-flight) is the
+/// caller's job.
+async fn run_backup_copy(
+    src_store: Arc<dyn object_store::ObjectStore>,
+    src_paths: namidb_storage::NamespacePaths,
+    req: &BackupRequest,
+) -> Response {
     let (dst_store, dst_paths) = match namidb_storage::parse_uri(&req.to) {
         Ok(parsed) => parsed,
         Err(e) => {
@@ -3619,22 +3653,9 @@ async fn admin_backup(
                 .into_response();
         }
     };
-    // Single-flight with a bounded wait: this route sits outside the request
-    // timeout, so unbounded waiters would pin global concurrency slots
-    // (item 40's slot economy).
-    let Ok(Ok(_permit)) = tokio::time::timeout(ADMIN_FLUSH_WAIT, backup.permit.acquire()).await
-    else {
-        return (
-            StatusCode::SERVICE_UNAVAILABLE,
-            Json(ErrorBody {
-                error: "another backup is already running; retry shortly".into(),
-            }),
-        )
-            .into_response();
-    };
     match namidb_storage::copy_namespace_snapshot(
-        backup.store.clone(),
-        backup.paths.clone(),
+        src_store,
+        src_paths,
         dst_store,
         dst_paths,
         req.version,
@@ -3665,6 +3686,88 @@ async fn admin_backup(
         )
             .into_response(),
     }
+}
+
+/// `/:namespace/v0/admin/backup` — the multi-tenant twin of
+/// [`admin_backup`]: same allowlist boundary, a PROCESS-WIDE single-flight
+/// (one multi-GB copy at a time across all namespaces), and per-namespace
+/// source paths resolved WITHOUT opening the namespace (the copy reads
+/// committed state only, so cold namespaces stay cold). Namespace-scoped
+/// tokens are enforced by `require_auth_multi` before this runs.
+async fn admin_backup_multi(
+    Path(namespace): Path<String>,
+    State(shared): State<SharedAppState>,
+    Extension(principal): Extension<Principal>,
+    Json(req): Json<BackupRequest>,
+) -> Response {
+    dispatch_admin_backup_multi(&shared, &namespace, &principal, req).await
+}
+
+async fn admin_backup_multi_unprefixed(
+    State(shared): State<SharedAppState>,
+    Extension(principal): Extension<Principal>,
+    headers: axum::http::HeaderMap,
+    Json(req): Json<BackupRequest>,
+) -> Response {
+    let namespace = namespace_from_header(&shared, &headers);
+    dispatch_admin_backup_multi(&shared, &namespace, &principal, req).await
+}
+
+async fn dispatch_admin_backup_multi(
+    shared: &SharedAppState,
+    namespace: &str,
+    principal: &Principal,
+    req: BackupRequest,
+) -> Response {
+    if !principal.allows_write() {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(ErrorBody {
+                error: "this token is read-only; admin backup is forbidden".into(),
+            }),
+        )
+            .into_response();
+    }
+    let Some(prefix) = shared.backup_target_prefix.as_deref() else {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(ErrorBody {
+                error: "admin backup is disabled: set --backup-target-uri / \
+                        NAMIDB_BACKUP_TARGET_URI to allowlist destinations"
+                    .into(),
+            }),
+        )
+            .into_response();
+    };
+    if !uri_within_prefix(&req.to, prefix) {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(ErrorBody {
+                error: format!(
+                    "destination is outside the --backup-target-uri allowlist (`{prefix}`)"
+                ),
+            }),
+        )
+            .into_response();
+    }
+    let (src_store, src_paths) = match shared.registry.backup_source(namespace) {
+        Ok(source) => source,
+        Err(e) => {
+            return (
+                StatusCode::BAD_REQUEST,
+                Json(ErrorBody {
+                    error: format!("namespace `{namespace}`: {e}"),
+                }),
+            )
+                .into_response();
+        }
+    };
+    let Ok(Ok(_permit)) =
+        tokio::time::timeout(ADMIN_FLUSH_WAIT, shared.backup_permit.acquire()).await
+    else {
+        return backup_busy_response();
+    };
+    run_backup_copy(src_store, src_paths, &req).await
 }
 
 async fn run_admin_flush(state: AppState) -> Response {
@@ -6959,6 +7062,110 @@ mod tests {
             .await
             .unwrap()
             .status()
+    }
+
+    /// Item 54 follow-up: the multi-tenant backup endpoint enforces the
+    /// same allowlist boundary, resolves per-namespace source paths, and
+    /// the destination reopens as a self-contained namespace.
+    #[tokio::test]
+    async fn multi_tenant_admin_backup_round_trips_with_allowlist() {
+        let scratch = std::env::temp_dir().join(format!("namidb-mt-backup-{}", std::process::id()));
+        std::fs::create_dir_all(&scratch).unwrap();
+        let prefix = format!("file://{}", scratch.display());
+
+        let (store, _) = namidb_storage::parse_uri("memory://mt-backup").unwrap();
+        let metrics = Metrics::new(env!("CARGO_PKG_VERSION"), Duration::ZERO);
+        let registry = Arc::new(registry::NamespaceRegistry::new(
+            store,
+            String::new(),
+            0,
+            Duration::from_secs(3600),
+            metrics.clone(),
+            registry::MaintenanceConfig::default(),
+        ));
+        let shared = SharedAppState::new_with_memory(
+            registry,
+            Arc::new(AuthConfig::open()),
+            metrics,
+            Duration::ZERO,
+            Duration::ZERO,
+            0,
+            0,
+            Duration::ZERO,
+            0,
+            0,
+            Arc::new(memory::MemoryGovernor::new(0)),
+            Duration::ZERO,
+            "acme".to_string(),
+        )
+        .with_backup_target(Some(prefix.clone()));
+        let app = build_multi_tenant_router(shared);
+
+        // Seed a committed node in `acme`.
+        let seeded = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/acme/v0/cypher")
+                    .header("content-type", "application/json")
+                    .body(Body::from(
+                        serde_json::to_vec(
+                            &serde_json::json!({ "query": "CREATE (:B {k: 'mt'})" }),
+                        )
+                        .unwrap(),
+                    ))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(seeded.status(), StatusCode::OK);
+
+        // Outside the allowlist boundary: 403.
+        let evil = post_admin_json(
+            &app,
+            "/acme/v0/admin/backup",
+            "ignored-open-mode",
+            serde_json::json!({ "to": format!("{prefix}-evil?ns=x") }),
+        )
+        .await;
+        assert_eq!(evil.status(), StatusCode::FORBIDDEN);
+
+        // Inside: live round-trip; the destination reopens with the data.
+        let dest = format!("{prefix}/mt-b1?ns=mtb1");
+        let response = post_admin_json(
+            &app,
+            "/acme/v0/admin/backup",
+            "ignored-open-mode",
+            serde_json::json!({ "to": dest }),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let json = body_json(response).await;
+        assert!(json["objects_copied"].as_u64().unwrap() > 0, "{json}");
+
+        let (dst_store, dst_paths) = namidb_storage::parse_uri(&dest).unwrap();
+        let restored = WriterSession::open(dst_store, dst_paths).await.unwrap();
+        let snap = restored.snapshot();
+        let plan =
+            namidb_query::lower(&namidb_query::parse("MATCH (b:B) RETURN b.k AS k").unwrap())
+                .unwrap();
+        let rows = namidb_query::execute(&plan, &snap, &namidb_query::Params::new())
+            .await
+            .unwrap();
+        assert_eq!(rows.len(), 1, "backup must carry acme's committed node");
+
+        // An invalid namespace name is a client error, not a panic.
+        let bad = post_admin_json(
+            &app,
+            "/bad%2Fname/v0/admin/backup",
+            "ignored-open-mode",
+            serde_json::json!({ "to": format!("{prefix}/x?ns=x") }),
+        )
+        .await;
+        assert_eq!(bad.status(), StatusCode::BAD_REQUEST);
+
+        std::fs::remove_dir_all(&scratch).ok();
     }
 
     /// RFC-034 multi-tenant: the registry spawns one committer per

--- a/crates/namidb-server/src/registry.rs
+++ b/crates/namidb-server/src/registry.rs
@@ -137,6 +137,22 @@ impl NamespaceRegistry {
         self.max_namespaces != 0 && len >= self.max_namespaces
     }
 
+    /// The shared store handle plus this namespace's paths, for a
+    /// point-in-time backup of COMMITTED state. Deliberately does NOT open
+    /// the namespace: the copy reads the durable manifest closure directly,
+    /// so a cold namespace stays cold.
+    pub(crate) fn backup_source(
+        &self,
+        namespace: &str,
+    ) -> Result<(Arc<dyn ObjectStore>, NamespacePaths), RegistryError> {
+        let ns_id = NamespaceId::new(namespace)
+            .map_err(|e| RegistryError::InvalidNamespace(e.to_string()))?;
+        Ok((
+            self.store.clone(),
+            NamespacePaths::new(self.root.clone(), ns_id),
+        ))
+    }
+
     /// Return an already-open namespace without recovering or allocating a
     /// new writer. Used by pressure-relief operations at the hard RSS limit:
     /// flushing a live memtable can free memory, while opening a cold

--- a/crates/namidb-server/src/shared.rs
+++ b/crates/namidb-server/src/shared.rs
@@ -55,6 +55,13 @@ pub struct SharedAppState {
     /// Pre-execution authorization hook (RFC-015 Wave B), shared across all
     /// namespaces. Defaults to allow-all ([`NoOpAuthz`]).
     pub authz: Arc<dyn AuthzHook>,
+    /// Destination-URI allowlist prefix for `/:namespace/v0/admin/backup`.
+    /// `None` disables the endpoint (see `Config::backup_target_uri`).
+    pub backup_target_prefix: Option<String>,
+    /// Process-wide single-flight for admin backups: one multi-GB copy at
+    /// a time regardless of namespace, keeping the global HTTP slot
+    /// economy honest (the admin routes sit outside the request timeout).
+    pub backup_permit: Arc<tokio::sync::Semaphore>,
 }
 
 impl SharedAppState {
@@ -126,6 +133,8 @@ impl SharedAppState {
             writer_lock_timeout,
             default_namespace,
             authz: Arc::new(NoOpAuthz),
+            backup_target_prefix: None,
+            backup_permit: Arc::new(tokio::sync::Semaphore::new(1)),
         }
     }
 
@@ -133,6 +142,13 @@ impl SharedAppState {
     /// allow-all ([`NoOpAuthz`]).
     pub fn with_authz(mut self, authz: Arc<dyn AuthzHook>) -> Self {
         self.authz = authz;
+        self
+    }
+
+    /// Enable the multi-tenant admin backup endpoint with a destination
+    /// allowlist prefix (builder style). `None` keeps it disabled.
+    pub fn with_backup_target(mut self, prefix: Option<String>) -> Self {
+        self.backup_target_prefix = prefix;
         self
     }
 

--- a/docs/testing/25tb-readiness.md
+++ b/docs/testing/25tb-readiness.md
@@ -755,8 +755,10 @@ pattern — ~1 day, sized, not rushed into this release.
 read-write role gate; single-flight with the 30 s bounded wait; Precondition→409,
 local-persistence→507; live round-trip + force/verify covered by in-lib tests.
 Restore stays CLI-only on purpose (offline destination required; the serving
-process IS the writer). Single-tenant only; multi-tenant needs per-namespace
-handles from the registry — roadmap note, hours.
+process IS the writer). The multi-tenant twin shipped next:
+/:namespace/v0/admin/backup with the same allowlist, process-wide single-flight,
+and cold-namespace-safe source resolution (the copy reads committed state, so
+no writer opens).
 
 ### Retractions (RET-01..04) — recorded for the record
 


### PR DESCRIPTION
Item 54's last follow-up (plan doc updated).

- `/:namespace/v0/admin/backup` + header-routed unprefixed form; same destination allowlist (`--backup-target-uri` → `SharedAppState`), namespace-scoped tokens enforced by `require_auth_multi`.
- **Process-wide** single-flight (one multi-GB copy at a time across namespaces) with the bounded 30 s wait — slot-economy rule from item 40.
- Per-namespace source resolved **without opening the namespace** (`registry.backup_source`): the copy reads the durable manifest closure, so cold namespaces stay cold — no registry slot spent, no writer epoch claimed.
- Copy + error mapping extracted into `run_backup_copy`, shared with the single-tenant handler.

Tests: seeded write → outside-allowlist 403 → live round-trip (destination reopens with the data) → invalid namespace name is a 400. Server+CLI suites and clippy green.