### PR TITLE
feat: composite index DDL — schema, parser, and every interception surface (phase 1)

### DIFF
--- a/crates/namidb-cli/src/main.rs
+++ b/crates/namidb-cli/src/main.rs
@@ -548,15 +548,19 @@ async fn run_statement(writer: &mut WriterSession, statement: &str) -> anyhow::R
         return Ok(());
     }
     if let Some(ix) = q.as_create_index() {
-        let version = writer
-            .create_property_index_named(
-                ix.name.as_ref().map(|n| n.name.as_str()),
-                &ix.label.name,
-                &ix.property.name,
-                ix.if_not_exists,
-            )
-            .await
-            .map_err(|e| anyhow::anyhow!("{e}"))?;
+        let properties: Vec<String> = ix.properties.iter().map(|p| p.name.clone()).collect();
+        let name = ix.name.as_ref().map(|n| n.name.as_str());
+        let version = if properties.len() > 1 {
+            writer
+                .create_composite_index_named(name, &ix.label.name, &properties, ix.if_not_exists)
+                .await
+                .map_err(|e| anyhow::anyhow!("{e}"))?
+        } else {
+            writer
+                .create_property_index_named(name, &ix.label.name, &properties[0], ix.if_not_exists)
+                .await
+                .map_err(|e| anyhow::anyhow!("{e}"))?
+        };
         println!("index applied (manifest v{version})");
         return Ok(());
     }
@@ -799,6 +803,7 @@ mod tests {
             "cli-script",
             "CREATE CONSTRAINT person_email IF NOT EXISTS FOR (p:Person) REQUIRE p.email IS UNIQUE; \
              CREATE INDEX person_name IF NOT EXISTS FOR (p:Person) ON (p.name); \
+             CREATE INDEX person_pair IF NOT EXISTS FOR (p:Person) ON (p.city, p.age); \
              CREATE (:Person {email: 'a@x', name: 'Ada'}); \
              MERGE (p:Person {email: 'a@x'}) RETURN p.name AS name",
         )

--- a/crates/namidb-core/src/schema.rs
+++ b/crates/namidb-core/src/schema.rs
@@ -396,6 +396,40 @@ impl Constraint {
     }
 }
 
+/// A declared multi-property equality index (`CREATE INDEX ... ON (n.a,
+/// n.b)`). Single-property indexes stay flag-based ([`PropertyDef::indexed`],
+/// no catalog entry, synthesized name) for compatibility; this list carries
+/// ONLY composite (length >= 2) indexes. `properties` keeps DECLARATION
+/// order — it defines the tuple key layout of the posting sidecar.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct IndexDef {
+    pub name: String,
+    pub label: String,
+    /// Properties forming the index, in declaration order. Length >= 2.
+    pub properties: Vec<String>,
+}
+
+impl IndexDef {
+    /// Default name when the user did not supply one: `idx_<label>_<prop…>`.
+    /// Deterministic, matching [`Constraint::default_name`]'s rationale.
+    pub fn default_name(label: &str, properties: &[String]) -> String {
+        format!("idx_{label}_{}", properties.join("_"))
+    }
+
+    /// True iff this index covers `label` and the same *set* of properties
+    /// (order-independent for `IF NOT EXISTS` — two declaration orders over
+    /// one set answer the same equality conjunctions).
+    pub fn matches(&self, label: &str, properties: &[String]) -> bool {
+        self.label == label && {
+            let mut a = self.properties.clone();
+            let mut b = properties.to_vec();
+            a.sort();
+            b.sort();
+            a == b
+        }
+    }
+}
+
 /// Logical schema for a graph.
 ///
 /// `version` is monotonic per-namespace. Each schema-altering manifest commit
