### PR TITLE
perf: bidirectional shortestPath for single bound pairs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ crates.io release will establish and document that API explicitly.
 ## [Unreleased]
 
 **Added**
+- `shortestPath` on a single bound pair now runs a bidirectional
+  meet-in-the-middle BFS (exactness kept via the classical stopping
+  criterion): the frontier is O(deg^(d/2)) per side instead of
+  O(deg^d). Multi-target groups, `allShortestPaths`, `min >= 2`, and
+  self-pairs keep the unidirectional visited BFS; the executor stamps
+  the route in telemetry (`shortest_bidirectional`) so tests and
+  operators can prove it engages.
 - The admin backup endpoint now serves multi-tenant deployments:
   `/:namespace/v0/admin/backup` (and the header-routed unprefixed form)
   with the same destination allowlist, a process-wide single-flight,

--- a/crates/namidb-query/src/exec/walker.rs
+++ b/crates/namidb-query/src/exec/walker.rs
@@ -1957,6 +1957,195 @@ pub(crate) async fn execute_expand(
     Ok(out)
 }
 
+/// Flip a pattern direction for the reverse side of a bidirectional BFS.
+fn flip_direction(direction: RelationshipDirection) -> RelationshipDirection {
+    match direction {
+        RelationshipDirection::Right => RelationshipDirection::Left,
+        RelationshipDirection::Left => RelationshipDirection::Right,
+        RelationshipDirection::Both => RelationshipDirection::Both,
+    }
+}
+
+/// Meet-in-the-middle BFS for one `(src, dst)` pair in `First` mode.
+/// Expands the SMALLER frontier each round (the reverse side flips the
+/// pattern direction), records first-arrival parents per side, and keeps
+/// expanding until the classical stopping criterion (`df + db >= best
+/// total`) proves the best meet is exactly shortest. A shortest walk is
+/// necessarily simple, so relationship-uniqueness holds by construction.
+/// Returns the `(trail, rel_values)` hit, or `None` when unreachable
+/// within `max` hops.
+#[allow(clippy::too_many_arguments)]
+async fn bidirectional_first_path(
+    snapshot: &Snapshot<'_>,
+    edge_types: &[String],
+    direction: RelationshipDirection,
+    src: NodeId,
+    dst: NodeId,
+    max: u32,
+    edge_read_mode: EdgeReadMode,
+    materialise_trail: bool,
+    src_value: Option<RuntimeValue>,
+    dst_value: Option<NodeValue>,
+) -> Result<Option<(Vec<RuntimeValue>, Vec<RuntimeValue>)>, ExecError> {
+    use std::collections::HashMap;
+    struct Side {
+        depth: u32,
+        frontier: Vec<NodeId>,
+        visited: HashMap<NodeId, u32>,
+        parents: HashMap<NodeId, (NodeId, EdgeView)>,
+    }
+    async fn expand_level(
+        side: &mut Side,
+        other: &Side,
+        snapshot: &Snapshot<'_>,
+        edge_types: &[String],
+        dir: RelationshipDirection,
+        edge_read_mode: EdgeReadMode,
+        best: &mut Option<(u32, NodeId)>,
+    ) -> Result<(), ExecError> {
+        let new_depth = side.depth + 1;
+        let mut next = Vec::new();
+        for index in 0..side.frontier.len() {
+            crate::exec::limits::check_deadline()?;
+            let node = side.frontier[index];
+            let neighbours =
+                neighbours_of_any(snapshot, edge_types, dir, node, edge_read_mode).await?;
+            for edge in neighbours {
+                let partner = partner_id(&edge, dir, node);
+                if side.visited.contains_key(&partner) {
+                    continue;
+                }
+                side.visited.insert(partner, new_depth);
+                side.parents.insert(partner, (node, edge));
+                if let Some(&other_depth) = other.visited.get(&partner) {
+                    let total = new_depth + other_depth;
+                    if best.is_none_or(|(current, _)| total < current) {
+                        *best = Some((total, partner));
+                    }
+                }
+                next.push(partner);
+            }
+        }
+        side.frontier = next;
+        side.depth = new_depth;
+        Ok(())
+    }
+
+    let mut fwd = Side {
+        depth: 0,
+        frontier: vec![src],
+        visited: HashMap::from([(src, 0)]),
+        parents: HashMap::new(),
+    };
+    let mut bwd = Side {
+        depth: 0,
+        frontier: vec![dst],
+        visited: HashMap::from([(dst, 0)]),
+        parents: HashMap::new(),
+    };
+    let flipped = flip_direction(direction);
+    let mut best: Option<(u32, NodeId)> = None;
+    loop {
+        let reach = fwd.depth + bwd.depth;
+        if let Some((total, _)) = best {
+            if reach >= total {
+                break;
+            }
+        }
+        if reach >= max || fwd.frontier.is_empty() || bwd.frontier.is_empty() {
+            break;
+        }
+        if fwd.frontier.len() <= bwd.frontier.len() {
+            expand_level(
+                &mut fwd,
+                &bwd,
+                snapshot,
+                edge_types,
+                direction,
+                edge_read_mode,
+                &mut best,
+            )
+            .await?;
+        } else {
+            expand_level(
+                &mut bwd,
+                &fwd,
+                snapshot,
+                edge_types,
+                flipped,
+                edge_read_mode,
+                &mut best,
+            )
+            .await?;
+        }
+    }
+    let Some((total, meet)) = best else {
+        return Ok(None);
+    };
+    if total > max || total == 0 {
+        return Ok(None);
+    }
+
+    // Reconstruct src -> dst: walk parents from the meet outward on both
+    // sides. The reverse side's edges were traversed against the pattern
+    // direction, but carry their STORED orientation, so the rel values are
+    // correct as-is.
+    let mut nodes: Vec<NodeId> = vec![meet];
+    let mut edges: Vec<EdgeView> = Vec::new();
+    let mut cursor = meet;
+    while cursor != src {
+        let (parent, edge) = fwd
+            .parents
+            .get(&cursor)
+            .expect("forward parent chain")
+            .clone();
+        edges.push(edge);
+        nodes.push(parent);
+        cursor = parent;
+    }
+    nodes.reverse();
+    edges.reverse();
+    let mut cursor = meet;
+    while cursor != dst {
+        let (parent, edge) = bwd
+            .parents
+            .get(&cursor)
+            .expect("backward parent chain")
+            .clone();
+        edges.push(edge);
+        nodes.push(parent);
+        cursor = parent;
+    }
+    debug_assert_eq!(edges.len() as u32, total);
+
+    let rel_values: Vec<RuntimeValue> = edges
+        .into_iter()
+        .map(|edge| RuntimeValue::Rel(Box::new(RelValue::from(edge))))
+        .collect();
+    let trail = if materialise_trail {
+        let mut trail = Vec::with_capacity(nodes.len() * 2 - 1);
+        for (index, node) in nodes.iter().enumerate() {
+            if index > 0 {
+                trail.push(rel_values[index - 1].clone());
+            }
+            let value = if *node == src {
+                src_value.clone()
+            } else if *node == dst {
+                dst_value.clone().map(|nv| RuntimeValue::Node(Box::new(nv)))
+            } else {
+                scan_node_for_id(snapshot, *node)
+                    .await?
+                    .map(|view| RuntimeValue::Node(Box::new(NodeValue::from(view))))
+            };
+            trail.push(value.unwrap_or(RuntimeValue::Null));
+        }
+        trail
+    } else {
+        Vec::new()
+    };
+    Ok(Some((trail, rel_values)))
+}
+
 /// Seed-grouped shortestPath/allShortestPaths execution: one pruned
 /// multi-target BFS per run of consecutive seed rows sharing a source node,
 /// serving every bound target of the run. Row order (and therefore output
