### PR TITLE
fix: remove a stray field inserted into the FROZEN 204 wire struct

### DIFF
--- a/crates/namidb-storage/tests/manifest_rollback_204.rs
+++ b/crates/namidb-storage/tests/manifest_rollback_204.rs
@@ -67,7 +67,6 @@ struct SstDescriptor204 {
     unique_property_indices: Vec<UniquePropertyIndexDescriptor204>,
     #[serde(default)]
     equality_property_indices: Vec<EqualityIndexDescriptor204>,
-    composite_equality_indices: Vec::new(),
     #[serde(default)]
     label_index: Option<LabelIndexDescriptor>,
     #[serde(default)]


### PR DESCRIPTION
Hotfix for PR #156, which merged with a red suite (process failure, recorded): the blanket constructor-fill landed one line inside `SstDescriptor204` — the deliberately frozen 2.0.4 wire-compat struct — as invalid syntax. The literal at the bottom of that test builds the CURRENT descriptor and correctly keeps the field; only the frozen definition reverts. `manifest_rollback_204` passes again; storage+query suites and clippy verified green BEFORE this merge.