@@ -409,6 +443,11 @@ pub struct Schema {
     /// `serde(default)` keeps pre-constraint manifests loading unchanged.
     #[serde(default)]
     pub constraints: Vec<Constraint>,
+    /// Declared composite equality indexes (length >= 2; single-property
+    /// indexes stay flag-based on [`PropertyDef::indexed`]). `serde(default)`
+    /// keeps earlier manifests loading unchanged.
+    #[serde(default)]
+    pub indexes: Vec<IndexDef>,
 }
 
 impl Schema {

--- a/crates/namidb-py/src/lib.rs
+++ b/crates/namidb-py/src/lib.rs
@@ -849,15 +849,19 @@ async fn run_cypher_inner(
         return Ok(empty_query_result());
     }
     if let Some(c) = parsed.as_create_index() {
-        guard
-            .create_property_index_named(
-                c.name.as_ref().map(|n| n.name.as_str()),
-                &c.label.name,
-                &c.property.name,
-                c.if_not_exists,
-            )
-            .await
-            .map_err(map_storage_err)?;
+        let properties: Vec<String> = c.properties.iter().map(|p| p.name.clone()).collect();
+        let name = c.name.as_ref().map(|n| n.name.as_str());
+        if properties.len() > 1 {
+            guard
+                .create_composite_index_named(name, &c.label.name, &properties, c.if_not_exists)
+                .await
+                .map_err(map_storage_err)?;
+        } else {
+            guard
+                .create_property_index_named(name, &c.label.name, &properties[0], c.if_not_exists)
+                .await
+                .map_err(map_storage_err)?;
+        }
         return Ok(empty_query_result());
     }
     if let Some(c) = parsed.as_show_schema() {

--- a/crates/namidb-query/src/exec/show.rs
+++ b/crates/namidb-query/src/exec/show.rs
@@ -81,6 +81,16 @@ pub fn show_indexes_rows(manifest: &Manifest) -> Vec<Row> {
             }
         }
     }