@@ -2053,6 +2242,47 @@ async fn execute_expand_shortest_grouped(
             hits.entry(starting)
                 .or_default()
                 .push((initial_trail.clone(), Vec::new()));
+        }
+
+        // NDB-09 final follow-up: ONE bound pair in `First` mode takes the
+        // bidirectional meet-in-the-middle BFS — O(deg^(d/2)) frontier per
+        // side instead of O(deg^d) — with exactness guaranteed by the
+        // classical stopping criterion (expand until df + db >= best meet).
+        // Multi-target groups, `All` mode, `min >= 2`, and self-pairs keep
+        // the unidirectional visited BFS below.
+        if shortest == crate::plan::ShortestMode::First
+            && min <= 1
+            && max > 1
+            && remaining.len() == 1
+        {
+            let target = *remaining.iter().next().expect("len checked");
+            if target != starting {
+                namidb_storage::route_telemetry::record_shortest_bidirectional();
+                let src_value = run[0].get(source).cloned();
+                let dst_value = run.iter().find_map(|row| match row.get(target_alias) {
+                    Some(RuntimeValue::Node(n)) if n.id == target => Some(n.as_ref().clone()),
+                    _ => None,
+                });
+                if let Some(hit) = bidirectional_first_path(
+                    snapshot,
+                    edge_types,
+                    direction,
+                    starting,
+                    target,
+                    max,
+                    edge_read_mode,
+                    materialise_trail,
+                    src_value,
+                    dst_value,
+                )
+                .await?
+                {
+                    hits.insert(target, vec![hit]);
+                }
+                // Found or not, the pair is answered: the unidirectional
+                // loop below exits immediately on an empty `remaining`.
+                remaining.clear();
+            }
         }
 
         struct PathState {

--- a/crates/namidb-query/tests/exec_shortest_path.rs
+++ b/crates/namidb-query/tests/exec_shortest_path.rs
@@ -326,6 +326,70 @@ async fn multi_pair_shortest_paths_answer_every_bound_target() {
     );
 }
 
