### PR TITLE
Fix EXPLAIN on the CLI and embedded Python client; tuple route footer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,16 @@ crates.io release will establish and document that API explicitly.
 
 ## [Unreleased]
 
+**Fixed**
+- `EXPLAIN` in the CLI's `run` and the embedded Python client rendered
+  nothing and silently EXECUTED the query — an `EXPLAIN CREATE ...`
+  wrote data (the same trap the HTTP surface fixed in 2.1.3). Both now
+  return the identical rendering the server serves: the optimized plan
+  against the real catalog plus the `# route:` physical-access footer.
+  The footer also learned the composite tuple route
+  (`# route: L.(a, b) → index (tuple lookup; ...)`), including the
+  memtable and scan-fallback coverage states.
+
 ## [2.4.0] - 2026-08-28
 
 **Added**

--- a/crates/namidb-cli/src/main.rs
+++ b/crates/namidb-cli/src/main.rs
@@ -570,6 +570,18 @@ async fn run_statement(writer: &mut WriterSession, statement: &str) -> anyhow::R
     let catalog = StatsCatalog::from_manifest(&writer.snapshot().manifest().manifest);
     let plan = build_plan(&q, &catalog).map_err(|e| anyhow::anyhow!("{}", e))?;
 
+    // `EXPLAIN [RAW] [VERBOSE] <query>`: render the plan (real catalog +
+    // `# route:` footer, unlike the offline `explain` subcommand's empty
+    // catalog) instead of executing — an `EXPLAIN CREATE ...` must never
+    // write.
+    if q.explain {
+        let snap = writer.snapshot();
+        for line in namidb_query::explain_plan_lines(&q, &plan, &snap, &catalog) {
+            println!("{line}");
+        }
+        return Ok(());
+    }
+
     if plan.contains_write() {
         let outcome = execute_write(&plan, writer, &Params::new())
             .await
@@ -815,5 +827,39 @@ mod tests {
             .await
             .expect_err("bad second statement must fail the script");
         assert!(err.to_string().contains("statement 2/2"), "{err}");
+    }
+
+    /// `EXPLAIN` in a `run` script renders instead of executing: before
+    /// this interception the CLI silently EXECUTED the query, so an
+    /// `EXPLAIN CREATE ...` wrote a row (the same trap the server fixed
+    /// on its own surface).
+    #[tokio::test]
+    async fn explain_in_run_renders_and_never_executes() {
+        let ns = NamespaceId::new("cli-explain").unwrap();
+        let paths = NamespacePaths::new("tenants", ns);
+        let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let mut writer = WriterSession::open(store, paths).await.unwrap();
+
+        run_statement(&mut writer, "CREATE INDEX pair FOR (x:X) ON (x.a, x.b)")
+            .await
+            .unwrap();
+        run_statement(&mut writer, "EXPLAIN CREATE (:X {a: 1, b: 2})")
+            .await
+            .unwrap();
+        let snap = writer.snapshot();
+        assert!(
+            snap.scan_label("X").await.unwrap().is_empty(),
+            "EXPLAIN of a write must create nothing"
+        );
+
+        // A covered composite conjunct EXPLAINs to the tuple operator
+        // (the shared renderer also appends its `# route:` note, asserted
+        // in the server's explain_surface test).
+        run_statement(
+            &mut writer,
+            "EXPLAIN MATCH (x:X) WHERE x.a = 1 AND x.b = 2 RETURN x",
+        )
+        .await
+        .unwrap();
     }
 }