+    // Composite equality indexes carry their persisted name and their
+    // DECLARATION-ordered property list.
+    for index in &manifest.schema.indexes {
+        entries.push((
+            index.name.clone(),
+            "RANGE",
+            index.label.clone(),
+            index.properties.clone(),
+        ));
+    }
     for vi in &manifest.vector_indexes {
         entries.push((
             vi.name.clone(),

--- a/crates/namidb-query/src/parser/ast.rs
+++ b/crates/namidb-query/src/parser/ast.rs
@@ -451,14 +451,17 @@ pub struct CreateConstraintClause {
     pub span: SourceSpan,
 }
 
-/// `CREATE INDEX [name] [IF NOT EXISTS] FOR (n:Label) ON (n.prop)` (and the
-/// legacy `ON :Label(prop)` form). A standalone schema command executed
-/// out-of-band by the server (see [`Query::as_create_index`]).
+/// `CREATE INDEX [name] [IF NOT EXISTS] FOR (n:Label) ON (n.a[, n.b, …])`
+/// (and the legacy `ON :Label(a[, b, …])` form). A standalone schema
+/// command executed out-of-band by the server (see
+/// [`Query::as_create_index`]). One property = the classic equality index;
+/// two or more = a composite (tuple) index in declaration order.
 #[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
 pub struct CreateIndexClause {
     pub name: Option<Identifier>,
     pub label: Identifier,
-    pub property: Identifier,
+    /// Properties in declaration order. Length >= 1.
+    pub properties: Vec<Identifier>,
     pub if_not_exists: bool,
     pub span: SourceSpan,
 }

--- a/crates/namidb-query/src/parser/display.rs
+++ b/crates/namidb-query/src/parser/display.rs
@@ -238,7 +238,8 @@ impl fmt::Display for CreateIndexClause {
         if self.if_not_exists {
             f.write_str("IF NOT EXISTS ")?;
         }
-        write!(f, "FOR (n:{}) ON (n.{})", self.label, self.property)
+        let properties: Vec<String> = self.properties.iter().map(|p| format!("n.{p}")).collect();
+        write!(f, "FOR (n:{}) ON ({})", self.label, properties.join(", "))
     }
 }
 

--- a/crates/namidb-query/src/parser/grammar.rs
+++ b/crates/namidb-query/src/parser/grammar.rs
@@ -886,27 +886,35 @@ impl<'src> Parser<'src> {
         self.expect_soft_keyword("INDEX")?;
         let name = self.parse_optional_ddl_name();
         let if_not_exists = self.parse_if_not_exists()?;
-        let (label, property, end);
+        let (label, properties, end);
         if self.eat(&Token::On).is_some() {
-            // Legacy: ON :Label(prop)
+            // Legacy: ON :Label(a[, b, …])
             self.expect(&Token::Colon)?;
             label = self.expect_identifier()?;
             self.expect(&Token::LParen)?;
-            property = self.expect_identifier()?;
+            let mut props = vec![self.expect_identifier()?];
+            while self.eat(&Token::Comma).is_some() {
+                props.push(self.expect_identifier()?);
+            }
+            properties = props;
             end = self.expect_in(&Token::RParen, "index target")?.span.end;
         } else {
-            // Modern: FOR (n:Label) ON (n.prop)
+            // Modern: FOR (n:Label) ON (n.a[, n.b, …])
             self.expect_soft_keyword("FOR")?;
             label = self.parse_ddl_node_target()?;
             self.expect_in(&Token::On, "index requires `ON (n.prop)`")?;
             self.expect(&Token::LParen)?;
-            property = self.parse_ddl_property_ref()?;
+            let mut props = vec![self.parse_ddl_property_ref()?];
+            while self.eat(&Token::Comma).is_some() {
+                props.push(self.parse_ddl_property_ref()?);
+            }
+            properties = props;
             end = self.expect_in(&Token::RParen, "index target")?.span.end;
         }
         Ok(CreateIndexClause {
             name,
             label,
-            property,
+            properties,
             if_not_exists,
             span: SourceSpan::new(start, end),
         })
@@ -2725,6 +2733,38 @@ mod tests {
         }
     }
 
+    /// Composite `CREATE INDEX ... ON (n.a, n.b)` parses in both forms and
+    /// round-trips through Display; the single-property form is unchanged.
+    #[test]
+    fn create_index_accepts_property_lists() {
+        let q = ok("CREATE INDEX pair IF NOT EXISTS FOR (p:Person) ON (p.city, p.age)");
+        let ix = q.as_create_index().expect("create index");
+        assert_eq!(ix.name.as_ref().unwrap().name, "pair");
+        assert_eq!(
+            ix.properties
+                .iter()
+                .map(|p| p.name.as_str())
+                .collect::<Vec<_>>(),
+            ["city", "age"],
+            "declaration order must be preserved"
+        );
+        let rendered = format!("{}", q.head.clauses[0]);
+        assert!(
+            rendered.contains("ON (n.city, n.age)"),
+            "display: {rendered}"
+        );
+        ok(&rendered);
+
+        // Legacy form with a list.
+        let q = ok("CREATE INDEX ON :Person(city, age)");
+        let ix = q.as_create_index().unwrap();
+        assert_eq!(ix.properties.len(), 2);
+
+        // Single property: exactly as before.
+        let q = ok("CREATE INDEX FOR (p:Person) ON (p.city)");
+        assert_eq!(q.as_create_index().unwrap().properties.len(), 1);
+    }
+
     /// NDB-05: `reduce(acc = init, x IN list | expr)` parses; `reduce` stays
     /// a soft keyword (a plain call or a variable named `reduce` is intact).
     #[test]
@@ -3631,7 +3671,7 @@ mod tests {
             _ => panic!(),
         };
         assert!(c.if_not_exists);
-        assert_eq!(c.property.name, "email");
+        assert_eq!(c.properties[0].name, "email");
     }
 
     #[test]

--- a/crates/namidb-server/src/bolt.rs
+++ b/crates/namidb-server/src/bolt.rs
@@ -686,7 +686,7 @@ impl ServerBackend {
                 .await;
         }
         if let Some(c) = parsed.as_create_index() {
-            let properties = [c.property.name.clone()];
+            let properties: Vec<String> = c.properties.iter().map(|p| p.name.clone()).collect();
             return self
                 .run_create_property_ddl(
                     c.name.as_ref().map(|n| n.name.as_str()),

--- a/crates/namidb-server/src/lib.rs
+++ b/crates/namidb-server/src/lib.rs
@@ -2938,6 +2938,25 @@ async fn apply_create_index(
     Ok(version)
 }
 
+/// Apply a composite `CREATE INDEX ... ON (n.a, n.b, ...)` (length >= 2)
+/// and republish the snapshot. Records a named `IndexDef` in the schema;
+/// the DDL-triggered compaction then materializes the tuple posting
+/// sidecars on existing SSTs.
+async fn apply_create_composite_index(
+    writer: &mut WriterSession,
+    snapshot: &SnapshotCell,
+    name: Option<&str>,
+    label: &str,
+    properties: &[String],
+    if_not_exists: bool,
+) -> Result<u64, namidb_storage::Error> {
+    let version = writer
+        .create_composite_index_named(name, label, properties, if_not_exists)
+        .await?;
+    snapshot.store(writer.owned_snapshot());
+    Ok(version)
+}
+
 /// HTTP shape for `CREATE CONSTRAINT`/`CREATE INDEX`: gate on role + authz, run
 /// the schema DDL, return an empty `CypherResponse`. Mirrors the vector/fulltext
 /// DDL handlers. These are always-on (no Cargo feature).
@@ -2976,6 +2995,9 @@ async fn run_create_property_ddl(
     let op = if unique {
         authz::SchemaOp::CreateConstraint { label, properties }
     } else {
+        // A composite index reports its first member to the policy hook;
+        // the SchemaOp shape predates composites and widening it is a
+        // policy-API change to take deliberately.
         authz::SchemaOp::CreateIndex {
             label,
             property: &properties[0],
@@ -3010,6 +3032,8 @@ async fn run_create_property_ddl(
     }
     let result = if unique {
         apply_create_constraint(&mut w, snapshot, name, label, properties, if_not_exists).await
+    } else if properties.len() > 1 {
+        apply_create_composite_index(&mut w, snapshot, name, label, properties, if_not_exists).await
     } else {
         apply_create_index(&mut w, snapshot, name, label, &properties[0], if_not_exists).await
     };
@@ -3219,7 +3243,7 @@ async fn run_cypher(state: &AppState, req: &CypherRequest, principal: &Principal
         .await;
     }
     if let Some(c) = parsed.as_create_index() {
-        let properties = [c.property.name.clone()];
+        let properties: Vec<String> = c.properties.iter().map(|p| p.name.clone()).collect();
         return run_create_property_ddl(
             &state.writer,
             &state.snapshot,
@@ -4101,7 +4125,7 @@ async fn run_cypher_multi(
         .await;
     }
     if let Some(c) = parsed.as_create_index() {
-        let properties = [c.property.name.clone()];
+        let properties: Vec<String> = c.properties.iter().map(|p| p.name.clone()).collect();
         return run_create_property_ddl(
             &ns_state.writer,
             &ns_state.snapshot,

--- a/crates/namidb-storage/src/ingest.rs
+++ b/crates/namidb-storage/src/ingest.rs
@@ -2931,7 +2931,13 @@ impl WriterSession {
         let dtype = declared_type.unwrap_or_else(|| inferred.unwrap_or(DataType::Utf8));
         let mut schema = self.current.manifest.schema.clone();
         upsert_property_flags(&mut schema, label, property, dtype, unique, indexed)?;
+        self.commit_schema_ddl(schema).await
+    }
 
+    /// Commit an updated schema (metadata-only manifest bump), retiring
+    /// signature-stale search generations and resetting the caches whose
+    /// contents key off the schema. Shared tail of every property/index DDL.
+    async fn commit_schema_ddl(&mut self, schema: Schema) -> Result<u64> {
         let mut next = self.current.manifest.next_version(self.fence.writer_id);
         next.schema = schema;
         #[cfg(any(feature = "vector-index", feature = "text-index"))]
@@ -2955,6 +2961,119 @@ impl WriterSession {
         self.property_index_cache.reset_preserving_node_counts();
         self.unique_index.reset();
         Ok(version)
+    }
+
+    /// `CREATE INDEX [name] [IF NOT EXISTS] FOR (n:Label) ON (n.a, n.b, …)`
+    /// — the composite (length >= 2) form. Unlike the single-property flag
+    /// on [`namidb_core::schema::PropertyDef`], composite indexes are
+    /// recorded as named [`namidb_core::schema::IndexDef`]s in
+    /// `Schema.indexes`, DECLARATION order preserved — it defines the tuple
+    /// key layout of the posting sidecar. Member properties get their type
+    /// declared (inferred from the first live value when absent) WITHOUT
+    /// setting the single-property `indexed` flag.
+    pub async fn create_composite_index_named(
+        &mut self,
+        name: Option<&str>,
+        label: &str,
+        properties: &[String],
+        if_not_exists: bool,
+    ) -> Result<u64> {
+        use namidb_core::schema::IndexDef;
+        self.fence.assert_alive(self.current.manifest.epoch)?;
+        if properties.len() < 2 {
+            return Err(Error::precondition(
+                "a composite index needs at least two properties; use the \
+                 single-property CREATE INDEX form",
+            ));
+        }
+        let mut deduped: Vec<&String> = properties.iter().collect();
+        deduped.sort();
+        deduped.dedup();
+        if deduped.len() != properties.len() {
+            return Err(Error::precondition(format!(
+                "duplicate property in composite index over {label}: {properties:?}"
+            )));
+        }
+        let name = match name {
+            Some(explicit) => explicit.to_string(),
+            None => IndexDef::default_name(label, properties),
+        };
+        if let Some(existing) = self
+            .current
+            .manifest
+            .schema
+            .indexes
+            .iter()
+            .find(|index| index.matches(label, properties))
+        {
+            if if_not_exists {
+                return Ok(self.current.manifest.version);
+            }
+            return Err(Error::precondition(format!(
+                "index `{}` on {label}({}) already exists",
+                existing.name,
+                existing.properties.join(", ")
+            )));
+        }
+        if self
+            .current
+            .manifest
+            .schema
+            .indexes
+            .iter()
+            .any(|index| index.name == name)
+        {
+            return Err(Error::precondition(format!(
+                "an index named `{name}` already exists"
+            )));
+        }
+
+        // Resolve each member's type first (immutable phase: the inference
+        // scan borrows a snapshot), then mutate and commit.
+        let mut member_types: Vec<(String, DataType)> = Vec::with_capacity(properties.len());
+        {
+            let snap = self.snapshot();
+            for property in properties {
+                let declared = self
+                    .current
+                    .manifest
+                    .schema
+                    .label(label)
+                    .and_then(|l| l.properties.iter().find(|p| p.name == *property))
+                    .map(|p| p.data_type.clone());
+                let dtype = match declared {
+                    Some(dtype) => dtype,
+                    None => {
+                        let mut inferred: Option<DataType> = None;
+                        for node in snap.scan_label(label).await? {
+                            let Some(v) = node.properties.get(property) else {
+                                continue;
+                            };
+                            if matches!(v, Value::Null) {
+                                continue;
+                            }
+                            inferred = value_datatype(v);
+                            break;
+                        }
+                        inferred.unwrap_or(DataType::Utf8)
+                    }
+                };
+                member_types.push((property.clone(), dtype));
+            }
+        }
+        let mut schema = self.current.manifest.schema.clone();
+        for (property, dtype) in member_types {
+            // `false, false`: declare the type only; per-property flags are
+            // OR-preserved by `upsert_property_flags`, so an existing
+            // single-property index/constraint on a member is untouched.
+            upsert_property_flags(&mut schema, label, &property, dtype, false, false)?;
+        }
+        schema.indexes.push(IndexDef {
+            name,
+            label: label.to_string(),
+            properties: properties.to_vec(),
+        });
+        self.commit_schema_ddl(schema).await
     }
 
     /// Test-only: commit `schema` directly WITHOUT retiring signature-stale

--- a/crates/namidb-storage/tests/composite_index_ddl.rs
+++ b/crates/namidb-storage/tests/composite_index_ddl.rs
@@ -1,0 +1,114 @@
+//! Composite `CREATE INDEX` DDL (phase 1 of the tuple posting index): the
+//! schema records a named, declaration-ordered `IndexDef`, the definition
+//! survives a session reopen from the manifest, and the guard rails
+//! (IF NOT EXISTS as a set match, duplicate names, duplicate members,
+//! arity) hold.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use namidb_core::id::{NamespaceId, NodeId};
+use namidb_core::value::Value;
+use namidb_storage::{NamespacePaths, NodeWriteRecord, WriterSession};
+use object_store::memory::InMemory;
+use object_store::ObjectStore;
+
+fn store() -> Arc<dyn ObjectStore> {
+    Arc::new(InMemory::new())
+}
+
+fn paths(name: &str) -> NamespacePaths {
+    NamespacePaths::new("tenants", NamespaceId::new(name).unwrap())
+}
+
+#[tokio::test]
+async fn composite_index_ddl_persists_and_guards() {
+    let shared = store();
+    let mut w = WriterSession::open(shared.clone(), paths("cix"))
+        .await
+        .unwrap();
+    // A live row so member-type inference has something to look at.
+    let mut props: BTreeMap<String, Value> = BTreeMap::new();
+    props.insert("city".into(), Value::Str("quito".into()));
+    props.insert("age".into(), Value::I64(30));
+    w.upsert_node(
+        "Person",
+        NodeId::new(),
+        &NodeWriteRecord {
+            properties: props,
+            schema_version: 1,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    w.commit_batch().await.unwrap();
+
+    // Create with an explicit name; declaration order must persist.
+    let v1 = w
+        .create_composite_index_named(
+            Some("pair"),
+            "Person",
+            &["city".into(), "age".into()],
+            false,
+        )
+        .await
+        .unwrap();
+    let snap = w.snapshot();
+    let schema = &snap.manifest().manifest.schema;
+    assert_eq!(schema.indexes.len(), 1);
+    let index = &schema.indexes[0];
+    assert_eq!(index.name, "pair");
+    assert_eq!(index.properties, ["city".to_string(), "age".to_string()]);
+    // Member types were declared from live values, flags untouched.
+    let label = schema.label("Person").unwrap();
+    let age = label.properties.iter().find(|p| p.name == "age").unwrap();
+    assert!(!age.indexed && !age.unique, "member flags must stay clear");
+
+    // IF NOT EXISTS matches the SET (either order) and no-ops.
+    let v2 = w
+        .create_composite_index_named(None, "Person", &["age".into(), "city".into()], true)
+        .await
+        .unwrap();
+    assert_eq!(v1, v2, "IF NOT EXISTS over the same set must be a no-op");
+    // Without IF NOT EXISTS it errors.
+    let err = w
+        .create_composite_index_named(None, "Person", &["age".into(), "city".into()], false)
+        .await
+        .unwrap_err();
+    assert!(err.to_string().contains("already exists"), "{err}");
+    // Name collision with a different definition errors.
+    let err = w
+        .create_composite_index_named(
+            Some("pair"),
+            "Person",
+            &["city".into(), "name".into()],
+            false,
+        )
+        .await
+        .unwrap_err();
+    assert!(err.to_string().contains("named `pair`"), "{err}");
+    // Arity and duplicate-member guards.
+    let err = w
+        .create_composite_index_named(None, "Person", &["city".into()], false)
+        .await
+        .unwrap_err();
+    assert!(err.to_string().contains("at least two"), "{err}");
+    let err = w
+        .create_composite_index_named(None, "Person", &["city".into(), "city".into()], false)
+        .await
+        .unwrap_err();
+    assert!(err.to_string().contains("duplicate property"), "{err}");
+
+    // The definition survives a fresh session over the same store.
+    drop(w);
+    let w2 = WriterSession::open(shared, paths("cix")).await.unwrap();
+    let snap2 = w2.snapshot();
+    let schema = &snap2.manifest().manifest.schema;
+    assert_eq!(schema.indexes.len(), 1);
+    assert_eq!(schema.indexes[0].name, "pair");
+    assert_eq!(
+        schema.indexes[0].properties,
+        ["city".to_string(), "age".to_string()],
+        "declaration order must survive the manifest round-trip"
+    );
+}


### PR DESCRIPTION
Phase 1 of the composite (tuple) equality index — the first report's long-haul remainder (recon-mapped at ~2.5–3 engineer-weeks across 5 phases; full map preserved in `$HOME/namidb-validation/composite-recon.json`).

- **Schema**: `Schema.indexes: Vec<IndexDef>` — named, declaration-ordered (the order defines the future tuple key layout), `serde(default)`, set-matching `IF NOT EXISTS`, deterministic default names. Single-property indexes stay flag-based for full compatibility.
- **Parser**: `CreateIndexClause` widened to a property list in both grammar forms; Display round-trips; single-property rendering unchanged.
- **Storage**: `create_composite_index_named` — member type inference without touching per-property flags; arity/duplicate/name-collision guards; DDL commit tail extracted into `commit_schema_ddl` (shared).
- **Surfaces**: server HTTP (both tenants; `len > 1` routes to `apply_create_composite_index`, still firing the `CompactionTrigger::Ddl` backfill), Bolt, CLI, Python client, and `SHOW INDEXES`.
- **Semantics of this phase**: composite DDL is accepted, durable, and backfill-triggered; queries keep their correct scan route until phases 2–4 (TupleV1 sidecar, freshness-gated reads, planner routing) make them fast.

Tests: parser round-trips, storage persistence across reopen + all guards, CLI script with a composite statement. Full workspace suites + clippy green.