### PR TITLE
Composite indexes phase 2: tuple posting sidecars in flush + compaction

### DIFF
--- a/crates/namidb-storage/src/compact.rs
+++ b/crates/namidb-storage/src/compact.rs
@@ -350,7 +350,19 @@ fn any_bucket_plans(manifest: &crate::manifest::Manifest, base_bytes: u64, ratio
                         properties: Vec::new(),
                     })
             };
-            plan_node_bucket(sources, base_bytes, ratio, &required, rebuild_search).is_some()
+            plan_node_bucket(
+                sources,
+                base_bytes,
+                ratio,
+                &required,
+                if scope.is_empty() {
+                    &manifest.schema.indexes
+                } else {
+                    &[]
+                },
+                rebuild_search,
+            )
+            .is_some()
         } else {
             plan_bucket_merge(sources, base_bytes, ratio).is_some()
         }
@@ -500,6 +512,7 @@ fn plan_node_bucket<'a>(
     base: u64,
     ratio: u64,
     required: &LabelDef,
+    composite: &[namidb_core::schema::IndexDef],
     force_search_rebuild: bool,
 ) -> Option<BucketPlan<'a>> {
     if let Some(plan) = plan_bucket_merge(sources, base, ratio) {
@@ -508,7 +521,7 @@ fn plan_node_bucket<'a>(
     let needs_migration = force_search_rebuild
         || sources
             .iter()
-            .any(|desc| node_descriptor_needs_migration(desc, required));
+            .any(|desc| node_descriptor_needs_migration(desc, required, composite));
     if !needs_migration || sources.is_empty() {
         return None;
     }
@@ -525,10 +538,14 @@ fn plan_node_bucket<'a>(
     })
 }
 
-fn node_descriptor_needs_migration(desc: &SstDescriptor, required: &LabelDef) -> bool {
+fn node_descriptor_needs_migration(
+    desc: &SstDescriptor,
+    required: &LabelDef,
+    composite: &[namidb_core::schema::IndexDef],
+) -> bool {
     !crate::manifest::node_locator_has_exact_records(desc)
         || !node_descriptor_has_property_pages(desc)
-        || node_descriptor_needs_non_record_migration(desc, required)
+        || node_descriptor_needs_non_record_migration(desc, required, composite)
 }
 
 fn node_descriptor_has_property_pages(desc: &SstDescriptor) -> bool {
@@ -539,7 +556,11 @@ fn node_descriptor_has_property_pages(desc: &SstDescriptor) -> bool {
     })
 }
 
-fn node_descriptor_needs_non_record_migration(desc: &SstDescriptor, required: &LabelDef) -> bool {
+fn node_descriptor_needs_non_record_migration(
+    desc: &SstDescriptor,
+    required: &LabelDef,
+    composite: &[namidb_core::schema::IndexDef],
+) -> bool {
     let required_equality: Vec<&str> = required
         .properties
         .iter()
@@ -567,6 +588,17 @@ fn node_descriptor_needs_non_record_migration(desc: &SstDescriptor, required: &L
                 && (index.format == crate::manifest::PropertyIndexFormat::PagedV1
                     || index.paged.is_some()
                     || index.paged_build_unsupported)
+        })
+        // The DDL-backfill arm for composite indexes (mirrors item 38's
+        // single-property arm): a declared composite index whose exact
+        // DECLARATION-ordered tuple has no sidecar on this SST forces the
+        // full-bucket rewrite, which is what makes CompactionTrigger::Ddl
+        // materialize tuple postings on pre-existing data for free.
+    }) || composite.iter().any(|declared| {
+        !desc.composite_equality_indices.iter().any(|index| {
+            index.properties == declared.properties
+                && index.mixed_type_complete
+                && (!index.path.is_empty() || index.paged_build_unsupported)
         })
     })
 }
@@ -1298,9 +1330,18 @@ async fn prepare_leveled(
         } else {
             label_def.clone()
         };