+/// The bidirectional route is ACTUALLY taken for single bound pairs — the
+/// reachability discipline: result parity alone would pass identically on
+/// the unidirectional route — and stays exact on odd lengths, undirected
+/// patterns, and unreachable pairs.
+#[tokio::test]
+async fn single_pair_shortest_path_takes_the_bidirectional_route() {
+    let mut writer = WriterSession::open(store(), paths("sp-bidi"))
+        .await
+        .unwrap();
+    let _ = build_graph(&mut writer).await;
+    // An isolated node: reachable by nothing.
+    writer
+        .upsert_node("Person", NodeId::new(), &person("Zoe"))
+        .unwrap();
+    writer.commit_batch().await.unwrap();
+    let snapshot = writer.snapshot();
+    let before = namidb_storage::route_telemetry::snapshot().shortest_bidirectional;
+
+    // Odd length, directed: Bob -> Carol -> Dave -> Eve.
+    let q = parse(
+        "MATCH (a:Person {name: 'Bob'}), (b:Person {name: 'Eve'}) \
+         MATCH p = shortestPath((a)-[:KNOWS*..5]->(b)) \
+         RETURN length(p) AS hops",
+    )
+    .unwrap();
+    let rows = execute(&lower(&q).unwrap(), &snapshot, &Params::new())
+        .await
+        .unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].get("hops"), Some(&RuntimeValue::Integer(3)));
+
+    // Undirected: Eve -- Alice -- Bob is 2 against the edge directions.
+    let q = parse(
+        "MATCH (a:Person {name: 'Eve'}), (b:Person {name: 'Bob'}) \
+         MATCH p = shortestPath((a)-[:KNOWS*..5]-(b)) \
+         RETURN length(p) AS hops",
+    )
+    .unwrap();
+    let rows = execute(&lower(&q).unwrap(), &snapshot, &Params::new())
+        .await
+        .unwrap();
+    assert_eq!(rows.len(), 1);
+    assert_eq!(rows[0].get("hops"), Some(&RuntimeValue::Integer(2)));
+
+    // Unreachable: no rows, no error.
+    let q = parse(
+        "MATCH (a:Person {name: 'Alice'}), (b:Person {name: 'Zoe'}) \
+         MATCH p = shortestPath((a)-[:KNOWS*..5]->(b)) \
+         RETURN length(p) AS hops",
+    )
+    .unwrap();
+    let rows = execute(&lower(&q).unwrap(), &snapshot, &Params::new())
+        .await
+        .unwrap();
+    assert!(rows.is_empty(), "{rows:?}");
+
+    let after = namidb_storage::route_telemetry::snapshot().shortest_bidirectional;
+    assert!(
+        after >= before + 3,
+        "all three single-pair queries must take the bidirectional route \
+         (before {before}, after {after})"
+    );
+}
+
 /// Dense layered graph: s → L1(40) → L2(40) → L3(40) → L4(40) → L5(40) → t,
 /// complete bipartite between consecutive layers. The walk-enumerating
 /// frontier holds 40^k entries at hop k (~102M Row clones by hop 5 — an

