### PR TITLE
Composite indexes phase 4: planner routing through NodeByPropertyTuple

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,21 @@ crates.io release will establish and document that API explicitly.
 ## [Unreleased]
 
 **Added**
+- Composite indexes: `CREATE INDEX [name] [IF NOT EXISTS] FOR (n:Label)
+  ON (n.a, n.b, ...)` now builds a real tuple posting index instead of
+  falling back to a scan. Declarations are schema DDL (durable in the
+  manifest, visible in `SHOW INDEXES`, accepted over HTTP, Bolt, and the
+  CLI); flush materializes one paged `tuple -> [node ids]` sidecar per
+  declared index and DDL-triggered compaction backfills pre-existing
+  SSTs. The planner routes `WHERE n.a = ... AND n.b = ...` conjuncts
+  (any order; extras stay as residual filters) through the new
+  `NodeByPropertyTuple` operator, with a unique-property conjunct still
+  taking priority and an exact scan fallback whenever coverage or
+  freshness cannot be proven — results never depend on the sidecar.
+  Numeric members follow Cypher equality (`30 = 30.0` matches through
+  the index). Route observability:
+  `namidb_tuple_lookup_route_total{route="native"|"fallback"}` on
+  `/metrics`.
 - `shortestPath` on a single bound pair now runs a bidirectional
   meet-in-the-middle BFS (exactness kept via the classical stopping
   criterion): the frontier is O(deg^(d/2)) per side instead of

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ NamiDB is a graph engine built on object storage. You write Cypher; it lays your
 What you get out of the box:
 
 - **A property graph** you query with Cypher / GQL — `CALL { … }` subqueries (correlated and uncorrelated), `EXISTS { … }`, `FOREACH`, label disjunction `(n:A|B)`, and open-ended / parameterised variable-length paths (`*`, `*1..$n`).
-- **Schema when you want it** — `CREATE CONSTRAINT` for uniqueness (single- *and* multi-property), `NOT NULL`, and `CREATE INDEX` for equality lookups, with `IF NOT EXISTS` and `SHOW CONSTRAINTS` / `SHOW INDEXES`. Schema-optional: the engine enforces only what you declare.
+- **Schema when you want it** — `CREATE CONSTRAINT` for uniqueness (single- *and* multi-property), `NOT NULL`, and `CREATE INDEX` for equality lookups on one property or a composite tuple, with `IF NOT EXISTS` and `SHOW CONSTRAINTS` / `SHOW INDEXES`. Schema-optional: the engine enforces only what you declare.
 - **Vector search** — store embeddings as node properties and rank with
   `cosine_similarity`, or build a range-readable clustered ANN index for
   cosine, dot, *and* Euclidean. Full-precision vectors are fetched only for a
@@ -207,6 +207,10 @@ CREATE CONSTRAINT cfg_uq IF NOT EXISTS
 
 -- An equality index for fast point lookups.
 CREATE INDEX FOR (d:Doc) ON (d.slug);
+
+-- …or a composite index: `WHERE d.tenant = $t AND d.slug = $s` (either
+-- order) routes through one tuple lookup instead of a scan.
+CREATE INDEX doc_ts IF NOT EXISTS FOR (d:Doc) ON (d.tenant, d.slug);
 
 -- Introspect what's declared.
 SHOW CONSTRAINTS;

--- a/crates/namidb-query/src/cost/cardinality.rs
+++ b/crates/namidb-query/src/cost/cardinality.rs
@@ -203,6 +203,38 @@ fn estimate_inner(plan: &LogicalPlan, catalog: &StatsCatalog) -> Cardinality {
                 operator: plan.operator_name(),
             }
         }
+        LogicalPlan::NodeByPropertyTuple {
+            input,
+            label,
+            alias,
+            properties,
+            ..
+        } => {
+            let child = estimate_inner(input, catalog);
+            // A tuple lookup is at least as selective as its most selective
+            // member; multiplying member selectivities would assume
+            // independence the stats cannot prove, so take the min fanout.
+            let fanout = properties
+                .iter()
+                .map(|property| property_lookup_fanout(catalog, label, property))
+                .fold(f64::INFINITY, f64::min);
+            let fanout = if fanout.is_finite() { fanout } else { 1.0 };
+            let rows = child.rows * fanout;
+            let mut bindings = child.bindings.clone();
+            bindings.insert(
+                alias.clone(),
+                BindingMeta {
+                    label: (!label.is_empty()).then(|| label.clone()),
+                    ..Default::default()
+                },
+            );
+            Cardinality {
+                rows,
+                bindings,
+                children: vec![child],
+                operator: plan.operator_name(),
+            }
+        }
         LogicalPlan::Expand {
             input,
             edge_type,

--- a/crates/namidb-query/src/cost/stats.rs
+++ b/crates/namidb-query/src/cost/stats.rs
@@ -35,6 +35,10 @@ pub struct StatsCatalog {
     /// `vector_search` rewrite looks a descriptor up by `(label, property,
     /// metric)` to decide whether a KNN shape can use the index.
     vector_indexes: Vec<VectorIndexDescriptor>,
+    /// Declared composite equality indexes (`schema.indexes`). The
+    /// composite-lookup rewrite matches a scan's equality conjuncts against
+    /// these member lists (declaration order is the tuple key layout).
+    composite_indexes: Vec<namidb_core::schema::IndexDef>,
 }
 
 /// Per-label aggregate stats.
@@ -118,7 +122,16 @@ impl StatsCatalog {
             total_nodes,
             total_edges: 0,
             vector_indexes: Vec::new(),
+            composite_indexes: Vec::new(),
         }
+    }
+
+    /// Declare composite indexes on a hand-built catalog. Unit tests use
+    /// this to exercise the composite-lookup rewrite without a manifest.
+    #[doc(hidden)]
+    pub fn with_composite_indexes(mut self, indexes: Vec<namidb_core::schema::IndexDef>) -> Self {
+        self.composite_indexes = indexes;
+        self
     }
 
     /// Build a catalog from a committed [`Manifest`].