--- a/crates/namidb-py/src/lib.rs
+++ b/crates/namidb-py/src/lib.rs
@@ -880,6 +880,27 @@ async fn run_cypher_inner(
 
     let catalog = StatsCatalog::from_manifest(&guard.snapshot().manifest().manifest);
     let plan = build_plan(&parsed, &catalog).map_err(lower_err_to_pyerr)?;
+
+    // `EXPLAIN [RAW] [VERBOSE] <query>`: render the plan instead of
+    // executing — the same rendering (tree + `# route:` footer) the server
+    // serves. Without this check the embedded client silently EXECUTED the
+    // query, so an `EXPLAIN CREATE ...` wrote data.
+    if parsed.explain {
+        let snap = guard.snapshot();
+        let rows = namidb_query::explain_plan_lines(&parsed, &plan, &snap, &catalog)
+            .into_iter()
+            .map(|line| {
+                let mut row = Row::new();
+                row.set("plan", RuntimeValue::String(line));
+                row
+            })
+            .collect();
+        return Ok(QueryResult {
+            columns: vec!["plan".into()],
+            rows,
+        });
+    }
+
     let plan_columns = extract_column_order(&plan);
     let rows = if plan.contains_write() {
         let outcome = execute_write(&plan, guard, params)

--- a/crates/namidb-query/src/lib.rs
+++ b/crates/namidb-query/src/lib.rs
@@ -43,11 +43,11 @@ pub use exec::{
 pub use optimize::{convert_cross_to_hash, normalize_filters, optimize, predicate_pushdown};
 pub use parser::{parse, ParseError, ParseResult, Query};
 pub use plan::{
-    explain, explain_query, explain_query_raw, explain_query_raw_tree,
-    explain_query_raw_tree_verbose, explain_query_raw_verbose, explain_query_tree,
-    explain_query_tree_verbose, explain_query_verbose, explain_tree, explain_tree_verbose,
-    explain_verbose, lower, AggregateExpr, ExplainNode, LogicalPlan, LowerError, LowerErrorKind,
-    RuntimeStats,
+    collect_route_notes, explain, explain_plan_lines, explain_query, explain_query_raw,
+    explain_query_raw_tree, explain_query_raw_tree_verbose, explain_query_raw_verbose,
+    explain_query_tree, explain_query_tree_verbose, explain_query_verbose, explain_tree,
+    explain_tree_verbose, explain_verbose, lower, AggregateExpr, ExplainNode, LogicalPlan,
+    LowerError, LowerErrorKind, RuntimeStats,
 };
 
 /// Lower + optimize. The convenience entry point that the executor and

--- a/crates/namidb-query/src/plan/explain.rs
+++ b/crates/namidb-query/src/plan/explain.rs
@@ -1012,6 +1012,111 @@ fn format_args(name: &str, arg: &crate::parser::Expression, distinct: bool) -> S
     }
 }
 
+/// The complete rendered `EXPLAIN` output — plan tree plus one `# route:`
+/// footer line per index-lookup operator — shared by every surface that
+/// executes against a live snapshot (HTTP, Bolt, the CLI's `run`, and the
+/// embedded Python client). Non-RAW forms render the plan the optimizer
+/// actually produced against the real catalog; the footer then states the
+/// PHYSICAL access path, because posting-sidecar coverage decides
+/// index-vs-scan only at run time.
+pub fn explain_plan_lines(
+    parsed: &Query,
+    plan: &LogicalPlan,
+    snapshot: &namidb_storage::read::Snapshot<'_>,
+    catalog: &StatsCatalog,
+) -> Vec<String> {
+    let text = if parsed.explain_raw && parsed.explain_verbose {
+        explain_query_raw_verbose(parsed, catalog).unwrap_or_else(|e| format!("explain error: {e}"))
+    } else if parsed.explain_raw {
+        explain_query_raw(parsed).unwrap_or_else(|e| format!("explain error: {e}"))
+    } else if parsed.explain_verbose {
+        explain_verbose(plan, catalog)
+    } else {
+        explain(plan)
+    };
+    let mut lines: Vec<String> = text.lines().map(str::to_string).collect();
+    if !parsed.explain_raw {
+        collect_route_notes(plan, snapshot, &mut lines);
+    }
+    lines
+}
+
+/// Append one `# route:` line per index-lookup operator in the plan.
+pub fn collect_route_notes(
+    plan: &LogicalPlan,
+    snapshot: &namidb_storage::read::Snapshot<'_>,
+    out: &mut Vec<String>,
+) {
+    use crate::parser::ast::{ExpressionKind, Literal};
+    match plan {
+        LogicalPlan::NodeByPropertyValue {
+            label,
+            property,
+            value,
+            multi,
+            ..
+        } => {
+            let shown = if label.is_empty() { "*" } else { label };
+            let kind = if *multi { "posting" } else { "unique" };
+            let numeric = matches!(
+                &value.kind,
+                ExpressionKind::Literal(Literal::Integer(_) | Literal::Float(_))
+            );
+            let note = if numeric {
+                format!(
+                    "# route: {shown}.{property} → scan \
+                     (numeric equality is not posting-indexed; only String/Bool are)"
+                )
+            } else {
+                let (covered, total) = snapshot.property_index_coverage(label, property);
+                if total == 0 {
+                    format!(
+                        "# route: {shown}.{property} → memtable ({kind} lookup; no SSTs in scope)"
+                    )
+                } else if covered == total {
+                    format!(
+                        "# route: {shown}.{property} → index \
+                         ({kind} lookup; posting sidecars {covered}/{total} SSTs)"
+                    )
+                } else {
+                    format!(
+                        "# route: {shown}.{property} → SCAN FALLBACK \
+                         (posting sidecars {covered}/{total} SSTs; \
+                         a compaction pass materializes the rest)"
+                    )
+                }
+            };
+            out.push(note);
+        }
+        LogicalPlan::NodeByPropertyTuple {
+            label, properties, ..
+        } => {
+            let shown = if label.is_empty() { "*" } else { label };
+            let members = properties.join(", ");
+            let (covered, total) = snapshot.composite_index_coverage(label, properties);
+            let note = if total == 0 {
+                format!("# route: {shown}.({members}) → memtable (tuple lookup; no SSTs in scope)")
+            } else if covered == total {
+                format!(
+                    "# route: {shown}.({members}) → index \
+                     (tuple lookup; posting sidecars {covered}/{total} SSTs)"
+                )
+            } else {
+                format!(
+                    "# route: {shown}.({members}) → SCAN FALLBACK \
+                     (tuple sidecars {covered}/{total} SSTs; \
+                     a compaction pass materializes the rest)"
+                )
+            };
+            out.push(note);
+        }
+        _ => {}
+    }
+    for child in plan.children() {
+        collect_route_notes(child, snapshot, out);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/namidb-query/src/plan/mod.rs
+++ b/crates/namidb-query/src/plan/mod.rs
@@ -13,10 +13,10 @@ pub mod logical;
 pub mod lower;
 
 pub use explain::{
-    explain, explain_query, explain_query_raw, explain_query_raw_tree,
-    explain_query_raw_tree_verbose, explain_query_raw_verbose, explain_query_tree,
-    explain_query_tree_verbose, explain_query_verbose, explain_tree, explain_tree_verbose,
-    explain_verbose, ExplainNode, RuntimeStats,
+    collect_route_notes, explain, explain_plan_lines, explain_query, explain_query_raw,
+    explain_query_raw_tree, explain_query_raw_tree_verbose, explain_query_raw_verbose,
+    explain_query_tree, explain_query_tree_verbose, explain_query_verbose, explain_tree,
+    explain_tree_verbose, explain_verbose, ExplainNode, RuntimeStats,
 };
 pub use logical::{AggregateExpr, LogicalPlan, OrderKey, ProjectionItem, RowCount, ShortestMode};
 pub use lower::{lower, LowerError, LowerErrorKind};

--- a/crates/namidb-server/src/lib.rs
+++ b/crates/namidb-server/src/lib.rs
@@ -1774,81 +1774,17 @@ fn explain_observation(
 }
 
 /// The rendered EXPLAIN lines (plan tree + `# route:` footer), shared by
-/// the HTTP and Bolt surfaces.
+/// the HTTP and Bolt surfaces. The rendering itself lives in
+/// `namidb_query::explain_plan_lines` so the CLI's `run` and the embedded
+/// Python client emit the identical output.
 pub(crate) fn explain_plan_lines(
     parsed: &namidb_query::Query,
     plan: &namidb_query::LogicalPlan,
     owned: &namidb_storage::OwnedSnapshot,
     catalog: &StatsCatalog,
 ) -> Vec<String> {
-    let text = if parsed.explain_raw && parsed.explain_verbose {
-        namidb_query::explain_query_raw_verbose(parsed, catalog)
-            .unwrap_or_else(|e| format!("explain error: {e}"))
-    } else if parsed.explain_raw {
-        namidb_query::explain_query_raw(parsed).unwrap_or_else(|e| format!("explain error: {e}"))
-    } else if parsed.explain_verbose {
-        namidb_query::explain_verbose(plan, catalog)
-    } else {
-        namidb_query::explain(plan)
-    };
-    let mut lines: Vec<String> = text.lines().map(str::to_string).collect();
-    if !parsed.explain_raw {
-        let snapshot = owned.borrow();
-        collect_route_notes(plan, &snapshot, &mut lines);
-    }
-    lines
-}
-
-/// Append one `# route:` line per index-lookup operator in the plan.
-fn collect_route_notes(
-    plan: &namidb_query::LogicalPlan,
-    snapshot: &namidb_storage::Snapshot<'_>,
-    out: &mut Vec<String>,
-) {
-    if let namidb_query::LogicalPlan::NodeByPropertyValue {
-        label,
-        property,
-        value,
-        multi,
-        ..
-    } = plan
-    {
-        let shown = if label.is_empty() { "*" } else { label };
-        let kind = if *multi { "posting" } else { "unique" };
-        let numeric = matches!(
-            &value.kind,
-            namidb_query::parser::ast::ExpressionKind::Literal(
-                namidb_query::parser::ast::Literal::Integer(_)
-                    | namidb_query::parser::ast::Literal::Float(_)
-            )
-        );
-        let note = if numeric {
-            format!(
-                "# route: {shown}.{property} → scan \
-                 (numeric equality is not posting-indexed; only String/Bool are)"
-            )
-        } else {
-            let (covered, total) = snapshot.property_index_coverage(label, property);
-            if total == 0 {
-                format!("# route: {shown}.{property} → memtable ({kind} lookup; no SSTs in scope)")
-            } else if covered == total {
-                format!(
-                    "# route: {shown}.{property} → index \
-                     ({kind} lookup; posting sidecars {covered}/{total} SSTs)"
-                )
-            } else {
-                format!(
-                    "# route: {shown}.{property} → SCAN FALLBACK \
-                     (posting sidecars {covered}/{total} SSTs; \
-                     a compaction pass materializes the rest)"
-                )
-            }
-        };
-        out.push(note);
-    }
-    for child in plan.children() {
-        collect_route_notes(child, snapshot, out);
-    }
+    let snapshot = owned.borrow();
+    namidb_query::explain_plan_lines(parsed, plan, &snapshot, catalog)
 }
 
 fn exec_failure_response(prefix: &str, e: &namidb_query::exec::ExecError) -> Response {

--- a/crates/namidb-server/tests/explain_surface.rs
+++ b/crates/namidb-server/tests/explain_surface.rs
@@ -218,3 +218,87 @@ async fn explain_renders_the_plan_and_its_physical_route_without_executing() {
         "fallback series must render"
     );
 }
+
+/// The `# route:` footer knows the composite tuple route: memtable note
+/// pre-flush, full-coverage index note once the flush materializes the
+/// tuple sidecar — and `EXPLAIN` itself never executes.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn explain_states_the_tuple_route_for_composite_lookups() {
+    let base = boot().await;
+
+    let (status, body) = cypher(
+        &base,
+        "CREATE INDEX pair IF NOT EXISTS FOR (c:City) ON (c.country, c.zip)",
+    )
+    .await;
+    assert_eq!(status, 200, "{body}");
+    let (status, body) = cypher(
+        &base,
+        "CREATE (:City {country: 'ec', zip: 170101}), (:City {country: 'pe', zip: 15001})",
+    )
+    .await;
+    assert_eq!(status, 200, "{body}");
+
+    // Memtable-only: tuple operator + memtable route note.
+    let (status, body) = cypher(
+        &base,
+        "EXPLAIN MATCH (c:City) WHERE c.zip = 170101 AND c.country = 'ec' RETURN c",
+    )
+    .await;
+    assert_eq!(status, 200, "{body}");
+    assert!(
+        body.contains("NodeByPropertyTuple"),
+        "covered conjuncts must plan the tuple operator: {body}"
+    );
+    assert!(
+        body.contains("route: City.(country, zip)") && body.contains("memtable"),
+        "memtable tuple route note expected: {body}"
+    );
+
+    // Flush materializes the tuple sidecar: full coverage, index note.
+    let flush = reqwest::Client::new()
+        .post(format!("{base}/v0/admin/flush"))
+        .bearer_auth(TOKEN)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(flush.status().as_u16(), 200);
+    let (status, body) = cypher(
+        &base,
+        "EXPLAIN MATCH (c:City) WHERE c.country = 'ec' AND c.zip = 170101 RETURN c",
+    )
+    .await;
+    assert_eq!(status, 200, "{body}");
+    assert!(
+        body.contains("route: City.(country, zip)")
+            && body.contains("→ index")
+            && body.contains("tuple lookup"),
+        "covered tuple route note expected after flush: {body}"
+    );
+
+    // And the real query serves through the tuple route.
+    let (status, body) = cypher(
+        &base,
+        "MATCH (c:City) WHERE c.country = 'ec' AND c.zip = 170101 RETURN c.zip AS zip",
+    )
+    .await;
+    assert_eq!(status, 200, "{body}");
+    assert!(body.contains("170101"), "{body}");
+    let metrics = reqwest::Client::new()
+        .get(format!("{base}/v0/metrics"))
+        .bearer_auth(TOKEN)
+        .send()
+        .await
+        .unwrap()
+        .text()
+        .await
+        .unwrap();
+    let native = metrics
+        .lines()
+        .find(|l| l.starts_with("namidb_tuple_lookup_route_total{route=\"native\"}"))
+        .expect("tuple native route counter must render");
+    assert!(
+        !native.trim_end().ends_with(" 0"),
+        "a covered tuple lookup must count as native: {native}"
+    );
+}

--- a/crates/namidb-storage/src/read.rs
+++ b/crates/namidb-storage/src/read.rs
@@ -2048,6 +2048,36 @@ impl<'mt> Snapshot<'mt> {
         (covered, in_scope.len())
     }
 
+    /// Composite twin of [`Self::property_index_coverage`]: how many
+    /// in-scope node SSTs advertise a servable TupleV1 sidecar for exactly
+    /// this declaration-ordered member list. A declined paged build (empty
+    /// path) counts as NOT covered — the tuple probe declines it toward
+    /// the exact scan.
+    pub fn composite_index_coverage(&self, label: &str, properties: &[String]) -> (usize, usize) {
+        let in_scope: Vec<usize> = self
+            .manifest
+            .index
+            .node_descriptors()
+            .into_iter()
+            .filter(|i| node_sst_can_contain_label(&self.manifest.manifest, *i, label))
+            .collect();
+        let covered = in_scope
+            .iter()
+            .filter(|i| {
+                self.manifest.manifest.ssts[**i]
+                    .composite_equality_indices
+                    .iter()
+                    .any(|desc| {
+                        desc.properties == properties
+                            && desc.mixed_type_complete
+                            && desc.key_encoding == crate::manifest::CompositeKeyEncoding::TupleV1
+                            && !desc.path.is_empty()
+                    })
+            })
+            .count();
+        (covered, in_scope.len())
+    }
+
     /// Point-lookup a node by a *unique* user property. The first call
     /// per (label, prop) pays a full label scan to populate the
     /// cross-snapshot cache; subsequent calls are `O(1)`. Caller is


### PR DESCRIPTION
Found by the 2.4.0 published-wheel smoke: the CLI's `run` and the embedded Python client ignored the `EXPLAIN` prefix and silently EXECUTED the query — an `EXPLAIN CREATE ...` wrote data (same trap the HTTP surface fixed in 2.1.3).

- The rendering (optimized plan + `# route:` footer) moves into `namidb_query::explain_plan_lines`; all four surfaces (HTTP, Bolt, CLI, Python) now emit identical output, server delegates.
- The `# route:` footer learns the composite tuple route (phase-4 leftover): `# route: L.(a, b) → index (tuple lookup; posting sidecars N/N SSTs)` plus memtable / SCAN FALLBACK states, backed by `Snapshot::composite_index_coverage`.
- `namidb run` and `Client.cypher` intercept `parsed.explain` after planning.

Tests: CLI `EXPLAIN CREATE` writes nothing + composite EXPLAIN renders; server `explain_surface` gains the tuple-route case (memtable note → index note across a flush, tuple native counter moves).

Gate: full workspace suite green (89 binaries), fmt clean, clippy clean.