### PR TITLE
Hot-reload the static auth tokens file (field report 3, item 58)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,17 @@ crates.io release will establish and document that API explicitly.
 
 ## [Unreleased]
 
+**Added**
+- The static auth tokens file hot-reloads: the server re-reads
+  `--auth-tokens-file` on `--auth-tokens-reload-interval` (default 10s,
+  `0s` disables) and swaps the token set atomically, so onboarding or
+  rotating a tenant's token no longer restarts every namespace. Change
+  detection is content-compare (rename-safe); a malformed, truncated, or
+  emptied file keeps the last good set serving — a reload can never
+  widen access or flip auth open. Revocation applies to new requests and
+  new Bolt LOGONs immediately; live single-tenant Bolt sessions keep
+  their LOGON principal (documented in docs/multi-tenancy.md).
+
 **Fixed**
 - The Bolt per-message decode guard rejected legitimate small-row
   batches: its fixed allowance was 64 KiB on top of 8x the message's own

--- a/crates/namidb-server/src/auth.rs
+++ b/crates/namidb-server/src/auth.rs
@@ -12,6 +12,7 @@
 
 use std::path::Path;
 use std::sync::Arc;
+use std::time::Duration;
 
 use serde::Deserialize;
 
@@ -96,9 +97,15 @@ impl std::fmt::Debug for AuthToken {
 }
 
 /// The process's accepted tokens. Empty = open (no auth).