@@ -267,6 +280,7 @@ impl StatsCatalog {
             total_nodes,
             total_edges,
             vector_indexes: m.vector_indexes.clone(),
+            composite_indexes: m.schema.indexes.clone(),
         }
     }
 
@@ -282,6 +296,11 @@ impl StatsCatalog {
         self.vector_indexes
             .iter()
             .find(|d| d.matches(label, property, metric))
+    }
+
+    /// Every declared composite equality index, in declaration order.
+    pub fn composite_indexes(&self) -> &[namidb_core::schema::IndexDef] {
+        &self.composite_indexes
     }
 
     pub fn label(&self, name: &str) -> Option<&LabelStats> {

--- a/crates/namidb-query/src/exec/walker.rs
+++ b/crates/namidb-query/src/exec/walker.rs
@@ -432,6 +432,40 @@ pub(crate) fn execute_inner_with_routing<'a>(
                 Ok(out)
             }
 
+            LogicalPlan::NodeByPropertyTuple {
+                input,
+                label,
+                alias,
+                properties,
+                values,
+            } => {
+                let input_rows =
+                    execute_inner_with_routing(input, snapshot, params, outer, routing).await?;
+                let mut out = Vec::new();
+                for row in input_rows {
+                    let member_values = values
+                        .iter()
+                        .map(|value| evaluate(value, &row, params))
+                        .collect::<Result<Vec<_>, _>>()?;
+                    for view in lookup_nodes_by_property_tuple_via_scan(
+                        snapshot,
+                        label,
+                        properties,
+                        &member_values,
+                    )
+                    .await?
+                    {
+                        let mut new_row = row.clone();
+                        new_row.set(
+                            alias.clone(),
+                            RuntimeValue::Node(Box::new(NodeValue::from(view))),
+                        );
+                        out.push(new_row);
+                    }
+                }
+                Ok(out)
+            }
+
             LogicalPlan::NodeByPropertyValue {
                 input,
                 label,
@@ -7171,6 +7205,84 @@ fn node_property_equals(
 /// Convert the scalar types whose physical equality is identical to Cypher's
 /// equality into a storage-index probe. Numeric values are excluded because
 /// Cypher intentionally compares integers and floats across physical types.
+/// Resolve a composite tuple lookup: the declared-index posting route when
+/// storage can serve it authoritatively, the exact scan otherwise. Mirrors
+/// [`lookup_nodes_by_property_via_scan`]'s contract — results NEVER depend
+/// on sidecar coverage, only the route taken does.
+pub(crate) async fn lookup_nodes_by_property_tuple_via_scan(
+    snapshot: &Snapshot<'_>,
+    label: &str,
+    properties: &[String],
+    values: &[RuntimeValue],
+) -> Result<Vec<namidb_storage::NodeView>, ExecError> {
+    // `member = NULL` is NULL (never true) under three-valued logic.
+    if values.iter().any(RuntimeValue::is_null) {
+        return Ok(Vec::new());
+    }
+    let core: Option<Vec<namidb_core::Value>> =
+        values.iter().map(tuple_member_core_value).collect();
+    if let Some(core) = core {
+        if let Some(ids) = snapshot
+            .indexed_node_ids_by_property_tuple(label, properties, &core)
+            .await
+            .map_err(ExecError::from)?
+        {
+            if label.is_empty() {
+                let mut out = Vec::with_capacity(ids.len());
+                for id in ids {
+                    if let Some(view) = snapshot
+                        .lookup_node_by_id(id)
+                        .await
+                        .map_err(ExecError::from)?
+                    {
+                        out.push(view);
+                    }
+                }
+                return Ok(out);
+            }
+            return snapshot
+                .batch_lookup_nodes(label, &ids)
+                .await
+                .map(|views| views.into_iter().flatten().collect())
+                .map_err(ExecError::from);
+        }
+    }
+    // Exact fallback: Cypher equality per member over the scan.
+    let all = if label.is_empty() {
+        snapshot
+            .scan_all_nodes_with_predicates_and_projection(&[], None)
+            .await
+            .map_err(ExecError::from)?
+    } else {
+        snapshot.scan_label(label).await.map_err(ExecError::from)?
+    };
+    Ok(all
+        .into_iter()
+        .filter(|view| {
+            properties
+                .iter()
+                .zip(values)
+                .all(|(property, value)| node_property_equals(view, property, value))
+        })
+        .collect())
+}
+
+/// Scalar runtime value -> storable core value for a tuple member probe.
+/// Unlike [`non_numeric_index_value`], numerics ARE included — TupleV1
+/// canonicalizes them to match Cypher's coercing equality.
+fn tuple_member_core_value(value: &RuntimeValue) -> Option<namidb_core::Value> {
+    match value {
+        RuntimeValue::Bool(value) => Some(namidb_core::Value::Bool(*value)),
+        RuntimeValue::Integer(value) => Some(namidb_core::Value::I64(*value)),
+        RuntimeValue::Float(value) => Some(namidb_core::Value::F64(*value)),
+        RuntimeValue::String(value) => Some(namidb_core::Value::Str(value.clone())),
+        RuntimeValue::Bytes(value) => Some(namidb_core::Value::Bytes(value.clone())),
+        RuntimeValue::Date(value) => Some(namidb_core::Value::Date(*value)),
+        RuntimeValue::DateTime(value) => Some(namidb_core::Value::DateTime(*value)),
+        _ => None,
+    }
+}
+
 fn non_numeric_index_value(value: &RuntimeValue) -> Option<namidb_core::Value> {
     match value {
         RuntimeValue::Bool(value) => Some(namidb_core::Value::Bool(*value)),
@@ -7337,6 +7449,14 @@ pub(crate) fn execute_factor_inner_with_routing<'a>(
                     arena: next_arena,
                     leaves: out_leaves,
                 })
+            }
+
+            // Composite tuple lookup: not factor-ported yet — run the flat
+            // implementation and wrap the result.
+            LogicalPlan::NodeByPropertyTuple { .. } => {
+                let rows =
+                    execute_inner_with_routing(plan, snapshot, params, outer, routing).await?;
+                Ok(FactorRowSet::from_flat(rows))
             }
 
             LogicalPlan::NodeByPropertyValue {
@@ -9397,6 +9517,11 @@ fn collect_plan_references(
         }
         LogicalPlan::NodeByPropertyValue { value, .. } => {
             collect_referenced_variables(value, out);
+        }
+        LogicalPlan::NodeByPropertyTuple { values, .. } => {
+            for value in values {
+                collect_referenced_variables(value, out);
+            }
         }
         LogicalPlan::VectorSearch { query, .. } => {
             collect_referenced_variables(query, out);

--- a/crates/namidb-query/src/exec/writer.rs
+++ b/crates/namidb-query/src/exec/writer.rs
@@ -683,6 +683,45 @@ fn execute_write_inner_mode<'a>(
                 Ok(out)
             }
 
+            // Commit-first composite tuple lookup. The transactional overlay
+            // declines numeric tuples storage-side, and the helper keeps an
+            // exact scan fallback, so read-your-own-writes results stay
+            // exact regardless of sidecar coverage.
+            LogicalPlan::NodeByPropertyTuple {
+                input,
+                label,
+                alias,
+                properties,
+                values,
+            } => {
+                let input_rows =
+                    execute_write_inner(input, writer, params, outcome, routing).await?;
+                let snap = snapshot_for_write_read(writer, routing);
+                let mut out = Vec::new();
+                for row in input_rows {
+                    let member_values = values
+                        .iter()
+                        .map(|value| evaluate(value, &row, params))
+                        .collect::<Result<Vec<_>, _>>()?;
+                    for view in crate::exec::walker::lookup_nodes_by_property_tuple_via_scan(
+                        &snap,
+                        label,
+                        properties,
+                        &member_values,
+                    )
+                    .await?
+                    {
+                        let mut new_row = row.clone();
+                        new_row.set(
+                            alias.clone(),
+                            RuntimeValue::Node(Box::new(NodeValue::from(view))),
+                        );
+                        out.push(new_row);
+                    }
+                }
+                Ok(out)
+            }
+
             // Same shape as NodeById: writes commit first, then the
             // unique-property lookup runs against the post-write snapshot.
             LogicalPlan::NodeByPropertyValue {

--- a/crates/namidb-query/src/optimize/anchor_inversion.rs
+++ b/crates/namidb-query/src/optimize/anchor_inversion.rs
@@ -85,6 +85,19 @@ fn rewrite(plan: LogicalPlan, catalog: &StatsCatalog) -> LogicalPlan {
             value,
             multi,
         },
+        LogicalPlan::NodeByPropertyTuple {
+            input,
+            label,
+            alias,
+            properties,
+            values,
+        } => LogicalPlan::NodeByPropertyTuple {
+            input: Box::new(rewrite(*input, catalog)),
+            label,
+            alias,
+            properties,
+            values,
+        },
         LogicalPlan::Expand {
             input,
             source,

--- a/crates/namidb-query/src/optimize/decorrelation.rs
+++ b/crates/namidb-query/src/optimize/decorrelation.rs
@@ -257,6 +257,19 @@ fn replace_argument(plan: LogicalPlan, x: &str, label: &str) -> LogicalPlan {
             value,
             multi,
         },
+        LogicalPlan::NodeByPropertyTuple {
+            input,
+            label: l,
+            alias,
+            properties,
+            values,
+        } => LogicalPlan::NodeByPropertyTuple {
+            input: Box::new(replace_argument(*input, x, label)),
+            label: l,
+            alias,
+            properties,
+            values,
+        },
         LogicalPlan::Expand {
             input,
             source,
@@ -343,6 +356,19 @@ fn recurse_children(plan: LogicalPlan, catalog: &StatsCatalog) -> LogicalPlan {
             property,
             value,
             multi,
+        },
+        LogicalPlan::NodeByPropertyTuple {
+            input,
+            label,
+            alias,
+            properties,
+            values,
+        } => LogicalPlan::NodeByPropertyTuple {
+            input: Box::new(convert_semi_apply_to_hash_semi_join(*input, catalog)),
+            label,
+            alias,
+            properties,
+            values,
         },
         LogicalPlan::Expand {
             input,

--- a/crates/namidb-query/src/optimize/join_conversion.rs
+++ b/crates/namidb-query/src/optimize/join_conversion.rs
@@ -62,6 +62,19 @@ fn recurse_children(plan: LogicalPlan, catalog: &StatsCatalog) -> LogicalPlan {
             value,
             multi,
         },
+        LogicalPlan::NodeByPropertyTuple {
+            input,
+            label,
+            alias,
+            properties,
+            values,
+        } => LogicalPlan::NodeByPropertyTuple {
+            input: Box::new(convert_cross_to_hash(*input, catalog)),
+            label,
+            alias,
+            properties,
+            values,
+        },
         LogicalPlan::Expand {
             input,
             source,

--- a/crates/namidb-query/src/optimize/join_reorder.rs
+++ b/crates/namidb-query/src/optimize/join_reorder.rs
@@ -99,6 +99,19 @@ fn recurse(plan: LogicalPlan, catalog: &StatsCatalog) -> LogicalPlan {
             value,
             multi,
         },
+        LogicalPlan::NodeByPropertyTuple {
+            input,
+            label,
+            alias,
+            properties,
+            values,
+        } => LogicalPlan::NodeByPropertyTuple {
+            input: Box::new(recurse(*input, catalog)),
+            label,
+            alias,
+            properties,
+            values,
+        },
         LogicalPlan::Expand {
             input,
             source,

--- a/crates/namidb-query/src/optimize/mod.rs
+++ b/crates/namidb-query/src/optimize/mod.rs
@@ -314,7 +314,8 @@ fn collect_produced(plan: &LogicalPlan, out: &mut BTreeSet<String>) {
             out.insert(alias.clone());
         }
         LogicalPlan::NodeById { input, alias, .. }
-        | LogicalPlan::NodeByPropertyValue { input, alias, .. } => {
+        | LogicalPlan::NodeByPropertyValue { input, alias, .. }
+        | LogicalPlan::NodeByPropertyTuple { input, alias, .. } => {
             collect_produced(input, out);
             out.insert(alias.clone());
         }

--- a/crates/namidb-query/src/optimize/multiway_join.rs
+++ b/crates/namidb-query/src/optimize/multiway_join.rs
@@ -401,6 +401,19 @@ fn recurse_children(plan: LogicalPlan) -> LogicalPlan {
             value,
             multi,
         },
+        LogicalPlan::NodeByPropertyTuple {
+            input,
+            label,
+            alias,
+            properties,
+            values,
+        } => LogicalPlan::NodeByPropertyTuple {
+            input: Box::new(rewrite(*input)),
+            label,
+            alias,
+            properties,
+            values,
+        },
         LogicalPlan::Expand {
             input,
             source,

--- a/crates/namidb-query/src/optimize/normalize.rs
+++ b/crates/namidb-query/src/optimize/normalize.rs
@@ -53,6 +53,19 @@ fn recurse_children(plan: LogicalPlan) -> LogicalPlan {
             value,
             multi,
         },
+        LogicalPlan::NodeByPropertyTuple {
+            input,
+            label,
+            alias,
+            properties,
+            values,
+        } => LogicalPlan::NodeByPropertyTuple {
+            input: Box::new(normalize_filters(*input)),
+            label,
+            alias,
+            properties,
+            values,
+        },
         LogicalPlan::Expand {
             input,
             source,

--- a/crates/namidb-query/src/optimize/projection_pushdown.rs
+++ b/crates/namidb-query/src/optimize/projection_pushdown.rs
@@ -107,6 +107,23 @@ fn collect_from_plan(plan: &LogicalPlan, req: &mut RequiredSet) {
             req.record_property(alias, property);
             collect_from_expr(value, req);
         }
+        LogicalPlan::NodeByPropertyTuple {
+            input,
+            alias,
+            properties,
+            values,
+            ..
+        } => {
+            collect_from_plan(input, req);
+            // Every member column must survive — the executor re-confirms
+            // the full tuple against the hydrated view.
+            for property in properties {
+                req.record_property(alias, property);
+            }
+            for value in values {
+                collect_from_expr(value, req);
+            }
+        }
         LogicalPlan::Expand {
             input,
             source,
@@ -597,6 +614,19 @@ fn rewrite(plan: LogicalPlan, req: &RequiredSet) -> LogicalPlan {
             property,
             value,
             multi,
+        },
+        LogicalPlan::NodeByPropertyTuple {
+            input,
+            label,
+            alias,
+            properties,
+            values,
+        } => LogicalPlan::NodeByPropertyTuple {
+            input: Box::new(rewrite(*input, req)),
+            label,
+            alias,
+            properties,
+            values,
         },
         LogicalPlan::Expand {
             input,

--- a/crates/namidb-query/src/optimize/pushdown.rs
+++ b/crates/namidb-query/src/optimize/pushdown.rs
@@ -120,6 +120,30 @@ fn pushdown_at(plan: LogicalPlan, pending: Vec<Expression>) -> LogicalPlan {
             )
         }
 
+        // Same alias-introducing shape again for the composite lookup.
+        LogicalPlan::NodeByPropertyTuple {
+            input,
+            label,
+            alias,
+            properties,
+            values,
+        } => {
+            let mut introduced = BTreeSet::new();
+            introduced.insert(alias.clone());
+            let (pushable, stay) = partition_by_alias_disjoint(pending, &introduced);
+            let new_input = pushdown_at(*input, pushable);
+            apply_filters(
+                LogicalPlan::NodeByPropertyTuple {
+                    input: Box::new(new_input),
+                    label,
+                    alias,
+                    properties,
+                    values,
+                },
+                stay,
+            )
+        }
+
         // ─── Expand: introduces target_alias (+ rel_alias?) ────────────
         LogicalPlan::Expand {
             input,

--- a/crates/namidb-query/src/optimize/unique_lookup.rs
+++ b/crates/namidb-query/src/optimize/unique_lookup.rs
@@ -3,6 +3,11 @@
 //!
 //! - `a.<prop> == <literal>` → `NodeByPropertyValue` when `<prop>` is
 //!   declared `unique` in the schema (see `PropertyDef::unique`).
+//! - `a.<m1> == <lit> AND a.<m2> == <lit> [AND ...]` → `NodeByPropertyTuple`
+//!   when the conjuncts cover EVERY member of a declared composite index
+//!   (`Schema::indexes`). Priority: unique single-property first (at most
+//!   one row), then the longest covered composite, then non-unique
+//!   single-property postings.
 //! - `elementId(a) == <expr>` / `id(a) == <expr>` → `NodeById` (a UUID
 //!   point lookup), with or without a label on the scan. This is what
 //!   turns a GUI's `MATCH (n) WHERE elementId(n) = $id` node fetch and
@@ -54,24 +59,45 @@ fn rewrite(plan: LogicalPlan, catalog: &StatsCatalog) -> LogicalPlan {
             } = input.as_ref()
             {
                 if predicates.is_empty() && projection.is_none() {
-                    if let Some(indexed) =
-                        extract_indexed_conjunct(&predicate, alias, label.as_deref(), catalog, None)
-                    {
-                        let lookup = LogicalPlan::NodeByPropertyValue {
-                            input: Box::new(LogicalPlan::Empty),
-                            label: indexed.label,
-                            alias: alias.clone(),
-                            property: indexed.property,
-                            value: indexed.value,
-                            multi: indexed.multi,
-                        };
-                        return match indexed.residual {
-                            Some(residual) => LogicalPlan::Filter {
-                                input: Box::new(lookup),
-                                predicate: residual,
-                            },
-                            None => lookup,
-                        };
+                    // Lookup priority: a unique single-property conjunct
+                    // (at most one row) beats a declared composite index,
+                    // which beats a non-unique single-property posting (the
+                    // composite consumes MORE conjuncts, so its posting set
+                    // is a subset of any member's).
+                    let single = extract_indexed_conjunct(
+                        &predicate,
+                        alias,
+                        label.as_deref(),
+                        catalog,
+                        None,
+                    );
+                    if let Some(indexed) = &single {
+                        if !indexed.multi {
+                            return finish_single_lookup(single.expect("checked above"), alias);
+                        }
+                    }
+                    if let Some(label) = label.as_deref() {
+                        if let Some(composite) =
+                            extract_composite_conjuncts(&predicate, alias, label, catalog)
+                        {
+                            let lookup = LogicalPlan::NodeByPropertyTuple {
+                                input: Box::new(LogicalPlan::Empty),
+                                label: label.to_owned(),
+                                alias: alias.clone(),
+                                properties: composite.properties,
+                                values: composite.values,
+                            };
+                            return match composite.residual {
+                                Some(residual) => LogicalPlan::Filter {
+                                    input: Box::new(lookup),
+                                    predicate: residual,
+                                },
+                                None => lookup,
+                            };
+                        }
+                    }
+                    if let Some(indexed) = single {
+                        return finish_single_lookup(indexed, alias);
                     }
                 }
             }
@@ -199,6 +225,19 @@ fn rewrite(plan: LogicalPlan, catalog: &StatsCatalog) -> LogicalPlan {
             property,
             value,
             multi,
+        },
+        LogicalPlan::NodeByPropertyTuple {
+            input,
+            label,
+            alias,
+            properties,
+            values,
+        } => LogicalPlan::NodeByPropertyTuple {
+            input: Box::new(rewrite(*input, catalog)),
+            label,
+            alias,
+            properties,
+            values,
         },
         LogicalPlan::Expand {
             input,
@@ -485,6 +524,139 @@ pub(super) fn extract_indexed_conjunct(
         multi,
         residual,
     })
+}
+
+/// Build the `NodeByPropertyValue` (+ residual filter) for a matched
+/// single-property conjunct — the tail the two priority branches share.
+fn finish_single_lookup(indexed: IndexedConjunct, alias: &str) -> LogicalPlan {
+    let lookup = LogicalPlan::NodeByPropertyValue {
+        input: Box::new(LogicalPlan::Empty),
+        label: indexed.label,
+        alias: alias.to_owned(),
+        property: indexed.property,
+        value: indexed.value,
+        multi: indexed.multi,
+    };
+    match indexed.residual {
+        Some(residual) => LogicalPlan::Filter {
+            input: Box::new(lookup),
+            predicate: residual,
+        },
+        None => lookup,
+    }
+}
+
+/// A matched composite-index lookup: members in DECLARATION order with
+/// their aligned value expressions, plus whatever conjuncts remain.
+struct CompositeConjunct {
+    properties: Vec<String>,
+    values: Vec<Expression>,
+    residual: Option<Expression>,
+}
+
+/// Match the scan's top-level equality conjuncts against the declared
+/// composite indexes. Fires only when EVERY member of a declared index has
+/// an uncorrelated `alias.<member> = <expr>` conjunct; among matches the
+/// longest member list wins (most conjuncts consumed). The matched values
+/// are reordered to declaration order — the tuple key layout — and every
+/// consumed conjunct leaves the residual.
+fn extract_composite_conjuncts(
+    predicate: &Expression,
+    scan_alias: &str,
+    label: &str,
+    catalog: &StatsCatalog,
+) -> Option<CompositeConjunct> {
+    let mut conjuncts = Vec::new();
+    collect_top_level_conjuncts(predicate, &mut conjuncts);
+
+    // First equality conjunct per property; a duplicate (`a=1 AND a=2`)
+    // stays in the residual and keeps filtering.
+    let mut equalities: std::collections::BTreeMap<String, (usize, Expression)> =
+        std::collections::BTreeMap::new();
+    for (index, conjunct) in conjuncts.iter().enumerate() {
+        let Some((property, value)) = extract_eq_on_prop(conjunct, scan_alias) else {
+            continue;
+        };
+        if !expression_aliases(&value).is_empty() {
+            continue;
+        }
+        equalities.entry(property).or_insert((index, value));
+    }
+    if equalities.len() < 2 {
+        return None;
+    }
+
+    let mut best: Option<&namidb_core::schema::IndexDef> = None;
+    for def in catalog.composite_indexes() {
+        if def.label != label {
+            continue;
+        }
+        if !def
+            .properties
+            .iter()
+            .all(|member| equalities.contains_key(member))
+        {
+            continue;
+        }
+        if best.is_none_or(|b| def.properties.len() > b.properties.len()) {
+            best = Some(def);
+        }
+    }
+    let def = best?;
+
+    let mut used = BTreeSet::new();
+    let mut values = Vec::with_capacity(def.properties.len());
+    for member in &def.properties {
+        let (index, value) = &equalities[member];
+        used.insert(*index);
+        values.push(value.clone());
+    }
+    let mut leaf_index = 0usize;
+    let residual = remove_top_level_conjunct_set(predicate, &used, &mut leaf_index);
+    debug_assert_eq!(
+        leaf_index,
+        conjuncts.len(),
+        "conjunction traversal must assign stable leaf ordinals"
+    );
+    Some(CompositeConjunct {
+        properties: def.properties.clone(),
+        values,
+        residual,
+    })
+}
+
+/// Set-removal twin of [`remove_top_level_conjunct`]: drop every leaf whose
+/// ordinal is in `remove`, preserving the remaining tree shape.
+fn remove_top_level_conjunct_set(
+    expr: &Expression,
+    remove: &BTreeSet<usize>,
+    next_index: &mut usize,
+) -> Option<Expression> {
+    if let ExpressionKind::Binary {
+        op: crate::parser::ast::BinaryOp::And,
+        left,
+        right,
+    } = &expr.kind
+    {
+        let left = remove_top_level_conjunct_set(left, remove, next_index);
+        let right = remove_top_level_conjunct_set(right, remove, next_index);
+        return match (left, right) {
+            (Some(left), Some(right)) => Some(Expression {
+                span: expr.span,
+                kind: ExpressionKind::Binary {
+                    op: crate::parser::ast::BinaryOp::And,
+                    left: Box::new(left),
+                    right: Box::new(right),
+                },
+            }),
+            (Some(remaining), None) | (None, Some(remaining)) => Some(remaining),
+            (None, None) => None,
+        };
+    }
+
+    let index = *next_index;
+    *next_index += 1;
+    (!remove.contains(&index)).then(|| expr.clone())
 }
 
 fn collect_top_level_conjuncts<'a>(expr: &'a Expression, out: &mut Vec<&'a Expression>) {

--- a/crates/namidb-query/src/plan/explain.rs
+++ b/crates/namidb-query/src/plan/explain.rs
@@ -335,7 +335,8 @@ fn plan_has_stats(plan: &LogicalPlan, catalog: &StatsCatalog) -> bool {
         LogicalPlan::NodeById { label, .. } => label
             .as_deref()
             .is_none_or(|l| catalog.label(l).map(|x| x.node_count > 0).unwrap_or(false)),
-        LogicalPlan::NodeByPropertyValue { label, .. } => {
+        LogicalPlan::NodeByPropertyValue { label, .. }
+        | LogicalPlan::NodeByPropertyTuple { label, .. } => {
             if label.is_empty() {
                 catalog.total_nodes() > 0
             } else {
@@ -401,6 +402,27 @@ fn write_header(plan: &LogicalPlan, out: &mut String) {
                 out,
                 "NodeByPropertyValue label={} alias={} {}={}",
                 label, alias, property, value
+            );
+        }
+        LogicalPlan::NodeByPropertyTuple {
+            label,
+            alias,
+            properties,
+            values,
+            ..
+        } => {
+            let label = if label.is_empty() { "*" } else { label };
+            let rendered: Vec<String> = properties
+                .iter()
+                .zip(values)
+                .map(|(p, v)| format!("{p}={v}"))
+                .collect();
+            let _ = write!(
+                out,
+                "NodeByPropertyTuple label={} alias={} ({})",
+                label,
+                alias,
+                rendered.join(", ")
             );
         }
         LogicalPlan::Expand {

--- a/crates/namidb-query/src/plan/logical.rs
+++ b/crates/namidb-query/src/plan/logical.rs
@@ -106,6 +106,26 @@ pub enum LogicalPlan {
         multi: bool,
     },
 
+    /// Fan-out lookup through a declared composite equality index
+    /// (`CREATE INDEX ON :L(a, b)`). `optimize::composite_lookup` emits
+    /// this when a scan's top-level equality conjuncts cover EVERY member
+    /// of a declared index; the executor probes
+    /// `Snapshot::indexed_node_ids_by_property_tuple` and keeps an exact
+    /// scan fallback for freshness declines, so results never depend on
+    /// sidecar coverage.
+    NodeByPropertyTuple {
+        input: Box<LogicalPlan>,
+        /// Explicit label scope (the declared index's label).
+        label: String,
+        alias: String,
+        /// Members in DECLARATION order — the tuple key layout, which is
+        /// why the rewrite reorders the matched conjuncts to the index
+        /// definition rather than source order.
+        properties: Vec<String>,
+        /// Member value expressions, aligned with `properties`.
+        values: Vec<Expression>,
+    },
+
     /// Expand `source` across an edge to produce `target_alias`.
     Expand {
         input: Box<LogicalPlan>,
@@ -513,6 +533,7 @@ impl LogicalPlan {
             }
             LogicalPlan::NodeById { input, .. }
             | LogicalPlan::NodeByPropertyValue { input, .. }
+            | LogicalPlan::NodeByPropertyTuple { input, .. }
             | LogicalPlan::Expand { input, .. }
             | LogicalPlan::Filter { input, .. }
             | LogicalPlan::Project { input, .. }
@@ -570,6 +591,7 @@ impl LogicalPlan {
             LogicalPlan::NodeScan { .. } => "NodeScan",
             LogicalPlan::NodeById { .. } => "NodeById",
             LogicalPlan::NodeByPropertyValue { .. } => "NodeByPropertyValue",
+            LogicalPlan::NodeByPropertyTuple { .. } => "NodeByPropertyTuple",
             LogicalPlan::Expand { optional, .. } => {
                 if *optional {
                     "OptionalExpand"

--- a/crates/namidb-query/tests/exec_composite_tuple.rs
+++ b/crates/namidb-query/tests/exec_composite_tuple.rs
@@ -1,0 +1,206 @@
+//! Composite index planner routing (phase 4): equality conjuncts covering
+//! every member of a declared composite index must PLAN the
+//! `NodeByPropertyTuple` lookup (reachability asserted on the plan shape
+//! AND the storage route counter — result parity alone is trivially
+//! satisfied by the scan fallback), serve the same rows as the scan
+//! semantics, respect conjunct order and priority rules, and leave
+//! partial-member shapes on their scan route.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use namidb_core::id::{NamespaceId, NodeId};
+use namidb_core::value::Value as CoreValue;
+use namidb_storage::{route_telemetry, NamespacePaths, NodeWriteRecord, WriterSession};
+use object_store::memory::InMemory;
+use object_store::ObjectStore;
+
+use namidb_query::{execute, lower, optimize, parse, LogicalPlan, Params, StatsCatalog};
+
+const PEOPLE: i64 = 24;
+
+fn person(ordinal: i64) -> NodeWriteRecord {
+    let mut props: BTreeMap<String, CoreValue> = BTreeMap::new();
+    let city = ["quito", "lima", "cuzco"][(ordinal % 3) as usize];
+    props.insert("city".into(), CoreValue::Str(city.into()));
+    props.insert("age".into(), CoreValue::I64(30 + ordinal % 4));
+    props.insert("email".into(), CoreValue::Str(format!("p{ordinal}@x")));
+    NodeWriteRecord {
+        properties: props,
+        schema_version: 1,
+        ..Default::default()
+    }
+}
+
+/// (quito, 30) holders: ordinal % 3 == 0 && ordinal % 4 == 0.
+fn expected_quito_30() -> usize {
+    (0..PEOPLE).filter(|o| o % 3 == 0 && o % 4 == 0).count()
+}
+
+async fn corpus(name: &str, flush: bool) -> WriterSession {
+    let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    let paths = NamespacePaths::new("tenants", NamespaceId::new(name).unwrap());
+    let mut writer = WriterSession::open(store, paths).await.unwrap();
+    for ordinal in 0..PEOPLE {
+        writer
+            .upsert_node("Person", NodeId::new(), &person(ordinal))
+            .unwrap();
+    }
+    writer.commit_batch().await.unwrap();
+    // Real DDL, exactly as the server routes it: the manifest schema (and
+    // therefore the optimizer's catalog) must carry both declarations.
+    writer
+        .create_unique_constraint("Person", "email")
+        .await
+        .unwrap();
+    writer
+        .create_composite_index_named(None, "Person", &["city".into(), "age".into()], false)
+        .await
+        .unwrap();
+    if flush {
+        // Flush/compact with the POST-DDL manifest schema, exactly as the
+        // server maintenance loop does — this is what materializes and
+        // backfills the tuple sidecars.
+        let committed = writer.snapshot().manifest().manifest.schema.clone();
+        writer.flush(committed.clone()).await.unwrap();
+        writer.compact_l0(&committed).await.unwrap();
+    }
+    writer
+}
+
+fn plan_has_tuple_lookup(plan: &LogicalPlan) -> bool {
+    matches!(plan, LogicalPlan::NodeByPropertyTuple { .. })
+        || plan.children().into_iter().any(plan_has_tuple_lookup)
+}
+
+fn plan_has_node_scan(plan: &LogicalPlan) -> bool {
+    matches!(plan, LogicalPlan::NodeScan { .. })
+        || plan.children().into_iter().any(plan_has_node_scan)
+}
+
+fn optimized(writer: &WriterSession, query: &str) -> LogicalPlan {
+    let snapshot = writer.snapshot();
+    let catalog = StatsCatalog::from_manifest(&snapshot.manifest().manifest);
+    optimize(lower(&parse(query).unwrap()).unwrap(), &catalog)
+}
+
+async fn run(writer: &WriterSession, query: &str) -> Vec<String> {
+    let snapshot = writer.snapshot();
+    let plan = optimized(writer, query);
+    let rows = execute(&plan, &snapshot, &Params::new()).await.unwrap();
+    let mut out: Vec<String> = rows
+        .iter()
+        .map(|row| {
+            let cells: Vec<String> = row
+                .bindings
+                .iter()
+                .map(|(column, value)| format!("{column}={value:?}"))
+                .collect();
+            cells.join("|")
+        })
+        .collect();
+    out.sort();
+    out
+}
+
+const COVERED: &str = "MATCH (p:Person) WHERE p.city = 'quito' AND p.age = 30 \
+                       RETURN p.email AS email";
+const COVERED_FLIPPED: &str = "MATCH (p:Person) WHERE p.age = 30 AND p.city = 'quito' \
+                               RETURN p.email AS email";
+const COVERED_FLOAT: &str = "MATCH (p:Person) WHERE p.city = 'quito' AND p.age = 30.0 \
+                             RETURN p.email AS email";
+const RESIDUAL: &str = "MATCH (p:Person) WHERE p.city = 'quito' AND p.age = 30 \
+                        AND p.email <> 'nobody@x' RETURN p.email AS email";
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn covered_conjuncts_plan_the_tuple_lookup_and_serve_natively() {
+    for (route, flush) in [("memtable", false), ("flushed", true)] {
+        let writer = corpus(&format!("cix-plan-{route}"), flush).await;
+
+        // Reachability, half one: the PLAN carries the tuple operator (in
+        // both conjunct spellings — the rewrite reorders to declaration
+        // order) and the Person label scan is gone.
+        for query in [COVERED, COVERED_FLIPPED] {
+            let plan = optimized(&writer, query);
+            assert!(
+                plan_has_tuple_lookup(&plan),
+                "{route}: covered conjuncts must plan NodeByPropertyTuple: {plan:?}"
+            );
+            assert!(
+                !plan_has_node_scan(&plan),
+                "{route}: the label scan must be replaced: {plan:?}"
+            );
+        }
+
+        // Reachability, half two: execution actually SERVES through the
+        // tuple route (parity alone would pass on the scan fallback).
+        let before = route_telemetry::snapshot();
+        let rows = run(&writer, COVERED).await;
+        assert_eq!(rows.len(), expected_quito_30(), "{route}: row parity");
+        let after = route_telemetry::snapshot();
+        assert!(
+            after.tuple_native > before.tuple_native,
+            "{route}: the tuple route must serve natively"
+        );
+        assert_eq!(
+            rows,
+            run(&writer, COVERED_FLIPPED).await,
+            "{route}: conjunct order must not change results"
+        );
+        // Cypher numeric coercion holds on the index route.
+        assert_eq!(
+            rows,
+            run(&writer, COVERED_FLOAT).await,
+            "{route}: 30 = 30.0 must hold through the tuple key"
+        );
+    }
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn residual_conjuncts_keep_filtering_above_the_tuple_lookup() {
+    let writer = corpus("cix-plan-residual", true).await;
+    let plan = optimized(&writer, RESIDUAL);
+    assert!(plan_has_tuple_lookup(&plan), "{plan:?}");
+    let rows = run(&writer, RESIDUAL).await;
+    assert_eq!(
+        rows.len(),
+        expected_quito_30(),
+        "the <> residual filters nothing here but must not break results"
+    );
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn partial_member_conjuncts_keep_the_scan_route() {
+    let writer = corpus("cix-plan-partial", true).await;
+    // Only one member: a partial tuple can NOT use the index (the recon's
+    // negative row) — the plan keeps its scan, results stay exact.
+    let query = "MATCH (p:Person) WHERE p.city = 'quito' RETURN p.email AS email";
+    let plan = optimized(&writer, query);
+    assert!(
+        !plan_has_tuple_lookup(&plan),
+        "a partial member set must not plan the tuple lookup: {plan:?}"
+    );
+    let rows = run(&writer, query).await;
+    assert_eq!(rows.len(), (0..PEOPLE).filter(|o| o % 3 == 0).count());
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn unique_property_lookup_outranks_the_composite() {
+    let writer = corpus("cix-plan-priority", true).await;
+    // A unique-property conjunct gives at most one row; it must win over
+    // the composite even though the tuple is also fully covered.
+    let query = "MATCH (p:Person) WHERE p.email = 'p0@x' AND p.city = 'quito' \
+                 AND p.age = 30 RETURN p.email AS email";
+    let plan = optimized(&writer, query);
+    assert!(
+        !plan_has_tuple_lookup(&plan),
+        "the unique email lookup must outrank the composite: {plan:?}"
+    );
+    fn has_unique_lookup(plan: &LogicalPlan) -> bool {
+        matches!(plan, LogicalPlan::NodeByPropertyValue { multi: false, .. })
+            || plan.children().into_iter().any(has_unique_lookup)
+    }
+    assert!(has_unique_lookup(&plan), "{plan:?}");
+    let rows = run(&writer, query).await;
+    assert_eq!(rows.len(), 1);
+}

--- a/docs/testing/25tb-readiness.md
+++ b/docs/testing/25tb-readiness.md
@@ -517,6 +517,22 @@ any customer needs search on the managed tier.
   (`EqualityKeyEncoding::TupleV1` + flush/compaction harvesters +
   read-side tuple probe + planner conjunct-cover detection). Sized at
   ~3-4 weeks; roadmap.
+  **Follow-up shipped (2026-08-28, unreleased):** composite `CREATE
+  INDEX` is end-to-end. Schema DDL (`Schema::indexes` / `IndexDef`,
+  every surface incl. `SHOW INDEXES` and the CLI), TupleV1 posting
+  sidecars harvested at flush and re-emitted by compaction (whose
+  migration predicate makes DDL-triggered sweeps backfill pre-existing
+  SSTs), `Snapshot::indexed_node_ids_by_property_tuple` with the
+  freshness/authoritative-or-decline contract, and the
+  `NodeByPropertyTuple` planner rewrite (declaration-order
+  canonicalization, unique-conjunct priority, residual filters, exact
+  scan fallback). One deliberate semantic upgrade over the single-
+  property route: TupleV1 canonicalizes numeric members to f64 keys and
+  confirms with Cypher-coercing equality, so `30 = 30.0` matches
+  through the index — the executor's `is_equal` coerces, and typed keys
+  would have broken index/scan parity. Route observability:
+  `tuple_native`/`tuple_fallback` counters +
+  `namidb_tuple_lookup_route_total` on `/metrics`.
 - The OFFICIAL artifacts all ship `vector-index,text-index`: release
   binaries (release-binaries.yml `features:` line), the Docker image
   (Dockerfile bakes them), and the wheels (pyproject maturin features).


### PR DESCRIPTION
Final phase of the composite index build (first field report, item 42). With this merged, `CREATE INDEX ON (n.a, n.b)` is end-to-end: DDL → TupleV1 sidecars → DDL-sweep backfill → storage tuple probe → **plan routing**.

- **New operator** `NodeByPropertyTuple`: declaration-ordered members, executed via `indexed_node_ids_by_property_tuple` with an exact scan fallback (results never depend on sidecar coverage). Implemented in the flat executor; factor path wraps it; write path runs commit-first.
- **Rewrite** (in `unique_lookup`): fires when a `Filter(NodeScan)`'s top-level equality conjuncts cover every member of a declared index. Priority: unique single-property > longest covered composite > non-unique single-property. Consumed conjuncts leave the residual; spelling order is irrelevant (members canonicalize to declaration order).
- **Catalog/cost**: `StatsCatalog` carries `schema.indexes`; tuple cardinality = min member fanout (no independence assumption).
- **EXPLAIN**: renders the operator with its member list.

Reachability tests assert BOTH halves per the project rule: the optimized plan contains the operator AND `tuple_native` moves during execution — plus flipped conjunct order, numeric coercion (`age = 30.0` finds `I64(30)` rows through the index), residual filters, partial member sets staying on the scan, and unique-priority.

Gate: full workspace suite green (89 binaries), fmt clean, clippy clean.

Docs: README example, CHANGELOG entry, item-42 follow-up in 25tb-readiness.md.