--- a/crates/namidb-storage/src/route_telemetry.rs
+++ b/crates/namidb-storage/src/route_telemetry.rs
@@ -19,6 +19,7 @@ static VECTOR_NATIVE: AtomicU64 = AtomicU64::new(0);
 static VECTOR_FALLBACK: AtomicU64 = AtomicU64::new(0);
 static PROPERTY_NATIVE: AtomicU64 = AtomicU64::new(0);
 static PROPERTY_FALLBACK: AtomicU64 = AtomicU64::new(0);
+static SHORTEST_BIDIRECTIONAL: AtomicU64 = AtomicU64::new(0);
 
 /// Record one text index search outcome: `native = true` when the index
 /// served the answer, `false` when it declined (freshness gate, missing or
@@ -55,6 +56,14 @@ pub fn record_property(native: bool) {
     }
 }
 
+/// Record one bidirectional (meet-in-the-middle) shortestPath execution.
+/// Same reachability rationale: a single-pair `shortestPath` silently taking
+/// the unidirectional route instead would be invisible to result-parity
+/// tests, so the executor stamps the route it actually took.
+pub fn record_shortest_bidirectional() {
+    SHORTEST_BIDIRECTIONAL.fetch_add(1, Ordering::Relaxed);
+}
+
 /// A monotonic snapshot of every route counter.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct RouteTelemetrySnapshot {
@@ -64,6 +73,7 @@ pub struct RouteTelemetrySnapshot {
     pub vector_fallback: u64,
     pub property_native: u64,
     pub property_fallback: u64,
+    pub shortest_bidirectional: u64,
 }
 
 pub fn snapshot() -> RouteTelemetrySnapshot {
@@ -74,6 +84,7 @@ pub fn snapshot() -> RouteTelemetrySnapshot {
         vector_fallback: VECTOR_FALLBACK.load(Ordering::Relaxed),
         property_native: PROPERTY_NATIVE.load(Ordering::Relaxed),
         property_fallback: PROPERTY_FALLBACK.load(Ordering::Relaxed),
+        shortest_bidirectional: SHORTEST_BIDIRECTIONAL.load(Ordering::Relaxed),
     }
 }
 

--- a/docs/testing/25tb-readiness.md
+++ b/docs/testing/25tb-readiness.md
@@ -656,7 +656,12 @@ row order preserved, engaged only when uncapped so LIMIT-pushdown prefix semanti
 stay untouched. Implementing it surfaced ANOTHER pre-existing trail bug: nodes(p)
 filled every intermediate hop with the pre-bound endpoint value (a 2-hop path
 returned ["n0","n2","n2"]) — fixed in both the grouped and per-seed paths by looking
-up the node actually reached. Bidirectional meet-in-the-middle stays roadmap.
+up the node actually reached. Bidirectional meet-in-the-middle shipped next:
+single bound pairs in First mode expand the smaller frontier from either end
+(reverse side flips the pattern direction), with first-arrival parent maps for
+reconstruction, the classical df+db >= best stopping criterion for exactness, and
+a route-telemetry counter so tests assert the route actually engages (parity alone
+would pass on the unidirectional route too).
 
 ### 48. [DONE — lands in 2.2.0] NDB-05: reduce() does not parse.
 


### PR DESCRIPTION
NDB-09's last deferred piece (plan item 47 addendum).

- Meet-in-the-middle BFS for a single bound `(src, dst)` pair in `First` mode: alternate-expand the smaller frontier (reverse side flips the pattern direction), first-arrival parent maps for reconstruction, and the classical `df + db >= best` stopping criterion for exactness — O(deg^(d/2)) frontier per side vs O(deg^d).
- Shortest walks are simple, so trail semantics hold by construction; trail node values resolved like the unidirectional path.
- Multi-target groups, `allShortestPaths`, `min >= 2`, and self-pairs stay unidirectional.
- Route stamped in process telemetry (`shortest_bidirectional`) — the reachability discipline: parity alone passes identically on the unidirectional route, so the test asserts the counter delta.

Tests: full shortest-path suite through the new route (10/10, exact lengths unchanged) + dedicated odd-length / undirected / unreachable / telemetry coverage. Full storage+query+server suites and clippy green.