### PR TITLE
Composite indexes phase 3: storage read path for tuple lookups

### DIFF
--- a/crates/namidb-server/src/metrics.rs
+++ b/crates/namidb-server/src/metrics.rs
@@ -981,6 +981,22 @@ impl Metrics {
         );
         let _ = writeln!(
             out,
+            "# HELP namidb_tuple_lookup_route_total Composite (multi-property) equality lookups \
+             by physical route; same reading as namidb_property_lookup_route_total."
+        );
+        let _ = writeln!(out, "# TYPE namidb_tuple_lookup_route_total counter");
+        let _ = writeln!(
+            out,
+            "namidb_tuple_lookup_route_total{{route=\"native\"}} {}",
+            routes.tuple_native
+        );
+        let _ = writeln!(
+            out,
+            "namidb_tuple_lookup_route_total{{route=\"fallback\"}} {}",
+            routes.tuple_fallback
+        );
+        let _ = writeln!(
+            out,
             "# HELP namidb_search_workspace_enabled Whether the process-wide object-native search workspace has been initialized."
         );
         let _ = writeln!(out, "# TYPE namidb_search_workspace_enabled gauge");

--- a/crates/namidb-storage/src/cache.rs
+++ b/crates/namidb-storage/src/cache.rs
@@ -195,10 +195,18 @@ pub fn encode_equality_tuple_key(values: &[&Value]) -> Option<Vec<u8>> {
         let (tag, bytes): (u8, Vec<u8>) = match value {
             Value::Str(s) => (b's', s.as_bytes().to_vec()),
             Value::Bool(v) => (b'b', vec![u8::from(*v)]),
-            Value::I64(v) => (b'i', v.to_be_bytes().to_vec()),
+            // Numerics share one canonical tag: Cypher equality coerces
+            // integer = float (`30 = 30.0` is TRUE, mirrored from the
+            // executor's `is_equal`), so members that compare equal MUST
+            // produce identical keys or the index route silently drops rows
+            // the scan route returns. `i64 -> f64` loses precision above
+            // 2^53, so distinct integers may share a posting — safe, because
+            // the read path re-confirms every candidate member-by-member
+            // with [`cypher_scalar_equal`].
+            Value::I64(v) => (b'n', (*v as f64).to_bits().to_be_bytes().to_vec()),
             Value::F64(v) if !v.is_nan() => {
                 let normalized = if *v == 0.0 { 0.0 } else { *v };
-                (b'f', normalized.to_bits().to_be_bytes().to_vec())
+                (b'n', normalized.to_bits().to_be_bytes().to_vec())
             }
             Value::Bytes(bytes) => (b'x', bytes.clone()),
             Value::Date(v) => (b'd', v.to_be_bytes().to_vec()),
@@ -215,6 +223,21 @@ pub fn encode_equality_tuple_key(values: &[&Value]) -> Option<Vec<u8>> {
         out.extend_from_slice(&bytes);
     }
     Some(out)
+}
+
+/// Cypher scalar equality — the confirmation twin of
+/// [`encode_equality_tuple_key`]. Mirrors the executor's `is_equal` for the
+/// scalar subset: `NULL` equals nothing (itself included), integer = float
+/// compares mathematically, everything else compares typed. Any two values
+/// this accepts as equal encode identical tuple members, and every key
+/// collision the lossy numeric canonicalization introduces is separated
+/// here.
+pub fn cypher_scalar_equal(a: &Value, b: &Value) -> bool {
+    match (a, b) {
+        (Value::Null, _) | (_, Value::Null) => false,
+        (Value::I64(x), Value::F64(y)) | (Value::F64(y), Value::I64(x)) => (*x as f64) == *y,
+        _ => a == b,
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -3567,14 +3590,33 @@ mod tuple_key_tests {
         let fake = key(&[&Value::Str("b:1".into()), &Value::I64(7)]).unwrap();
         let real = key(&[&Value::Bool(true), &Value::I64(7)]).unwrap();
         assert_ne!(fake, real);
-        // Typed members: I64(1) and F64(1.0) stay distinct (Value::PartialEq
-        // semantics), while -0.0 folds into 0.0.
+        // Numeric members canonicalize: Cypher's `1 = 1.0` is TRUE, so both
+        // encodings MUST collide (the scan route would return the row; the
+        // index route must never lose it). -0.0 folds into 0.0, and integer
+        // zero joins them.
         let int = key(&[&Value::I64(1), &Value::Str("x".into())]).unwrap();
         let float = key(&[&Value::F64(1.0), &Value::Str("x".into())]).unwrap();
-        assert_ne!(int, float);
+        assert_eq!(int, float);
         let pos = key(&[&Value::F64(0.0)]).unwrap();
         let neg = key(&[&Value::F64(-0.0)]).unwrap();
+        let zero = key(&[&Value::I64(0)]).unwrap();
         assert_eq!(pos, neg);
+        assert_eq!(pos, zero);
+        // Above 2^53 the canonicalization is lossy: DISTINCT integers may
+        // share a posting (both round to the same f64). That is a false
+        // POSITIVE only — confirmation separates them, because same-type
+        // integers compare exactly; false negatives remain impossible.
+        let big_a = key(&[&Value::I64((1 << 53) + 1)]).unwrap();
+        let big_b = key(&[&Value::I64(1 << 53)]).unwrap();
+        assert_eq!(big_a, big_b);
+        assert!(!cypher_scalar_equal(
+            &Value::I64((1 << 53) + 1),
+            &Value::I64(1 << 53)
+        ));
+        // The confirmation twin agrees with the executor's coercion.
+        assert!(cypher_scalar_equal(&Value::I64(30), &Value::F64(30.0)));
+        assert!(!cypher_scalar_equal(&Value::I64(30), &Value::F64(30.5)));
+        assert!(!cypher_scalar_equal(&Value::Null, &Value::Null));
         // Order matters: declaration order IS the layout.
         let xy = key(&[&Value::Str("x".into()), &Value::Str("y".into())]).unwrap();
         let yx = key(&[&Value::Str("y".into()), &Value::Str("x".into())]).unwrap();

--- a/crates/namidb-storage/src/read.rs
+++ b/crates/namidb-storage/src/read.rs
@@ -1288,6 +1288,262 @@ impl<'mt> Snapshot<'mt> {
         )
     }
 
+    /// Return the live node ids matching EVERY member of a declared
+    /// composite equality index.
+    ///
+    /// `properties` and `values` are aligned and MUST be in the index's
+    /// DECLARATION order — the planner canonicalizes conjunct order through
+    /// the schema's `IndexDef` before calling. `Some(ids)` is authoritative
+    /// (including an empty vector): a composite index over exactly this
+    /// member list is declared, every relevant node SST advertised a usable
+    /// TupleV1 sidecar, memtable and writer-staged claimants were unioned
+    /// in, and each candidate was confirmed member-by-member against its
+    /// current last-write-wins node view. `None` means no such index, a
+    /// coverage/freshness gap (a pre-DDL SST still awaiting its backfill
+    /// rewrite, a declined paged build, an unreadable sidecar), or a
+    /// non-scalar member; callers must keep their exact scan fallback.
+    pub async fn indexed_node_ids_by_property_tuple(
+        &self,
+        label: &str,
+        properties: &[String],
+        values: &[Value],
+    ) -> Result<Option<Vec<NodeId>>> {
+        namidb_core::profile_scope!("Snapshot::indexed_node_ids_by_property_tuple");
+        if properties.len() < 2 || properties.len() != values.len() {
+            return Ok(None);
+        }
+        let declared = self
+            .manifest
+            .manifest
+            .schema
+            .indexes
+            .iter()
+            .any(|def| def.properties == properties);
+        if !declared {
+            return Ok(None);
+        }
+        // `member = NULL` never evaluates true in Cypher.
+        if values.iter().any(|value| matches!(value, Value::Null)) {
+            return Ok(Some(Vec::new()));
+        }
+        let value_refs: Vec<&Value> = values.iter().collect();
+        // Non-scalar members are never filed in the sidecar; only the exact
+        // scan can answer them.
+        let Some(probe_key) = crate::cache::encode_equality_tuple_key(&value_refs) else {
+            return Ok(None);
+        };
+        // The writer-private (RYOW) constraint machinery keys numerics
+        // TYPED, so a float probe would authoritatively miss integer
+        // holders Cypher considers equal (`30 = 30.0`). Decline to the
+        // exact scan in transactional snapshots instead.
+        if self.transactional_property_index.is_some()
+            && values
+                .iter()
+                .any(|value| matches!(value, Value::I64(_) | Value::F64(_)))
+        {
+            return Ok(None);
+        }
+
+        let mut candidates: Vec<NodeId>;
+        if let Some(ids) = self
+            .transactional_tuple_candidates(label, properties, &value_refs)
+            .await?
+        {
+            candidates = ids;
+        } else {
+            let all_node_ssts: Vec<usize> = self.manifest.index.node_descriptors();
+            let sst_idxs: Vec<usize> = all_node_ssts
+                .into_iter()
+                .filter(|idx| {
+                    label.is_empty()
+                        || node_sst_can_contain_label(&self.manifest.manifest, *idx, label)
+                })
+                .collect();
+            // The freshness rule: EVERY relevant SST must advertise a usable
+            // tuple sidecar for exactly this member list, or the whole lookup
+            // declines. An empty-path descriptor is a declined paged build —
+            // it satisfies the migration predicate but cannot serve reads.
+            let sidecars: Option<Vec<_>> = sst_idxs
+                .iter()
+                .map(|idx| {
+                    self.manifest.manifest.ssts[*idx]
+                        .composite_equality_indices
+                        .iter()
+                        .find(|desc| {
+                            desc.properties == properties
+                                && desc.mixed_type_complete
+                                && desc.key_encoding
+                                    == crate::manifest::CompositeKeyEncoding::TupleV1
+                                && !desc.path.is_empty()
+                        })
+                })
+                .collect();
+            let Some(sidecars) = sidecars else {
+                crate::route_telemetry::record_tuple(false);
+                return Ok(None);
+            };
+            candidates = self.memtable_tuple_claimants(label, properties, &probe_key)?;
+            for sidecar in sidecars {
+                let absolute = format!(
+                    "{}/{}",
+                    self.paths.namespace_prefix().as_ref(),
+                    sidecar.path
+                );
+                match self
+                    .probe_composite_property_sidecar(sidecar, &absolute, &probe_key)
+                    .await
+                {
+                    Ok(ids) => candidates.extend(ids),
+                    Err(error) if optional_accelerator_fallback(&error) => {
+                        tracing::warn!(
+                            path = %sidecar.path,
+                            error = %error,
+                            "tuple accelerator unavailable; falling back to exact scan"
+                        );
+                        crate::route_telemetry::record_tuple(false);
+                        return Ok(None);
+                    }
+                    Err(error) => return Err(error),
+                }
+            }
+            candidates.sort_unstable();
+            candidates.dedup();
+        }
+
+        // Confirmation makes staleness impossible: a posting from a
+        // superseded version, a tombstoned node, or a colliding label is
+        // dropped by re-checking every member on the current view.
+        let mut confirmed = Vec::with_capacity(candidates.len());
+        const CONFIRM_BATCH: usize = 256;
+        for batch in candidates.chunks(CONFIRM_BATCH) {
+            let views = self.batch_lookup_nodes(label, batch).await?;
+            for (id, view) in batch.iter().zip(views) {
+                if view.as_ref().is_some_and(|view| {
+                    properties.iter().zip(values).all(|(name, value)| {
+                        view.properties
+                            .get(name)
+                            .is_some_and(|stored| crate::cache::cypher_scalar_equal(stored, value))
+                    })
+                }) {
+                    confirmed.push(*id);
+                }
+            }
+        }
+        crate::route_telemetry::record_tuple(true);
+        Ok(Some(confirmed))
+    }
+
+    /// Memtable claimants of one exact TupleV1 key: every live upsert whose
+    /// members all encode to `probe_key`. A point scan rather than a cached
+    /// map — the committed claimant cache is String-keyed and single-property;
+    /// tuple lookups pay one memtable walk per probe instead.
+    fn memtable_tuple_claimants(
+        &self,
+        label: &str,
+        members: &[String],
+        probe_key: &[u8],
+    ) -> Result<Vec<NodeId>> {
+        let mut ids = Vec::new();
+        for (mk, entry) in self.node_entries() {
+            let MemKey::Node { id } = mk else {
+                continue;
+            };
+            let MemOp::Upsert(payload) = &entry.op else {
+                continue;
+            };
+            let record = NodeWriteRecord::decode(payload)?;
+            if !label.is_empty()
+                && !record_carries_label(&record, label, &self.manifest.manifest.label_dict)
+            {
+                continue;
+            }
+            let values: Option<Vec<&Value>> = members
+                .iter()
+                .map(|name| record.properties.get(name))
+                .collect();
+            let Some(values) = values else {
+                continue;
+            };
+            if crate::cache::encode_equality_tuple_key(&values).as_deref() == Some(probe_key) {
+                ids.push(*id);
+            }
+        }
+        Ok(ids)
+    }
+
+    /// Tuple twin of [`Self::transactional_property_candidates`]: the
+    /// writer-private constraint machinery is already keyed by `(label,
+    /// names)` lists, so composite lookups reuse it verbatim.
+    async fn transactional_tuple_candidates(
+        &self,
+        label: &str,
+        properties: &[String],
+        values: &[&Value],
+    ) -> Result<Option<Vec<NodeId>>> {
+        let Some(index) = self.transactional_property_index else {
+            return Ok(None);
+        };
+        let names = properties.to_vec();
+        let Some(key) = crate::unique_index::encode_probe_key(values) else {
+            return Ok(None);
+        };
+        if let Some(ids) = index.probe_all(label, &names, &key) {
+            return Ok(Some(ids));
+        }
+        let views = if label.is_empty() {
+            self.scan_all_nodes_with_predicates_and_projection(&[], None)
+                .await?
+        } else {
+            self.scan_label(label).await?
+        };
+        let entries = views.iter().map(|view| (view.id, &view.properties));
+        if self.transactional_property_index_staged {
+            index.populate_staged(label, &names, entries);
+        } else {
+            index.populate(label, &names, entries);
+        }
+        Ok(Some(
+            index
+                .probe_all(label, &names, &key)
+                .expect("transactional tuple map was just populated"),
+        ))
+    }
+
+    /// Point probe of one composite tuple sidecar. Composite descriptors are
+    /// PagedV1-only (no legacy body predates them), so a stale/partial paged
+    /// file is an invariant error rather than a fallback tier.
+    async fn probe_composite_property_sidecar(
+        &self,
+        descriptor: &crate::manifest::CompositeEqualityIndexDescriptor,
+        absolute: &str,
+        probe_key: &[u8],
+    ) -> Result<Vec<NodeId>> {
+        let source = self
+            .pinned_sidecar_source(absolute, Some(descriptor.size_bytes))
+            .await?;
+        let keys = vec![probe_key.to_vec()];
+        let (found, stats) =
+            crate::sst::paged_index::probe_equality_bytes_limited_from_source(&source, &keys, None)
+                .await?;
+        if stats.index_entries != descriptor.distinct_values {
+            return Err(Error::invariant(format!(
+                "paged composite entry count mismatch: manifest {}, header {}",
+                descriptor.distinct_values, stats.index_entries
+            )));
+        }
+        if let Some(cache) = &self.property_index_cache {
+            cache.record_equality_index_bytes_read(stats.bytes_read);
+        }
+        Ok(found
+            .get(probe_key)
+            .map(|ids| {
+                ids.iter()
+                    .map(|id| NodeId::from_uuid(Uuid::from_bytes(*id)))
+                    .collect()
+            })
+            .unwrap_or_default())
+    }
+
     async fn indexed_node_ids_by_property_value_inner(
         &self,
         label: &str,

--- a/crates/namidb-storage/src/route_telemetry.rs
+++ b/crates/namidb-storage/src/route_telemetry.rs
@@ -19,6 +19,8 @@ static VECTOR_NATIVE: AtomicU64 = AtomicU64::new(0);
 static VECTOR_FALLBACK: AtomicU64 = AtomicU64::new(0);
 static PROPERTY_NATIVE: AtomicU64 = AtomicU64::new(0);
 static PROPERTY_FALLBACK: AtomicU64 = AtomicU64::new(0);
+static TUPLE_NATIVE: AtomicU64 = AtomicU64::new(0);
+static TUPLE_FALLBACK: AtomicU64 = AtomicU64::new(0);
 static SHORTEST_BIDIRECTIONAL: AtomicU64 = AtomicU64::new(0);
 
 /// Record one text index search outcome: `native = true` when the index
@@ -56,6 +58,17 @@ pub fn record_property(native: bool) {
     }
 }
 
+/// Record one composite tuple-lookup outcome; same contract as
+/// [`record_property`], for `WHERE a = ... AND b = ...` conjuncts served
+/// through a declared composite index's tuple posting sidecars.
+pub fn record_tuple(native: bool) {
+    if native {
+        TUPLE_NATIVE.fetch_add(1, Ordering::Relaxed);
+    } else {
+        TUPLE_FALLBACK.fetch_add(1, Ordering::Relaxed);
+    }
+}
+
 /// Record one bidirectional (meet-in-the-middle) shortestPath execution.
 /// Same reachability rationale: a single-pair `shortestPath` silently taking
 /// the unidirectional route instead would be invisible to result-parity
@@ -73,6 +86,8 @@ pub struct RouteTelemetrySnapshot {
     pub vector_fallback: u64,
     pub property_native: u64,
     pub property_fallback: u64,
+    pub tuple_native: u64,
+    pub tuple_fallback: u64,
     pub shortest_bidirectional: u64,
 }
 
@@ -84,6 +99,8 @@ pub fn snapshot() -> RouteTelemetrySnapshot {
         vector_fallback: VECTOR_FALLBACK.load(Ordering::Relaxed),
         property_native: PROPERTY_NATIVE.load(Ordering::Relaxed),
         property_fallback: PROPERTY_FALLBACK.load(Ordering::Relaxed),
+        tuple_native: TUPLE_NATIVE.load(Ordering::Relaxed),
+        tuple_fallback: TUPLE_FALLBACK.load(Ordering::Relaxed),
         shortest_bidirectional: SHORTEST_BIDIRECTIONAL.load(Ordering::Relaxed),
     }
 }
@@ -101,6 +118,8 @@ mod tests {
         super::record_vector(false);
         super::record_property(true);
         super::record_property(false);
+        super::record_tuple(true);
+        super::record_tuple(false);
         let after = super::snapshot();
         assert!(after.text_native > before.text_native);
         assert!(after.text_fallback > before.text_fallback);
@@ -108,5 +127,7 @@ mod tests {
         assert!(after.vector_fallback > before.vector_fallback);
         assert!(after.property_native > before.property_native);
         assert!(after.property_fallback > before.property_fallback);
+        assert!(after.tuple_native > before.tuple_native);
+        assert!(after.tuple_fallback > before.tuple_fallback);
     }
 }

--- a/crates/namidb-storage/src/sst/paged_index.rs
+++ b/crates/namidb-storage/src/sst/paged_index.rs
@@ -1944,8 +1944,41 @@ async fn probe_equality_limited_with_source(
     max_ids_per_value: Option<usize>,
 ) -> Result<(BTreeMap<String, Vec<[u8; 16]>>, PagedProbeStats)> {
     let keys: Vec<Vec<u8>> = values.iter().map(|v| v.as_bytes().to_vec()).collect();
+    let (found, stats) =
+        probe_equality_bytes_limited_with_source(source, &keys, max_ids_per_value).await?;
+    let mut out = BTreeMap::new();
+    for (key, ids) in found {
+        out.insert(
+            String::from_utf8(key)
+                .map_err(|e| Error::invariant(format!("equality index key utf8: {e}")))?,
+            ids,
+        );
+    }
+    Ok((out, stats))
+}
+
+/// Generation-pinned equality probe over raw byte keys.
+///
+/// Composite tuple sidecars key postings by [`TupleV1`] encodings, which
+/// are not UTF-8; this is the byte-transparent surface the String probes
+/// above wrap.
+///
+/// [`TupleV1`]: crate::manifest::CompositeKeyEncoding::TupleV1
+pub async fn probe_equality_bytes_limited_from_source(
+    source: &PinnedObjectRangeSource,
+    keys: &[Vec<u8>],
+    max_ids_per_value: Option<usize>,
+) -> Result<(BTreeMap<Vec<u8>, Vec<[u8; 16]>>, PagedProbeStats)> {
+    probe_equality_bytes_limited_with_source(source, keys, max_ids_per_value).await
+}
+
+async fn probe_equality_bytes_limited_with_source(
+    source: &dyn PagedRangeSource,
+    keys: &[Vec<u8>],
+    max_ids_per_value: Option<usize>,
+) -> Result<(BTreeMap<Vec<u8>, Vec<[u8; 16]>>, PagedProbeStats)> {
     let byte_limit = max_ids_per_value.map(|ids| ids.saturating_mul(16));
-    let (found, stats) = probe_source(source, PagedIndexKind::Equality, &keys, byte_limit).await?;
+    let (found, stats) = probe_source(source, PagedIndexKind::Equality, keys, byte_limit).await?;
     let mut out = BTreeMap::new();
     for (key, value) in found {
         if value.len() % 16 != 0 {
@@ -1961,11 +1994,7 @@ async fn probe_equality_limited_with_source(
                 id
             })
             .collect();
-        out.insert(
-            String::from_utf8(key)
-                .map_err(|e| Error::invariant(format!("equality index key utf8: {e}")))?,
-            ids,
-        );
+        out.insert(key, ids);
     }
     Ok((out, stats))
 }

--- a/crates/namidb-storage/tests/composite_tuple_probe.rs
+++ b/crates/namidb-storage/tests/composite_tuple_probe.rs
@@ -1,0 +1,206 @@
+//! Composite tuple probe (phase 3): `indexed_node_ids_by_property_tuple`
+//! serves declared composite indexes from TupleV1 sidecars, unions the
+//! memtable delta, confirms every candidate member-by-member (dropping
+//! superseded postings and separating lossy-numeric collisions), and
+//! declines — never lies — when any relevant SST lacks coverage.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use namidb_core::id::{NamespaceId, NodeId};
+use namidb_core::schema::Schema;
+use namidb_core::value::Value;
+use namidb_storage::{route_telemetry, NamespacePaths, NodeWriteRecord, WriterSession};
+use object_store::memory::InMemory;
+use object_store::ObjectStore;
+
+fn person(city: &str, age: i64) -> NodeWriteRecord {
+    let mut props: BTreeMap<String, Value> = BTreeMap::new();
+    props.insert("city".into(), Value::Str(city.into()));
+    props.insert("age".into(), Value::I64(age));
+    NodeWriteRecord {
+        properties: props,
+        schema_version: 1,
+        ..Default::default()
+    }
+}
+
+async fn open(store: &Arc<dyn ObjectStore>, name: &str) -> WriterSession {
+    let paths = NamespacePaths::new("tenants", NamespaceId::new(name).unwrap());
+    WriterSession::open(store.clone(), paths).await.unwrap()
+}
+
+/// The manifest's schema AFTER DDL — the schema flush/compaction must run
+/// with, exactly as the server's maintenance loop passes it.
+fn committed_schema(w: &WriterSession) -> Schema {
+    w.snapshot().manifest().manifest.schema.clone()
+}
+
+fn pair() -> Vec<String> {
+    vec!["city".into(), "age".into()]
+}
+
+async fn probe(w: &WriterSession, label: &str, values: &[Value]) -> Option<Vec<NodeId>> {
+    let snapshot = w.snapshot();
+    let mut ids = snapshot
+        .indexed_node_ids_by_property_tuple(label, &pair(), values)
+        .await
+        .unwrap()?;
+    ids.sort_unstable();
+    Some(ids)
+}
+
+fn sorted(mut ids: Vec<NodeId>) -> Vec<NodeId> {
+    ids.sort_unstable();
+    ids
+}
+
+#[tokio::test]
+async fn tuple_probe_unions_sst_and_memtable_and_confirms() {
+    let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    let mut w = open(&store, "tp-union").await;
+
+    let a = NodeId::new();
+    let b = NodeId::new();
+    w.upsert_node("Person", a, &person("quito", 30)).unwrap();
+    w.upsert_node("Person", b, &person("lima", 44)).unwrap();
+    w.commit_batch().await.unwrap();
+    w.create_composite_index_named(None, "Person", &["city".into(), "age".into()], false)
+        .await
+        .unwrap();
+    let schema = committed_schema(&w);
+    w.flush(schema).await.unwrap();
+
+    // Memtable delta after the flush: a new claimant of the probed tuple,
+    // and `b` moves AWAY from (lima, 44) — its SST posting is now stale.
+    let c = NodeId::new();
+    w.upsert_node("Person", c, &person("quito", 30)).unwrap();
+    w.upsert_node("Person", b, &person("cuzco", 44)).unwrap();
+    w.commit_batch().await.unwrap();
+
+    let before = route_telemetry::snapshot();
+    assert_eq!(
+        probe(&w, "Person", &[Value::Str("quito".into()), Value::I64(30)]).await,
+        Some(sorted(vec![a, c])),
+        "flushed and memtable claimants must union"
+    );
+    assert_eq!(
+        probe(&w, "Person", &[Value::Str("lima".into()), Value::I64(44)]).await,
+        Some(Vec::new()),
+        "a superseded SST posting must be dropped by confirmation, authoritatively"
+    );
+    // Cypher coerces integer = float: the float probe must find the same
+    // rows the flat scan would.
+    assert_eq!(
+        probe(
+            &w,
+            "Person",
+            &[Value::Str("quito".into()), Value::F64(30.0)]
+        )
+        .await,
+        Some(sorted(vec![a, c])),
+        "numeric members canonicalize across I64/F64"
+    );
+    // The any-label scope serves too (harvest follows the stored value).
+    assert_eq!(
+        probe(&w, "", &[Value::Str("quito".into()), Value::I64(30)]).await,
+        Some(sorted(vec![a, c])),
+    );
+    let after = route_telemetry::snapshot();
+    assert!(
+        after.tuple_native >= before.tuple_native + 4,
+        "each native serve must stamp the tuple route"
+    );
+
+    // `member = NULL` never matches, authoritatively.
+    assert_eq!(
+        probe(&w, "Person", &[Value::Str("quito".into()), Value::Null]).await,
+        Some(Vec::new()),
+    );
+    // Reversed member order is NOT this index: declaration order is the key
+    // layout, so the caller gets a decline, not wrong postings.
+    let snapshot = w.snapshot();
+    assert!(snapshot
+        .indexed_node_ids_by_property_tuple(
+            "Person",
+            &["age".into(), "city".into()],
+            &[Value::I64(30), Value::Str("quito".into())],
+        )
+        .await
+        .unwrap()
+        .is_none());
+    // An undeclared pair declines outright.
+    assert!(snapshot
+        .indexed_node_ids_by_property_tuple(
+            "Person",
+            &["city".into(), "name".into()],
+            &[Value::Str("quito".into()), Value::Str("x".into())],
+        )
+        .await
+        .unwrap()
+        .is_none());
+}
+
+#[tokio::test]
+async fn tuple_probe_declines_without_coverage_then_serves_after_backfill() {
+    let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    let mut w = open(&store, "tp-backfill").await;
+
+    let a = NodeId::new();
+    w.upsert_node("Person", a, &person("quito", 30)).unwrap();
+    w.upsert_node("Person", NodeId::new(), &person("lima", 44))
+        .unwrap();
+    w.commit_batch().await.unwrap();
+    // Flushed BEFORE the index existed: the SST has no tuple sidecar.
+    let pre_ddl = committed_schema(&w);
+    w.flush(pre_ddl).await.unwrap();
+    w.create_composite_index_named(None, "Person", &["city".into(), "age".into()], false)
+        .await
+        .unwrap();
+
+    let before = route_telemetry::snapshot();
+    assert_eq!(
+        probe(&w, "Person", &[Value::Str("quito".into()), Value::I64(30)]).await,
+        None,
+        "an uncovered SST must decline the whole lookup, not lose its rows"
+    );
+    let after = route_telemetry::snapshot();
+    assert!(
+        after.tuple_fallback > before.tuple_fallback,
+        "the coverage decline must stamp the fallback route"
+    );
+
+    // The DDL-triggered sweep backfills the sidecar; the probe now serves.
+    let post_ddl = committed_schema(&w);
+    w.compact_l0(&post_ddl).await.unwrap();
+    assert_eq!(
+        probe(&w, "Person", &[Value::Str("quito".into()), Value::I64(30)]).await,
+        Some(vec![a]),
+        "after the backfill rewrite the tuple route must serve"
+    );
+}
+
+#[tokio::test]
+async fn tuple_probe_is_authoritative_on_a_memtable_only_store() {
+    let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    let mut w = open(&store, "tp-memtable").await;
+
+    let a = NodeId::new();
+    w.upsert_node("Person", a, &person("quito", 30)).unwrap();
+    w.upsert_node("Person", NodeId::new(), &person("lima", 44))
+        .unwrap();
+    w.commit_batch().await.unwrap();
+    w.create_composite_index_named(None, "Person", &["city".into(), "age".into()], false)
+        .await
+        .unwrap();
+
+    // No SSTs at all: the memtable IS the store and the answer is complete.
+    assert_eq!(
+        probe(&w, "Person", &[Value::Str("quito".into()), Value::I64(30)]).await,
+        Some(vec![a]),
+    );
+    assert_eq!(
+        probe(&w, "Person", &[Value::Str("quito".into()), Value::I64(31)]).await,
+        Some(Vec::new()),
+    );
+}


### PR DESCRIPTION
Third phase of the composite index build. `Snapshot::indexed_node_ids_by_property_tuple` serves `WHERE a = x AND b = y` from the TupleV1 posting sidecars with the single-property route's authoritative-or-decline contract.

- **Freshness**: every relevant node SST must carry a usable tuple sidecar for the exact declared member list or the lookup declines (pre-backfill SSTs and declined paged builds can never lose rows). Memtable claimants union in via a point scan; RYOW overlays reuse the `(label, names)`-keyed constraint machinery; every candidate is re-confirmed member-by-member.
- **Numeric coercion**: the executor's Cypher equality treats `30 = 30.0` as TRUE, so TupleV1 now canonicalizes I64/F64 through one f64-bits tag (the typed-tag design in the recon would have broken index/scan parity). Lossy >2^53 collisions are false positives only, separated by the new `cypher_scalar_equal` confirmation twin. The RYOW layer keys numerics typed, so transactional snapshots decline numeric tuple probes rather than returning a false authoritative miss.
- **Bytes probe**: TupleV1 keys aren't UTF-8, so the paged equality probe gained a byte-transparent surface the String probes now wrap.
- **Telemetry**: `tuple_native`/`tuple_fallback` route counters + `namidb_tuple_lookup_route_total` on `/metrics` — reachability proof for the planner phase's tests.

Gate: full workspace suite green (88 binaries), fmt clean, clippy clean.

Next: phase 4 routes the planner (`NodeByPropertyTuple` operator, conjunct detection, EXPLAIN) — until then queries keep their scan routes.