+///
+/// The token set lives behind interior mutability: every consumer (HTTP
+/// state, Bolt accept loop, shared multi-tenant state) holds a clone of the
+/// same boot-time `Arc<AuthConfig>`, so a hot reload must swap INSIDE the
+/// config — replacing the outer Arc would never reach those clones. Clones
+/// of `AuthConfig` therefore share one token cell by design.
 #[derive(Debug, Clone, Default)]
 pub struct AuthConfig {
-    tokens: Vec<AuthToken>,
+    tokens: Arc<std::sync::RwLock<Arc<Vec<AuthToken>>>>,
     /// Optional OIDC/JWT validator. When present, a bearer token is first
     /// attempted as a JWT (mapped from a group claim); static tokens are the
     /// fallback. Only compiled under the `jwt` feature.
@@ -115,15 +122,29 @@ impl AuthConfig {
     /// A single read-write token — the back-compat `--auth-token` path.
     #[allow(clippy::needless_update)] // `..Default::default()` fills the jwt field under the `jwt` feature
     pub fn single_read_write(secret: impl Into<String>) -> Self {
+        Self::from_tokens(vec![AuthToken {
+            name: "auth-token".into(),
+            secret: Arc::from(secret.into()),
+            role: Role::ReadWrite,
+            namespaces: None,
+        }])
+    }
+
+    #[allow(clippy::needless_update)] // `..Default::default()` fills the jwt field under the `jwt` feature
+    fn from_tokens(tokens: Vec<AuthToken>) -> Self {
         Self {
-            tokens: vec![AuthToken {
-                name: "auth-token".into(),
-                secret: Arc::from(secret.into()),
-                role: Role::ReadWrite,
-                namespaces: None,
-            }],
+            tokens: Arc::new(std::sync::RwLock::new(Arc::new(tokens))),
             ..Default::default()
         }
+    }
+
+    /// The current token set, cloned out under a short read lock so the
+    /// constant-time walk never holds it.
+    fn current_tokens(&self) -> Arc<Vec<AuthToken>> {
+        self.tokens
+            .read()
+            .expect("auth token lock poisoned")
+            .clone()
     }
 
     /// Load tokens from a JSON file:
@@ -138,11 +159,17 @@ impl AuthConfig {
     /// `role` defaults to `read-write` and `name` to `token-<i>`. A file with
     /// an empty `tokens` array is rejected — that would silently disable auth;
     /// omit the flag and pass `--no-auth` to run open on purpose.
-    #[allow(clippy::needless_update)] // `..Default::default()` fills the jwt field under the `jwt` feature
     pub fn load_file(path: &Path) -> anyhow::Result<Self> {
         let body = std::fs::read_to_string(path)
             .map_err(|e| anyhow::anyhow!("reading auth tokens file {}: {e}", path.display()))?;
-        let file: TokenFile = serde_json::from_str(&body)
+        Ok(Self::from_tokens(Self::parse_tokens(path, &body)?))
+    }
+
+    /// Parse + validate a tokens-file body. Shared by boot and reload so a
+    /// reload can never accept what boot would reject — in particular an
+    /// empty token set (silently open) or an empty secret (`Bearer `).
+    fn parse_tokens(path: &Path, body: &str) -> anyhow::Result<Vec<AuthToken>> {
+        let file: TokenFile = serde_json::from_str(body)
             .map_err(|e| anyhow::anyhow!("parsing auth tokens file {}: {e}", path.display()))?;
         if file.tokens.is_empty() {
             anyhow::bail!(
@@ -151,8 +178,7 @@ impl AuthConfig {
                 path.display()
             );
         }
-        let tokens = file
-            .tokens
+        file.tokens
             .into_iter()
             .enumerate()
             .map(|(i, e)| {
@@ -169,11 +195,73 @@ impl AuthConfig {
                     namespaces: e.namespaces,
                 })
             })
-            .collect::<anyhow::Result<Vec<_>>>()?;
-        Ok(Self {
-            tokens,
-            ..Default::default()
-        })
+            .collect::<anyhow::Result<Vec<_>>>()
+    }
+
+    /// Re-read `path` and swap the token set. On ANY error the current set
+    /// keeps serving (fail to last-good): a truncated mid-write file, a
+    /// malformed edit, or an emptied set can only be a no-op, never an
+    /// accidental auth widening or shutdown. Only the token cell is touched
+    /// — the JWT validator and the boot open/closed decision are immutable.
+    pub fn reload_from(&self, path: &Path) -> anyhow::Result<usize> {
+        let body = std::fs::read_to_string(path)
+            .map_err(|e| anyhow::anyhow!("reading auth tokens file {}: {e}", path.display()))?;
+        let tokens = Self::parse_tokens(path, &body)?;
+        let count = tokens.len();
+        *self.tokens.write().expect("auth token lock poisoned") = Arc::new(tokens);
+        Ok(count)
+    }
+
+    /// Poll `path` every `interval` and apply changes — the static-token
+    /// twin of the JWKS `spawn_refresh`. Content-compare, not mtime, so
+    /// rename(2) swaps and coarse clocks are immune; a zero interval
+    /// disables the task. HTTP picks a reload up on the next request;
+    /// multi-tenant Bolt on the next statement outside an explicit
+    /// transaction. Revocation does NOT terminate live single-tenant Bolt
+    /// sessions (their principal is cached at LOGON) — kill the connection
+    /// if immediate revocation is required.
+    pub fn spawn_file_reload(self: &Arc<Self>, path: std::path::PathBuf, interval: Duration) {
+        if interval.is_zero() {
+            return;
+        }
+        let auth = Arc::clone(self);
+        tokio::spawn(async move {
+            let mut last_applied: Option<Vec<u8>> = None;
+            let mut ticker = tokio::time::interval(interval);
+            ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+            loop {
+                ticker.tick().await;
+                let bytes = match std::fs::read(&path) {
+                    Ok(bytes) => bytes,
+                    Err(error) => {
+                        tracing::warn!(
+                            path = %path.display(),
+                            %error,
+                            "auth tokens file unreadable; keeping the current set"
+                        );
+                        continue;
+                    }
+                };
+                if last_applied.as_deref() == Some(bytes.as_slice()) {
+                    continue;
+                }
+                match auth.reload_from(&path) {
+                    Ok(count) => {
+                        last_applied = Some(bytes);
+                        tracing::info!(tokens = count, "auth tokens file reloaded");
+                    }
+                    Err(error) => {
+                        tracing::warn!(
+                            path = %path.display(),
+                            %error,
+                            "auth tokens file invalid; keeping the current set"
+                        );
+                        // Do not record the bytes: a later tick retries until
+                        // the file parses (covers partial writes healing).
+                    }
+                }
+            }
+        });
     }
 
     /// Attach a JWT validator. Bearer tokens are then first interpreted as
@@ -188,7 +276,7 @@ impl AuthConfig {
     /// the server runs open.
     pub fn is_open(&self) -> bool {
         let jwt_active = self.jwt_active();
-        self.tokens.is_empty() && !jwt_active
+        self.current_tokens().is_empty() && !jwt_active
     }
 
     #[cfg(feature = "jwt")]
@@ -242,8 +330,9 @@ impl AuthConfig {
     /// name, groups empty), honouring the namespace scope.
     fn token_principal(&self, presented: &str, namespace: &str) -> Option<Principal> {
         let single_tenant = namespace.is_empty();
+        let tokens = self.current_tokens();
         let mut granted: Option<&AuthToken> = None;
-        for t in &self.tokens {
+        for t in tokens.iter() {
             if constant_time_eq(presented.as_bytes(), t.secret.as_bytes())
                 && (single_tenant
                     || t.namespaces
@@ -287,8 +376,9 @@ impl AuthConfig {
                 return Some(role);
             }
         }
+        let tokens = self.current_tokens();
         let mut granted = None;
-        for t in &self.tokens {
+        for t in tokens.iter() {
             if constant_time_eq(presented.as_bytes(), t.secret.as_bytes())
                 && (single_tenant
                     || t.namespaces
@@ -303,7 +393,7 @@ impl AuthConfig {
 
     /// Number of configured tokens, for the boot log.
     pub(crate) fn len(&self) -> usize {
-        self.tokens.len()
+        self.current_tokens().len()
     }
 }
 
@@ -381,29 +471,26 @@ mod tests {
     #[allow(clippy::needless_update)]
     fn role_for_in_enforces_namespace_scope() {
         // acme-key is scoped to ["acme"]; beta-key to ["beta"]; any-key unscoped.
-        let c = AuthConfig {
-            tokens: vec![
-                AuthToken {
-                    name: "acme".into(),
-                    secret: Arc::from("acme-key"),
-                    role: Role::ReadWrite,
-                    namespaces: Some(vec!["acme".into()]),
-                },
-                AuthToken {
-                    name: "beta".into(),
-                    secret: Arc::from("beta-key"),
-                    role: Role::ReadOnly,
-                    namespaces: Some(vec!["beta".into()]),
-                },
-                AuthToken {
-                    name: "any".into(),
-                    secret: Arc::from("any-key"),
-                    role: Role::ReadWrite,
-                    namespaces: None,
-                },
-            ],
-            ..Default::default()
-        };
+        let c = AuthConfig::from_tokens(vec![
+            AuthToken {
+                name: "acme".into(),
+                secret: Arc::from("acme-key"),
+                role: Role::ReadWrite,
+                namespaces: Some(vec!["acme".into()]),
+            },
+            AuthToken {
+                name: "beta".into(),
+                secret: Arc::from("beta-key"),
+                role: Role::ReadOnly,
+                namespaces: Some(vec!["beta".into()]),
+            },
+            AuthToken {
+                name: "any".into(),
+                secret: Arc::from("any-key"),
+                role: Role::ReadWrite,
+                namespaces: None,
+            },
+        ]);
 
         // acme-key reaches acme but not beta.
         assert_eq!(c.role_for_in("acme-key", "acme"), Some(Role::ReadWrite));
@@ -425,23 +512,20 @@ mod tests {
     #[test]
     #[allow(clippy::needless_update)]
     fn role_for_distinguishes_read_only_and_read_write() {
-        let c = AuthConfig {
-            tokens: vec![
-                AuthToken {
-                    name: "rw".into(),
-                    secret: Arc::from("write-key"),
-                    role: Role::ReadWrite,
-                    namespaces: None,
-                },
-                AuthToken {
-                    name: "ro".into(),
-                    secret: Arc::from("read-key"),
-                    role: Role::ReadOnly,
-                    namespaces: None,
-                },
-            ],
-            ..Default::default()
-        };
+        let c = AuthConfig::from_tokens(vec![
+            AuthToken {
+                name: "rw".into(),
+                secret: Arc::from("write-key"),
+                role: Role::ReadWrite,
+                namespaces: None,
+            },
+            AuthToken {
+                name: "ro".into(),
+                secret: Arc::from("read-key"),
+                role: Role::ReadOnly,
+                namespaces: None,
+            },
+        ]);
         assert_eq!(c.role_for("write-key"), Some(Role::ReadWrite));
         assert_eq!(c.role_for("read-key"), Some(Role::ReadOnly));
         assert_eq!(c.role_for("nope"), None);
@@ -474,6 +558,118 @@ mod tests {
         let path = dir.join(format!("namidb-auth-empty-{}.json", std::process::id()));
         std::fs::write(&path, r#"{ "tokens": [] }"#).unwrap();
         assert!(AuthConfig::load_file(&path).is_err());
+        std::fs::remove_file(&path).ok();
+    }
+
+    fn temp_tokens_file(tag: &str, body: &str) -> std::path::PathBuf {
+        let path =
+            std::env::temp_dir().join(format!("namidb-auth-{tag}-{}.json", std::process::id()));
+        std::fs::write(&path, body).unwrap();
+        path
+    }
+
+    /// Item 58: a reload swaps grants in place — new token serves with its
+    /// new role, the removed one stops.
+    #[test]
+    fn reload_swaps_token_set() {
+        let path = temp_tokens_file(
+            "swap",
+            r#"{ "tokens": [{ "name": "old", "token": "old-key", "role": "read-write" }] }"#,
+        );
+        let c = AuthConfig::load_file(&path).unwrap();
+        assert_eq!(c.role_for("old-key"), Some(Role::ReadWrite));
+        std::fs::write(
+            &path,
+            r#"{ "tokens": [{ "name": "new", "token": "new-key", "role": "read-only" }] }"#,
+        )
+        .unwrap();
+        assert_eq!(c.reload_from(&path).unwrap(), 1);
+        assert_eq!(c.role_for("new-key"), Some(Role::ReadOnly));
+        assert_eq!(c.role_for("old-key"), None, "revoked token must stop");
+        std::fs::remove_file(&path).ok();
+    }
+
+    /// Fail to last-good: truncated JSON, an emptied set, and an empty
+    /// secret each error AND keep the original token serving — a reload
+    /// can never widen access or flip auth open.
+    #[test]
+    fn reload_keeps_old_set_on_malformed_file() {
+        let path = temp_tokens_file(
+            "malformed",
+            r#"{ "tokens": [{ "name": "good", "token": "good-key" }] }"#,
+        );
+        let c = AuthConfig::load_file(&path).unwrap();
+        for bad in [
+            r#"{ "tokens": [{ "name": "trunc""#,
+            r#"{ "tokens": [] }"#,
+            r#"{ "tokens": [{ "name": "empty", "token": "" }] }"#,
+        ] {
+            std::fs::write(&path, bad).unwrap();
+            assert!(c.reload_from(&path).is_err(), "{bad}");
+            assert_eq!(
+                c.role_for("good-key"),
+                Some(Role::ReadWrite),
+                "old set must keep serving after: {bad}"
+            );
+            assert!(!c.is_open(), "a bad reload must never open the server");
+        }
+        std::fs::remove_file(&path).ok();
+    }
+
+    /// Every consumer holds a clone of the boot Arc<AuthConfig>; the swap
+    /// is interior, so a reload through one handle must be visible through
+    /// all clones. Pins the design against a naive replace-the-Arc
+    /// regression.
+    #[test]
+    fn clones_share_reloads() {
+        let path = temp_tokens_file(
+            "clones",
+            r#"{ "tokens": [{ "name": "a", "token": "a-key" }] }"#,
+        );
+        let boot = AuthConfig::load_file(&path).unwrap();
+        let http_state = boot.clone();
+        let bolt_loop = boot.clone();
+        std::fs::write(
+            &path,
+            r#"{ "tokens": [{ "name": "b", "token": "b-key" }] }"#,
+        )
+        .unwrap();
+        boot.reload_from(&path).unwrap();
+        for (label, handle) in [("http", &http_state), ("bolt", &bolt_loop)] {
+            assert_eq!(handle.role_for("b-key"), Some(Role::ReadWrite), "{label}");
+            assert_eq!(handle.role_for("a-key"), None, "{label}");
+        }
+        std::fs::remove_file(&path).ok();
+    }
+
+    /// The poll task end-to-end: an on-disk edit is picked up within a few
+    /// intervals, and a later malformed write leaves the last good set.
+    #[tokio::test]
+    async fn spawn_file_reload_applies_disk_edits() {
+        let path = temp_tokens_file(
+            "poll",
+            r#"{ "tokens": [{ "name": "first", "token": "first-key" }] }"#,
+        );
+        let auth = Arc::new(AuthConfig::load_file(&path).unwrap());
+        auth.spawn_file_reload(path.clone(), Duration::from_millis(25));
+        std::fs::write(
+            &path,
+            r#"{ "tokens": [{ "name": "second", "token": "second-key" }] }"#,
+        )
+        .unwrap();
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        while auth.role_for("second-key").is_none() {
+            assert!(
+                std::time::Instant::now() < deadline,
+                "reload never picked up the edit"
+            );
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        assert_eq!(auth.role_for("first-key"), None);
+        // A malformed overwrite keeps the second set serving.
+        std::fs::write(&path, "not json").unwrap();
+        tokio::time::sleep(Duration::from_millis(120)).await;
+        assert_eq!(auth.role_for("second-key"), Some(Role::ReadWrite));
         std::fs::remove_file(&path).ok();
     }
 }

--- a/crates/namidb-server/src/lib.rs
+++ b/crates/namidb-server/src/lib.rs
@@ -121,6 +121,10 @@ pub struct Config {
     /// `read-write` role. Takes precedence over `auth_token` when set. `None`
     /// falls back to `auth_token`.
     pub auth_tokens_file: Option<std::path::PathBuf>,
+    /// How often to re-read `auth_tokens_file` and hot-swap the token set
+    /// (content-compare; malformed files keep the current set). Zero
+    /// disables the reload task.
+    pub auth_tokens_reload_interval: Duration,
     /// Explicit opt-in to run without any authentication (every request is
     /// anonymous read-write). Without this, a boot with no auth source
     /// configured fails instead of silently serving open — an unset
@@ -900,6 +904,18 @@ pub async fn run_with_memory_max_bytes(
         None => (auth, None),
     };
     let auth = Arc::new(auth);
+    // Hot-reload the static token set so onboarding/rotating a tenant's
+    // token no longer requires restarting everyone's namespaces (third
+    // field report, item 58).
+    if let Some(path) = &config.auth_tokens_file {
+        auth.spawn_file_reload(path.clone(), config.auth_tokens_reload_interval);
+        if !config.auth_tokens_reload_interval.is_zero() {
+            info!(
+                interval = ?config.auth_tokens_reload_interval,
+                "auth tokens file hot-reload enabled"
+            );
+        }
+    }
     // Refresh the JWKS hourly so keys can rotate without a restart.
     #[cfg(feature = "jwt")]
     if let Some(v) = &jwt_validator {
@@ -7617,6 +7633,87 @@ mod tests {
             default_ns.to_string(),
         );
         build_multi_tenant_router(shared)
+    }
+
+    /// Item 58 end-to-end over the real middleware: onboarding a tenant is
+    /// an atomic file rewrite + one poll interval — 401 before, 200 after —
+    /// and revocation flows the other way, with namespace scoping intact.
+    #[tokio::test]
+    async fn tokens_file_hot_reload_onboards_and_revokes_without_restart() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("tokens.json");
+        std::fs::write(
+            &path,
+            r#"{ "tokens": [{ "name": "acme", "token": "acme-key", "role": "read-write", "namespaces": ["acme"] }] }"#,
+        )
+        .unwrap();
+        let auth = Arc::new(AuthConfig::load_file(&path).unwrap());
+        auth.spawn_file_reload(path.clone(), Duration::from_millis(25));
+        let app = multi_tenant_app_auth(Arc::clone(&auth), "acme").await;
+
+        assert_eq!(
+            mt_cypher_token(&app, "/acme/v0/cypher", None, "acme-key", "RETURN 1 AS one").await,
+            StatusCode::OK
+        );
+        // The cooperative not yet onboarded: 401.
+        assert_eq!(
+            mt_cypher_token(&app, "/coop/v0/cypher", None, "coop-key", "RETURN 1 AS one").await,
+            StatusCode::UNAUTHORIZED
+        );
+
+        // Onboard via atomic rewrite (temp + rename, as the docs instruct).
+        let tmp = dir.path().join("tokens.json.tmp");
+        std::fs::write(
+            &tmp,
+            r#"{ "tokens": [
+                { "name": "acme", "token": "acme-key", "role": "read-write", "namespaces": ["acme"] },
+                { "name": "coop", "token": "coop-key", "role": "read-write", "namespaces": ["coop"] }
+            ] }"#,
+        )
+        .unwrap();
+        std::fs::rename(&tmp, &path).unwrap();
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        loop {
+            let status =
+                mt_cypher_token(&app, "/coop/v0/cypher", None, "coop-key", "RETURN 1 AS one").await;
+            if status == StatusCode::OK {
+                break;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "onboarded token never took effect, last status {status}"
+            );
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+        // Scoping still enforced for the new token: outside its namespace
+        // the token resolves no principal at all (401, matching the
+        // pre-reload middleware semantics pinned in the scoped-token tests).
+        assert_eq!(
+            mt_cypher_token(&app, "/acme/v0/cypher", None, "coop-key", "RETURN 1 AS one").await,
+            StatusCode::UNAUTHORIZED
+        );
+
+        // Revocation: rewrite without acme; next requests 401.
+        let tmp = dir.path().join("tokens.json.tmp");
+        std::fs::write(
+            &tmp,
+            r#"{ "tokens": [{ "name": "coop", "token": "coop-key", "role": "read-write", "namespaces": ["coop"] }] }"#,
+        )
+        .unwrap();
+        std::fs::rename(&tmp, &path).unwrap();
+        let deadline = std::time::Instant::now() + Duration::from_secs(5);
+        loop {
+            let status =
+                mt_cypher_token(&app, "/acme/v0/cypher", None, "acme-key", "RETURN 1 AS one").await;
+            if status == StatusCode::UNAUTHORIZED {
+                break;
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "revocation never took effect, last status {status}"
+            );
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
     }
 
     async fn mt_cypher_token(

--- a/crates/namidb-server/src/main.rs
+++ b/crates/namidb-server/src/main.rs
@@ -86,6 +86,18 @@ struct Cli {
     #[arg(long, env = "NAMIDB_AUTH_TOKENS_FILE")]
     auth_tokens_file: Option<std::path::PathBuf>,
 
+    /// How often to re-read `--auth-tokens-file` and hot-swap the token set
+    /// without a restart (write the file atomically: temp + rename). A
+    /// malformed or emptied file keeps the current set serving. `0s`
+    /// disables the reload task.
+    #[arg(
+        long,
+        env = "NAMIDB_AUTH_TOKENS_RELOAD_INTERVAL",
+        default_value = "10s",
+        value_parser = humantime::parse_duration,
+    )]
+    auth_tokens_reload_interval: Duration,
+
     // ── OIDC/JWT auth (only compiled with the `jwt` feature) ──────────
     /// JWKS URL to fetch signing keys for bearer-token JWT validation.
     /// Setting `--jwt-jwks-url` enables JWT auth: a bearer token is first
@@ -384,6 +396,7 @@ fn main() -> anyhow::Result<()> {
         listen: cli.listen,
         auth_token: cli.auth_token,
         auth_tokens_file: cli.auth_tokens_file,
+        auth_tokens_reload_interval: cli.auth_tokens_reload_interval,
         no_auth: cli.no_auth,
         group_commit_window: cli.group_commit_window,
         backup_target_uri: cli.backup_target_uri,

--- a/crates/namidb-server/tests/bolt_integration.rs
+++ b/crates/namidb-server/tests/bolt_integration.rs
@@ -162,6 +162,7 @@ async fn boot_bolt_grouped(ns: &str) -> (std::net::SocketAddr, tokio::task::Join
         listen: http_addr,
         auth_token: Some("test-token".into()),
         auth_tokens_file: None,
+        auth_tokens_reload_interval: std::time::Duration::ZERO,
         no_auth: false,
         backup_target_uri: None,
         group_commit_window: Duration::from_millis(2),
@@ -304,6 +305,7 @@ async fn boot_bolt_multi(
         default_namespace: format!("{ns_prefix}-default"),
         max_namespaces: 100,
         namespace_idle_timeout: Duration::from_secs(3600),
+        auth_tokens_reload_interval: std::time::Duration::ZERO,
     };
     let task = tokio::spawn(async move {
         if let Err(e) = namidb_server::run(config).await {
@@ -638,6 +640,7 @@ async fn boot_bolt_config(
         listen: http_addr,
         auth_token: Some("test-token".into()),
         auth_tokens_file: None,
+        auth_tokens_reload_interval: std::time::Duration::ZERO,
         no_auth: false,
         backup_target_uri: None,
         group_commit_window: Duration::ZERO,
@@ -734,6 +737,7 @@ async fn boot_bolt_tokens(
         default_namespace: ns.to_string(),
         max_namespaces: 100,
         namespace_idle_timeout: Duration::from_secs(3600),
+        auth_tokens_reload_interval: std::time::Duration::ZERO,
     };
     let task = tokio::spawn(async move {
         if let Err(e) = namidb_server::run(config).await {
@@ -959,6 +963,7 @@ async fn bolt_create_then_match_roundtrip() {
         listen: http_addr,
         auth_token: Some("test-token".into()),
         auth_tokens_file: None,
+        auth_tokens_reload_interval: std::time::Duration::ZERO,
         no_auth: false,
         backup_target_uri: None,
         group_commit_window: Duration::ZERO,
@@ -1052,6 +1057,7 @@ async fn bolt_bad_token_yields_failure() {
         listen: http_addr,
         auth_token: Some("correct-token".into()),
         auth_tokens_file: None,
+        auth_tokens_reload_interval: std::time::Duration::ZERO,
         no_auth: false,
         backup_target_uri: None,
         group_commit_window: Duration::ZERO,
@@ -1223,6 +1229,7 @@ async fn bolt_memgraph_introspection_populates_schema() {
         listen: http_addr,
         auth_token: Some("test-token".into()),
         auth_tokens_file: None,
+        auth_tokens_reload_interval: std::time::Duration::ZERO,
         no_auth: false,
         backup_target_uri: None,
         group_commit_window: Duration::ZERO,

--- a/crates/namidb-server/tests/ddl_index_backfill.rs
+++ b/crates/namidb-server/tests/ddl_index_backfill.rs
@@ -27,6 +27,7 @@ async fn boot(store_uri: String) -> String {
         listen: http_addr,
         auth_token: Some(TOKEN.into()),
         auth_tokens_file: None,
+        auth_tokens_reload_interval: std::time::Duration::ZERO,
         no_auth: false,
         backup_target_uri: None,
         group_commit_window: Duration::ZERO,

--- a/crates/namidb-server/tests/disk_full_degraded.rs
+++ b/crates/namidb-server/tests/disk_full_degraded.rs
@@ -29,6 +29,7 @@ async fn boot() -> String {
         listen: http_addr,
         auth_token: Some(TOKEN.into()),
         auth_tokens_file: None,
+        auth_tokens_reload_interval: std::time::Duration::ZERO,
         no_auth: false,
         backup_target_uri: None,
         group_commit_window: Duration::ZERO,

--- a/crates/namidb-server/tests/explain_surface.rs
+++ b/crates/namidb-server/tests/explain_surface.rs
@@ -20,6 +20,7 @@ async fn boot() -> String {
         listen: http_addr,
         auth_token: Some(TOKEN.into()),
         auth_tokens_file: None,
+        auth_tokens_reload_interval: std::time::Duration::ZERO,
         no_auth: false,
         backup_target_uri: None,
         group_commit_window: Duration::ZERO,

--- a/crates/namidb-server/tests/scan_gate.rs
+++ b/crates/namidb-server/tests/scan_gate.rs
@@ -22,6 +22,7 @@ async fn boot() -> String {
         listen: http_addr,
         auth_token: Some(TOKEN.into()),
         auth_tokens_file: None,
+        auth_tokens_reload_interval: std::time::Duration::ZERO,
         no_auth: false,
         backup_target_uri: None,
         group_commit_window: Duration::ZERO,

--- a/crates/namidb-server/tests/startup_validation.rs
+++ b/crates/namidb-server/tests/startup_validation.rs
@@ -12,6 +12,7 @@ fn base_config(ns: &str) -> namidb_server::Config {
         listen: "127.0.0.1:0".parse().unwrap(),
         auth_token: Some("test-token".into()),
         auth_tokens_file: None,
+        auth_tokens_reload_interval: std::time::Duration::ZERO,
         no_auth: false,
         backup_target_uri: None,
         group_commit_window: Duration::ZERO,

--- a/crates/namidb-server/tests/tls_integration.rs
+++ b/crates/namidb-server/tests/tls_integration.rs
@@ -66,6 +66,7 @@ async fn serves_https_and_bolt_over_tls() {
         backup_target_uri: None,
         group_commit_window: Duration::ZERO,
         auth_tokens_file: None,
+        auth_tokens_reload_interval: std::time::Duration::ZERO,
         #[cfg(feature = "jwt")]
         jwt: None,
         #[cfg(feature = "pdp")]

--- a/docs/multi-tenancy.md
+++ b/docs/multi-tenancy.md
@@ -336,12 +336,28 @@ for any namespace not in `tenants`. Mint and rotate it in your IdP — NamiDB on
 verifies it, and refreshes the JWKS hourly so key rotation needs no restart
 (`crates/namidb-server/src/lib.rs:461-465`).
 
-### Adding or rotating a static token requires a restart
+### Adding or rotating a static token: hot reload (since 2.5.0)
 
-`AuthConfig::load_file` runs once at boot (`lib.rs:437-438`); there is no SIGHUP
-reload for the static-token file. To add or rotate a static token: write the new
-entry, restart the server, then remove the old entry on a later restart. (JWT
-key rotation does *not* need a restart — the JWKS refreshes on a timer.)
+The server re-reads `--auth-tokens-file` on an interval
+(`--auth-tokens-reload-interval`, default `10s`, `0s` disables) and swaps the
+token set atomically — onboarding or rotating a tenant no longer restarts
+anyone. Semantics to rely on:
+
+- **Write the file atomically** (write a temp file, then `rename(2)`; keep it
+  `0600`). A partial or malformed file is rejected and the LAST GOOD set keeps
+  serving — a bad reload can never widen access, empty the set, or flip the
+  server open. The next tick picks up the completed write.
+- HTTP requests see a reload on the **next request** (both single- and
+  multi-tenant). Multi-tenant Bolt re-resolves the principal **per statement**
+  (pinned for the life of an explicit transaction).
+- **Revocation does not terminate live single-tenant Bolt sessions**: their
+  principal is cached at LOGON. Kill the connection (or restart) if immediate
+  revocation of an active session is required; fresh LOGONs with the revoked
+  token are refused as soon as the reload lands.
+- Change detection is content-compare, not mtime, so `rename(2)` swaps and
+  ConfigMap-style updates are picked up reliably.
+
+(JWT key rotation likewise needs no restart — the JWKS refreshes on a timer.)
 
 ## Proposed / Future
 
@@ -387,8 +403,6 @@ lazy.
   serving a JWKS — a new trust boundary, RFC-sized.
 - **Explicit namespace lifecycle.** A real create/list/delete API instead of
   lazy `get_or_open`, so provisioning and de-provisioning are first-class.
-- **Static-token hot-reload.** A SIGHUP / file-watch reload so a minted token
-  takes effect without a restart.
 - **PDP namespace input.** The external-PDP request document advertises an
   `input.namespace` field (`crates/namidb-server/src/pdp.rs:19-26`) but
   `plan_input` does not currently emit it (`pdp.rs:138-151`), so OPA policies


### PR DESCRIPTION
Onboarding or rotating a tenant's token no longer restarts every namespace.

- Token set behind interior mutability in `AuthConfig` — every consumer (HTTP, Bolt, shared state) holds a clone of the boot Arc, so the swap is inside the config; a naive Arc replacement is pinned against by test.
- `spawn_file_reload` mirrors the JWKS `spawn_refresh` precedent: interval poll (default 10s, `0s` disables), content-compare (rename-safe), and fail-to-last-good — boot's validations are shared, so a malformed/emptied file can never widen access or flip auth open.
- Documented semantics: atomic write (temp+rename), HTTP picks up per request, multi-tenant Bolt per statement, and revocation does not kill live single-tenant Bolt sessions (LOGON-cached principal).

Tests: 5 new (unit swap/fail-closed/shared-clones/poll-task + multi-tenant middleware onboard/scope/revoke round-trip). Gate: full workspace green (89 binaries), fmt, clippy.