-        let Some(plan) =
-            plan_node_bucket(&sources, base_bytes, ratio, &sidecar_def, rebuild_search)
-        else {
+        let Some(plan) = plan_node_bucket(
+            &sources,
+            base_bytes,
+            ratio,
+            &sidecar_def,
+            if label.is_empty() {
+                &schema.indexes
+            } else {
+                &[]
+            },
+            rebuild_search,
+        ) else {
             continue;
         };
         // A lone, otherwise-current legacy SST needs only its access bundle
@@ -1312,7 +1353,15 @@ async fn prepare_leveled(
         if plan.inputs.len() == 1
             && (!crate::manifest::node_locator_has_exact_records(plan.inputs[0])
                 || !node_descriptor_has_property_pages(plan.inputs[0]))
-            && !node_descriptor_needs_non_record_migration(plan.inputs[0], &sidecar_def)
+            && !node_descriptor_needs_non_record_migration(
+                plan.inputs[0],
+                &sidecar_def,
+                if label.is_empty() {
+                    &schema.indexes
+                } else {
+                    &[]
+                },
+            )
             && !rebuild_search
         {
             let source = (*plan.inputs[0]).clone();
@@ -2942,6 +2991,7 @@ fn partition_index_build_memory(aggregate: usize, collector_count: usize) -> Res
 struct NodeSidecarHarvest {
     unique: UniqueSidecarCollector,
     equality: EqualitySidecarCollector,
+    composite: crate::flush::CompositeSidecarCollector,
     label_index: LabelIndexCollector,
     node_locator_upload: crate::sst::paged_index::NodeLocatorRecordUpload,
     property_pages_upload: crate::sst::nodes::property_pages::NodePropertyPageUpload,
@@ -3020,6 +3070,14 @@ fn merge_node_sources(
     let mut writer = IncrementalNodeSstWriter::new(label_def, options, merge_chunk_rows())?;
     let mut unique = UniqueSidecarCollector::new(sidecar_def)?;
     let mut equality = EqualitySidecarCollector::new(sidecar_def)?;
+    // Composite tuple sidecars are an id-primary concern (flush harvests
+    // them on that path only); legacy per-label buckets carry none.
+    let composite_defs: &[namidb_core::schema::IndexDef] = if bucket_scope.is_empty() {
+        &schema.indexes
+    } else {
+        &[]
+    };
+    let mut composite = crate::flush::CompositeSidecarCollector::new(composite_defs)?;
     let mut label_index = LabelIndexCollector::new()?;
     let mut node_locator_records = crate::sst::paged_index::NodeLocatorRecordBuilder::new();
     let mut property_pages = crate::sst::nodes::property_pages::NodePropertyPageBuilder::new_bound(
@@ -3110,6 +3168,7 @@ fn merge_node_sources(
                 if let Some(rec) = &rec {
                     unique.observe(row.id, rec)?;
                     equality.observe(row.id, rec)?;
+                    composite.observe(row.id, rec)?;
                     label_index.observe(row.id, rec)?;
                     stats.observe(rec);
                     #[cfg(feature = "vector-index")]
@@ -3163,6 +3222,7 @@ fn merge_node_sources(
         sidecars: NodeSidecarHarvest {
             unique,
             equality,
+            composite,
             label_index,
             node_locator_upload,
             property_pages_upload,
@@ -3828,6 +3888,13 @@ async fn put_node_sst_leveled(
             .equality
             .finish(paths, level.as_u32(), &id, label)?;
     index_sidecars.extend(equality_sidecars);
+    // Composite tuple sidecars are re-emitted from the same reconciled
+    // winner stream, superseding the input SSTs' partials.
+    let (composite_equality_indices, composite_sidecars) =
+        sidecars
+            .composite
+            .finish(paths, level.as_u32(), &id, label)?;
+    index_sidecars.extend(composite_sidecars);
     // Rebuild the label-index sidecar from the reconciled rows. id-primary
     // buckets (scope == "") carry per-row label sets, so this re-emits the
     // `LabelId -> [NodeId]` postings (with per-label counts) the cost model
@@ -3883,7 +3950,7 @@ async fn put_node_sst_leveled(
         bloom: bloom_descriptor,
         unique_property_indices,
         equality_property_indices,
-        composite_equality_indices: Vec::new(),
+        composite_equality_indices,
         label_index,
         node_locator: Some(node_locator),
         // Per-(label, property) stats recomputed off the winner stream so
@@ -6762,7 +6829,7 @@ mod tests {
             .collect();
         let required = crate::flush::union_indexed_props(&sc);
         assert!(
-            plan_node_bucket(&incomplete_refs, u64::MAX, 10, &required, false).is_some(),
+            plan_node_bucket(&incomplete_refs, u64::MAX, 10, &required, &[], false).is_some(),
             "an incomplete-coverage marker must force a one-time rewrite"
         );
 
@@ -6794,7 +6861,7 @@ mod tests {
             .collect();
         let required = crate::flush::union_indexed_props(&sc);
         let migration =
-            plan_node_bucket(&refs, u64::MAX, 10, &required, false).expect("migration plan");
+            plan_node_bucket(&refs, u64::MAX, 10, &required, &[], false).expect("migration plan");
         assert_eq!(migration.inputs.len(), 1);
         assert_eq!(migration.target_level, 1);
 
@@ -6844,7 +6911,7 @@ mod tests {
 
         let upgraded_refs = vec![upgraded];
         assert!(
-            plan_node_bucket(&upgraded_refs, u64::MAX, 10, &required, false).is_none(),
+            plan_node_bucket(&upgraded_refs, u64::MAX, 10, &required, &[], false).is_none(),
             "migration must not rewrite the same L1 again"
         );
     }
@@ -6954,7 +7021,7 @@ mod tests {
 
         let required = crate::flush::union_indexed_props(&sc);
         assert!(
-            plan_node_bucket(&[upgraded], u64::MAX, 10, &required, false).is_none(),
+            plan_node_bucket(&[upgraded], u64::MAX, 10, &required, &[], false).is_none(),
             "the completed access bundle must not schedule another migration"
         );
     }
@@ -7012,7 +7079,7 @@ mod tests {
             .filter(|sst| sst.kind == SstKind::Nodes)
             .collect();
         let required = crate::flush::union_indexed_props(&indexed_schema);
-        assert!(plan_node_bucket(&refs, u64::MAX, 10, &required, false).is_some());
+        assert!(plan_node_bucket(&refs, u64::MAX, 10, &required, &[], false).is_some());
 
         let out = compact_leveled(&ms, &fence, &ddl, &indexed_schema, u64::MAX, 10)
             .await
@@ -7030,7 +7097,7 @@ mod tests {
             .any(|index| index.property == "name" && index.paged.is_some()));
         let refs = vec![node];
         assert!(
-            plan_node_bucket(&refs, u64::MAX, 10, &required, false).is_none(),
+            plan_node_bucket(&refs, u64::MAX, 10, &required, &[], false).is_none(),
             "the DDL migration must be a one-time rewrite"
         );
     }
@@ -7092,7 +7159,7 @@ mod tests {
         let refs = vec![node];
         let required = crate::flush::union_indexed_props(&indexed_schema);
         assert!(
-            plan_node_bucket(&refs, u64::MAX, 10, &required, false).is_none(),
+            plan_node_bucket(&refs, u64::MAX, 10, &required, &[], false).is_none(),
             "unsupported PagedV1 key must not trigger endless maintenance"
         );
     }

--- a/crates/namidb-storage/src/flush.rs
+++ b/crates/namidb-storage/src/flush.rs
@@ -957,6 +957,11 @@ fn prepare_node_pending(
     let (equality_property_indices, equality_sidecars) =
         prepare_equality_property_sidecars(paths, level.as_u32(), &id, "", label_def, rows)?;
     index_sidecars.extend(equality_sidecars);
+    // Composite (tuple) sidecars, one per declared composite index. Same
+    // stream, same coverage-marker rule.
+    let (composite_equality_indices, composite_sidecars) =
+        prepare_composite_property_sidecars(paths, level.as_u32(), &id, "", &schema.indexes, rows)?;
+    index_sidecars.extend(composite_sidecars);
 
     // The label index (`LabelId -> [NodeId, ...]`) replaces "the SST partition
     // IS the label index" now that one node SST spans every label.
@@ -1037,7 +1042,7 @@ fn prepare_node_pending(
         bloom: bloom_descriptor,
         unique_property_indices,
         equality_property_indices,
-        composite_equality_indices: Vec::new(),
+        composite_equality_indices,
         label_index,
         node_locator: Some(node_locator),
         per_label_property_stats: compute_per_label_property_stats(rows, schema, label_dict)?,
@@ -2019,6 +2024,195 @@ impl EqualitySidecarCollector {
         }
         Ok((descriptors, bodies))
     }
+}
+
+/// Streaming harvester for COMPOSITE (tuple) posting sidecars — the
+/// TupleV1 analogue of [`EqualitySidecarCollector`]. One sidecar per
+/// declared composite index (deduplicated by property list: the harvest is
+/// label-agnostic, mirroring the single-property doctrine that coverage
+/// follows the stored value and readers confirm candidates). A row is
+/// filed only when EVERY member is present and indexable — a missing or
+/// unindexable member makes the tuple unmatchable by an indexable probe,
+/// exactly like the transactional tuple probe's rules.
+#[derive(Debug)]
+pub(crate) struct CompositeSidecarCollector {
+    /// Deduplicated member lists, each in DECLARATION order.
+    tuples: Vec<Vec<String>>,
+    sorter: crate::sst::external_pairs::ExternalPairSorter,
+}
+
+impl CompositeSidecarCollector {
+    pub(crate) fn new(indexes: &[namidb_core::schema::IndexDef]) -> Result<Self> {
+        let mut tuples: Vec<Vec<String>> = Vec::new();
+        for index in indexes {
+            if !tuples.contains(&index.properties) {
+                tuples.push(index.properties.clone());
+            }
+        }
+        u32::try_from(tuples.len())
+            .map_err(|_| Error::invariant("composite index count exceeds u32"))?;
+        Ok(Self {
+            tuples,
+            sorter: crate::sst::external_pairs::ExternalPairSorter::from_env()?,
+        })
+    }
+
+    pub(crate) fn observe(&mut self, id: [u8; 16], rec: &NodeWriteRecord) -> Result<()> {
+        for (ordinal, members) in self.tuples.iter().enumerate() {
+            let values: Option<Vec<&namidb_core::Value>> = members
+                .iter()
+                .map(|name| rec.properties.get(name))
+                .collect();
+            let Some(values) = values else {
+                continue;
+            };
+            if let Some(key) = crate::cache::encode_equality_tuple_key(&values) {
+                self.sorter.push(ordinal as u32, &key, id)?;
+            }
+        }
+        Ok(())
+    }
+
+    /// Serialise one PagedV1 sidecar per composite index, INCLUDING an
+    /// empty one — the descriptor doubles as the coverage marker, exactly
+    /// like the single-property rule: readers prove completeness only when
+    /// every node SST advertises the tuple.
+    pub(crate) fn finish(
+        self,
+        paths: &NamespacePaths,
+        level: u32,
+        sst_id: &Uuid,
+        label: &str,
+    ) -> Result<CompositePropertySidecars> {
+        let mut sorted = self.sorter.finish()?;
+        let mut builders: Vec<_> = self
+            .tuples
+            .iter()
+            .map(|_| crate::sst::paged_index::SortedSpooledPagedIndexBuilder::equality())
+            .collect();
+        let mut distinct_counts = vec![0_u64; self.tuples.len()];
+        // Tuple sidecars have no legacy bincode body (they postdate the
+        // rolling-upgrade window that body served), so the legacy slots stay
+        // empty in the shared posting finisher.
+        let mut legacy: Vec<Option<LegacyMapSpool>> = self.tuples.iter().map(|_| None).collect();
+        let mut posting: Option<PendingExternalPosting> = None;
+        while let Some(pair) = sorted.next_pair()? {
+            if pair.property as usize >= builders.len() {
+                return Err(Error::invariant(
+                    "composite-index scratch ordinal is out of range",
+                ));
+            }
+            if posting
+                .as_ref()
+                .is_some_and(|active| active.property != pair.property || active.key != pair.key)
+            {
+                finish_external_posting(
+                    posting.take().expect("active posting checked above"),
+                    &mut builders,
+                    &mut distinct_counts,
+                    &mut legacy,
+                )?;
+            }
+            if posting.is_none() {
+                posting = Some(PendingExternalPosting::new(pair.property, pair.key)?);
+            }
+            posting
+                .as_mut()
+                .expect("posting initialized above")
+                .push(pair.id)?;
+        }
+        if let Some(posting) = posting {
+            finish_external_posting(posting, &mut builders, &mut distinct_counts, &mut legacy)?;
+        }
+
+        let mut descriptors = Vec::new();
+        let mut bodies = Vec::new();
+        for ((members, builder), distinct_values) in
+            self.tuples.into_iter().zip(builders).zip(distinct_counts)
+        {
+            let declined = builder.declined();
+            let slug = composite_sidecar_slug(&members);
+            if declined {
+                // No legacy fallback exists for tuples: record the decline so
+                // the migration predicate does not rewrite this SST forever,
+                // and readers fall back to the scan for it.
+                descriptors.push(crate::manifest::CompositeEqualityIndexDescriptor {
+                    properties: members,
+                    path: String::new(),
+                    size_bytes: 0,
+                    distinct_values,
+                    mixed_type_complete: true,
+                    key_encoding: crate::manifest::CompositeKeyEncoding::TupleV1,
+                    format: crate::manifest::PropertyIndexFormat::PagedV1,
+                    paged: None,
+                    paged_build_unsupported: true,
+                });
+                continue;
+            }
+            let upload = builder.finish()?;
+            let paged_name = format!(
+                "{}-{}-{}.eqtix_{}.pidx",
+                uuid_path_id(sst_id),
+                SstKind::Nodes.path_tag(),
+                label,
+                slug,
+            );
+            let paged_path = paths.sst_object(level, &paged_name);
+            let paged_relative = relative_sst_path(level, &paged_name);
+            descriptors.push(crate::manifest::CompositeEqualityIndexDescriptor {
+                properties: members,
+                path: paged_relative,
+                size_bytes: upload.size_bytes(),
+                distinct_values,
+                mixed_type_complete: true,
+                key_encoding: crate::manifest::CompositeKeyEncoding::TupleV1,
+                format: crate::manifest::PropertyIndexFormat::PagedV1,
+                paged: None,
+                paged_build_unsupported: false,
+            });
+            bodies.push((paged_path, SidecarPayload::Paged(upload)));
+        }
+        Ok((descriptors, bodies))
+    }
+}
+
+/// Filename slug for a composite sidecar: member names joined by `+`
+/// (identifier-safe by PropertyDef validation), hash-capped so a long
+/// member list cannot overflow filename limits.
+fn composite_sidecar_slug(members: &[String]) -> String {
+    let joined = members.join("+");
+    if joined.len() <= 96 {
+        joined
+    } else {
+        format!("{:016x}", xxhash_rust::xxh3::xxh3_64(joined.as_bytes()))
+    }
+}
+
+/// One composite index's harvested `tuple -> [id, ...]` postings plus the
+/// descriptor list, mirroring [`EqualityPropertySidecars`].
+pub(crate) type CompositePropertySidecars = (
+    Vec<crate::manifest::CompositeEqualityIndexDescriptor>,
+    Vec<(Path, SidecarPayload)>,
+);
+
+/// Harvest tuple sidecars for every declared composite index, feeding the
+/// same reconciled row stream the single-property harvest sees.
+pub(crate) fn prepare_composite_property_sidecars(
+    paths: &NamespacePaths,
+    level: u32,
+    sst_id: &Uuid,
+    label: &str,
+    indexes: &[namidb_core::schema::IndexDef],
+    rows: &[NodeRow],
+) -> Result<CompositePropertySidecars> {
+    let mut collector = CompositeSidecarCollector::new(indexes)?;
+    for row in rows {
+        if let MemOp::Upsert(payload) = &row.op {
+            let rec = NodeWriteRecord::decode(payload)?;
+            collector.observe(row.id, &rec)?;
+        }
+    }
+    collector.finish(paths, level, sst_id, label)
 }
 
 struct PendingExternalPosting {

--- a/crates/namidb-storage/tests/composite_index_sidecars.rs
+++ b/crates/namidb-storage/tests/composite_index_sidecars.rs
@@ -1,0 +1,215 @@
+//! Composite tuple sidecars (phase 2 of the tuple posting index): flush
+//! harvests one PagedV1 `tuple -> [id]` sidecar per declared composite
+//! index from the reconciled row stream, compaction re-emits it from the
+//! merged winners, and the DDL-backfill arm of the migration predicate
+//! forces a rewrite of any pre-existing SST that lacks the declared tuple
+//! (the item-38 rule generalized to declaration-ordered member lists).
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use namidb_core::id::{NamespaceId, NodeId};
+use namidb_core::schema::{DataType, IndexDef, LabelDef, PropertyDef, Schema, SchemaBuilder};
+use namidb_core::value::Value;
+use namidb_storage::manifest::{CompositeEqualityIndexDescriptor, SstKind};
+use namidb_storage::{NamespacePaths, NodeWriteRecord, WriterSession};
+use object_store::memory::InMemory;
+use object_store::ObjectStore;
+
+fn plain_schema() -> Schema {
+    SchemaBuilder::new()
+        .label(LabelDef {
+            name: "Person".into(),
+            properties: vec![
+                PropertyDef::new("city", DataType::Utf8, false).unwrap(),
+                PropertyDef::new("age", DataType::Int64, false).unwrap(),
+            ],
+        })
+        .unwrap()
+        .build()
+}
+
+fn indexed_schema() -> Schema {
+    let mut schema = plain_schema();
+    schema.indexes.push(IndexDef {
+        name: "pair".into(),
+        label: "Person".into(),
+        properties: vec!["city".into(), "age".into()],
+    });
+    schema
+}
+
+fn person(city: &str, age: i64) -> NodeWriteRecord {
+    let mut props: BTreeMap<String, Value> = BTreeMap::new();
+    props.insert("city".into(), Value::Str(city.into()));
+    props.insert("age".into(), Value::I64(age));
+    NodeWriteRecord {
+        properties: props,
+        schema_version: 1,
+        ..Default::default()
+    }
+}
+
+async fn open(store: &Arc<dyn ObjectStore>, name: &str) -> (WriterSession, NamespacePaths) {
+    let paths = NamespacePaths::new("tenants", NamespaceId::new(name).unwrap());
+    let writer = WriterSession::open(store.clone(), paths.clone())
+        .await
+        .unwrap();
+    (writer, paths)
+}
+
+/// Every node-SST descriptor's composite entries, flattened.
+fn composite_entries(writer: &WriterSession) -> Vec<CompositeEqualityIndexDescriptor> {
+    let snap = writer.snapshot();
+    snap.manifest()
+        .manifest
+        .ssts
+        .iter()
+        .filter(|d| d.kind == SstKind::Nodes)
+        .flat_map(|d| d.composite_equality_indices.iter().cloned())
+        .collect()
+}
+
+fn node_sst_count(writer: &WriterSession) -> usize {
+    let snap = writer.snapshot();
+    snap.manifest()
+        .manifest
+        .ssts
+        .iter()
+        .filter(|d| d.kind == SstKind::Nodes)
+        .count()
+}
+
+#[tokio::test]
+async fn flush_emits_a_tuple_sidecar_per_composite_index() {
+    let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    let (mut w, _) = open(&store, "cix-flush").await;
+
+    // Three distinct tuples across four complete rows; the fifth row is
+    // missing a member and must stay unfiled without poisoning the sidecar.
+    w.upsert_node("Person", NodeId::new(), &person("quito", 30))
+        .unwrap();
+    w.upsert_node("Person", NodeId::new(), &person("quito", 30))
+        .unwrap();
+    w.upsert_node("Person", NodeId::new(), &person("quito", 31))
+        .unwrap();
+    w.upsert_node("Person", NodeId::new(), &person("lima", 30))
+        .unwrap();
+    let mut partial: BTreeMap<String, Value> = BTreeMap::new();
+    partial.insert("city".into(), Value::Str("cuenca".into()));
+    w.upsert_node(
+        "Person",
+        NodeId::new(),
+        &NodeWriteRecord {
+            properties: partial,
+            schema_version: 1,
+            ..Default::default()
+        },
+    )
+    .unwrap();
+    w.commit_batch().await.unwrap();
+    w.flush(indexed_schema()).await.unwrap();
+
+    let entries = composite_entries(&w);
+    assert_eq!(entries.len(), 1, "one declared index -> one sidecar entry");
+    let entry = &entries[0];
+    assert_eq!(
+        entry.properties,
+        ["city".to_string(), "age".to_string()],
+        "descriptor must keep DECLARATION order"
+    );
+    assert!(
+        entry.path.contains(".eqtix_city+age.pidx"),
+        "tuple sidecars use the composite naming, got {}",
+        entry.path
+    );
+    assert_eq!(
+        entry.distinct_values, 3,
+        "four complete rows over three tuples; the partial row is unfiled"
+    );
+    assert!(entry.mixed_type_complete);
+    assert!(!entry.paged_build_unsupported);
+    assert!(entry.size_bytes > 0);
+}
+
+#[tokio::test]
+async fn ddl_after_flush_backfills_via_compaction_then_settles() {
+    let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    let (mut w, _) = open(&store, "cix-backfill").await;
+
+    w.upsert_node("Person", NodeId::new(), &person("quito", 30))
+        .unwrap();
+    w.upsert_node("Person", NodeId::new(), &person("lima", 44))
+        .unwrap();
+    w.commit_batch().await.unwrap();
+    // Flushed BEFORE the composite index existed: no tuple coverage.
+    w.flush(plain_schema()).await.unwrap();
+    assert!(
+        composite_entries(&w).is_empty(),
+        "pre-DDL SSTs advertise no composite sidecars"
+    );
+
+    // The DDL-triggered sweep runs with the index in the schema; the
+    // migration predicate must force the single-SST rewrite (this is the
+    // whole backfill mechanism — no separate builder exists).
+    let outcome = w.compact_l0(&indexed_schema()).await.unwrap();
+    assert!(
+        outcome.new_ssts_written >= 1,
+        "an uncovered SST must be rewritten, not skipped"
+    );
+    let entries = composite_entries(&w);
+    assert_eq!(entries.len(), 1);
+    assert_eq!(
+        entries[0].properties,
+        ["city".to_string(), "age".to_string()]
+    );
+    assert_eq!(entries[0].distinct_values, 2);
+
+    // Once covered, the same schema must NOT rewrite again (the predicate
+    // is satisfied, so the sweep settles instead of looping forever).
+    let settled = w.compact_l0(&indexed_schema()).await.unwrap();
+    assert_eq!(
+        settled.new_ssts_written, 0,
+        "a covered SST must not be rewritten by the same declaration"
+    );
+}
+
+#[tokio::test]
+async fn compaction_reemits_tuples_from_the_reconciled_winners() {
+    let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    let (mut w, _) = open(&store, "cix-merge").await;
+
+    // First generation: the target holds ("quito", 30).
+    let target = NodeId::new();
+    w.upsert_node("Person", target, &person("quito", 30))
+        .unwrap();
+    w.commit_batch().await.unwrap();
+    w.flush(indexed_schema()).await.unwrap();
+
+    // Second generation: the target moves to ("cuenca", 30) and a sibling
+    // arrives; the superseded quito tuple must NOT survive the merge.
+    w.upsert_node("Person", target, &person("cuenca", 30))
+        .unwrap();
+    w.upsert_node("Person", NodeId::new(), &person("lima", 44))
+        .unwrap();
+    w.commit_batch().await.unwrap();
+    w.flush(indexed_schema()).await.unwrap();
+
+    w.compact_l0(&indexed_schema()).await.unwrap();
+    assert_eq!(
+        node_sst_count(&w),
+        1,
+        "both generations merged into one SST"
+    );
+    let entries = composite_entries(&w);
+    assert_eq!(entries.len(), 1);
+    assert_eq!(
+        entries[0].distinct_values, 2,
+        "winners are (cuenca,30) and (lima,44); the superseded tuple is gone"
+    );
+    assert!(
+        entries[0].path.contains(".eqtix_city+age.pidx"),
+        "compaction keeps the composite naming, got {}",
+        entries[0].path
+    );
+}


### PR DESCRIPTION
Second phase of the composite index build (first field report, long-haul item). Every declared composite index now materializes a PagedV1 `tuple -> [id]` posting sidecar on node SSTs.

- **Flush**: `CompositeSidecarCollector` observes the reconciled row stream (same one the single-property harvest sees), files only rows with every member present and scalar (TupleV1 keys), and emits one `.eqtix_{slug}.pidx` sidecar per declared index. Empty sidecars still get descriptors — the descriptor is the coverage marker. A declined paged build records `paged_build_unsupported` (tuples have no legacy body) so readers fall back and migration settles.
- **Compaction**: winner stream feeds the same collector on id-primary buckets; `put_node_sst_leveled` re-emits descriptors, superseding input partials.
- **Backfill**: the migration predicate gains the composite arm — a declared index with no matching tuple sidecar on an SST forces the rewrite, so `CompactionTrigger::Ddl` materializes postings on pre-existing data with no separate builder.

Tests (`composite_index_sidecars.rs`): flush emission with declaration order + distinct counts + partial rows unfiled; DDL-after-flush backfill that then settles; merge re-emission where the superseded tuple disappears.

Gate: full workspace suite green (87 binaries), fmt clean, clippy clean.

Read path (tuple probe + freshness) and planner routing follow in the next phases; until then composite DDL remains accepted/durable/backfilled with queries on their existing routes.