### PR TITLE
List and cancel in-flight queries (field report 3, item 56)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,21 @@ crates.io release will establish and document that API explicitly.
 ## [Unreleased]
 
 **Added**
+- Operators can now see and kill in-flight queries: `GET /v0/admin/queries`
+  lists them (id, protocol, namespace, sanitized statement, elapsed) and
+  `POST /v0/admin/queries/:id/cancel` aborts one at the executor's
+  cooperative probe points — the same ~hundred sites the query timeout
+  uses, covering reads and writes over HTTP and Bolt, single- and
+  multi-tenant (namespace-scoped: a tenant token can neither see nor
+  cancel another tenant's queries). A cancelled write surfaces
+  "query cancelled by administrator" (HTTP 409 `cancelled`,
+  Bolt `Neo.TransientError.Transaction.Terminated`), discards its staged
+  batch through the same recovery path an error takes, and leaves the
+  writer immediately usable. Both routes sit behind auth and the
+  write-role gate; statement text never reaches unauthenticated
+  `/v0/metrics`. Found along the way: a bare giant `UNWIND range(...)`
+  expansion had no cooperative probes at all — it could neither time out
+  nor be cancelled; the loops now probe like every other operator.
 - The static auth tokens file hot-reloads: the server re-reads
   `--auth-tokens-file` on `--auth-tokens-reload-interval` (default 10s,
   `0s` disables) and swaps the token set atomically, so onboarding or

--- a/crates/namidb-bolt/src/session.rs
+++ b/crates/namidb-bolt/src/session.rs
@@ -530,6 +530,10 @@ pub enum BackendError {
     /// The query exceeded a configured deterministic result limit (row cap,
     /// search result caps). Also deliberately not transient.
     ResourceLimit(String),
+    /// An administrator cancelled this execution. Transient by Neo4j
+    /// convention (Transaction.Terminated): the STATEMENT may be retried —
+    /// whether it should be is the operator's conversation to have.
+    Cancelled(String),
     /// Anything else.
     Other(String),
 }
@@ -545,6 +549,7 @@ impl BackendError {
             BackendError::Constraint(_) => "Neo.ClientError.Schema.ConstraintValidationFailed",
             BackendError::Forbidden(_) => "Neo.ClientError.Security.Forbidden",
             BackendError::Timeout(_) => "Neo.ClientError.Transaction.TransactionTimedOut",
+            BackendError::Cancelled(_) => "Neo.TransientError.Transaction.Terminated",
             BackendError::ResourceLimit(_) => "Neo.ClientError.Statement.ResourceLimitExceeded",
             BackendError::Other(_) => "Neo.DatabaseError.General.UnknownError",
         }
@@ -561,6 +566,7 @@ impl BackendError {
             | BackendError::Forbidden(s)
             | BackendError::Timeout(s)
             | BackendError::ResourceLimit(s)
+            | BackendError::Cancelled(s)
             | BackendError::Other(s) => s,
         }
     }

--- a/crates/namidb-query/src/exec/limits.rs
+++ b/crates/namidb-query/src/exec/limits.rs
@@ -57,10 +57,11 @@ pub(crate) async fn with_limits<F: Future>(
 /// scoped.
 #[inline]
 pub(crate) fn check_deadline() -> Result<(), ExecError> {
-    if namidb_storage::cancel::deadline_exceeded() {
-        Err(ExecError::Timeout)
-    } else {
-        Ok(())
+    use namidb_storage::cancel::Interrupt;
+    match namidb_storage::cancel::interrupted() {
+        None => Ok(()),
+        Some(Interrupt::Timeout) => Err(ExecError::Timeout),
+        Some(Interrupt::Cancelled) => Err(ExecError::Cancelled),
     }
 }
 

--- a/crates/namidb-query/src/exec/walker.rs
+++ b/crates/namidb-query/src/exec/walker.rs
@@ -43,6 +43,10 @@ pub enum ExecError {
     /// configured query timeout). Surfaced from the scan / expand loops and
     /// at operator boundaries; never raised when no deadline is in scope.
     Timeout,
+    /// The query was cancelled by an administrator (the server's cancel
+    /// flag, probed at the same cooperative sites as the deadline). Never
+    /// raised when no flag is in scope.
+    Cancelled,
     /// A read query tried to materialise more rows in one operator than the
     /// server's configured row cap allows. Carries the cap. Never raised
     /// when no cap is in scope.
@@ -57,6 +61,7 @@ impl fmt::Display for ExecError {
             ExecError::Runtime(m) => write!(f, "runtime: {}", m),
             ExecError::Constraint(m) => write!(f, "constraint violation: {}", m),
             ExecError::Timeout => write!(f, "query exceeded the configured timeout"),
+            ExecError::Cancelled => write!(f, "query cancelled by administrator"),
             ExecError::RowCap(cap) => {
                 write!(f, "query exceeded the configured row cap of {cap}")
             }
@@ -954,10 +959,18 @@ pub(crate) fn execute_inner_with_routing<'a>(
                     execute_inner_with_routing(input, snapshot, params, outer, routing).await?;
                 let mut out = Vec::new();
                 for row in rows {
+                    // A huge `UNWIND range(...)` is a pure-CPU expansion with
+                    // no scan underneath — without a probe here it could
+                    // neither time out nor be cancelled (found by the item-56
+                    // cancel test).
+                    crate::exec::limits::check_deadline()?;
                     let v = evaluate(list, &row, params)?;
                     match v {
                         RuntimeValue::List(items) => {
                             for item in items {
+                                if out.len() % namidb_storage::cancel::CHECK_STRIDE == 0 {
+                                    crate::exec::limits::check_deadline()?;
+                                }
                                 let mut new_row = row.clone();
                                 new_row.set(alias.clone(), item);
                                 out.push(new_row);
@@ -7958,10 +7971,15 @@ pub(crate) fn execute_factor_inner_with_routing<'a>(
                 let input_rows = input_set.materialize_all(None);
                 let mut out = Vec::new();
                 for row in input_rows {
+                    // Same cancellation probes as the flat Unwind arm.
+                    crate::exec::limits::check_deadline()?;
                     let v = evaluate(list, &row, params)?;
                     match v {
                         RuntimeValue::List(items) => {
                             for item in items {
+                                if out.len() % namidb_storage::cancel::CHECK_STRIDE == 0 {
+                                    crate::exec::limits::check_deadline()?;
+                                }
                                 let mut new_row = row.clone();
                                 new_row.set(alias.clone(), item);
                                 out.push(new_row);

--- a/crates/namidb-server/src/bolt.rs
+++ b/crates/namidb-server/src/bolt.rs
@@ -1252,7 +1252,17 @@ impl ServerBackend {
         }
 
         let _in_flight = self.state.metrics.track_in_flight();
-        let obs = self.run_query(cypher, params, &cancellation).await;
+        let registered = self.state.metrics.queries().register(
+            crate::metrics::Protocol::Bolt,
+            &self.state.namespace,
+            cypher,
+        );
+        let obs = namidb_storage::cancel::with_cancel_flag(
+            registered.cancel_flag(),
+            self.run_query(cypher, params, &cancellation),
+        )
+        .await;
+        drop(registered);
         self.state.metrics.observe_query(
             Protocol::Bolt,
             obs.kind,
@@ -1294,7 +1304,17 @@ impl ServerBackend {
         }
 
         let _in_flight = self.state.metrics.track_in_flight();
-        let obs = self.run_query_in_tx(cypher, params, &cancellation).await;
+        let registered = self.state.metrics.queries().register(
+            crate::metrics::Protocol::Bolt,
+            &self.state.namespace,
+            cypher,
+        );
+        let obs = namidb_storage::cancel::with_cancel_flag(
+            registered.cancel_flag(),
+            self.run_query_in_tx(cypher, params, &cancellation),
+        )
+        .await;
+        drop(registered);
         self.state.metrics.observe_query(
             Protocol::Bolt,
             obs.kind,
@@ -1577,6 +1597,9 @@ fn map_exec_err_ref(e: &ExecError) -> BackendError {
         // query is malformed" without string-matching the message, and must
         // NOT auto-retry either (a re-run exceeds the same budget again).
         ExecError::Timeout => BackendError::Timeout("query exceeded the configured timeout".into()),
+        ExecError::Cancelled | ExecError::Storage(namidb_storage::Error::Cancelled) => {
+            BackendError::Cancelled("query cancelled by administrator".into())
+        }
         ExecError::RowCap(cap) => {
             BackendError::ResourceLimit(format!("query exceeded the configured row cap of {cap}"))
         }

--- a/crates/namidb-server/src/lib.rs
+++ b/crates/namidb-server/src/lib.rs
@@ -688,6 +688,8 @@ pub fn build_router(state: AppState) -> Router {
     let maintenance = Router::new()
         .route("/v0/admin/flush", post(admin_flush))
         .route("/v0/admin/backup", post(admin_backup))
+        .route("/v0/admin/queries", get(admin_queries))
+        .route("/v0/admin/queries/:id/cancel", post(admin_cancel_query))
         .layer(middleware::from_fn_with_state(state.clone(), require_auth));
 
     limit_router(
@@ -795,6 +797,11 @@ pub fn build_multi_tenant_router(shared: SharedAppState) -> Router {
         .route("/v0/admin/flush", post(admin_flush_multi_unprefixed))
         .route("/:namespace/v0/admin/backup", post(admin_backup_multi))
         .route("/v0/admin/backup", post(admin_backup_multi_unprefixed))
+        .route("/:namespace/v0/admin/queries", get(admin_queries_multi))
+        .route(
+            "/:namespace/v0/admin/queries/:id/cancel",
+            post(admin_cancel_query_multi),
+        )
         .layer(middleware::from_fn_with_state(
             shared.clone(),
             require_auth_multi,
@@ -1616,6 +1623,9 @@ fn exec_error_classification(
     use namidb_query::exec::ExecError;
     match e {
         ExecError::Timeout => (StatusCode::GATEWAY_TIMEOUT, Some("timeout")),
+        ExecError::Cancelled | ExecError::Storage(namidb_storage::Error::Cancelled) => {
+            (StatusCode::CONFLICT, Some("cancelled"))
+        }
         ExecError::RowCap(_) => (StatusCode::PAYLOAD_TOO_LARGE, Some("row_cap")),
         // A unique-constraint violation is a client error (duplicate value), not
         // a server fault — surface it as 409 Conflict.
@@ -1656,6 +1666,9 @@ fn exec_error_taxonomy(e: &namidb_query::exec::ExecError) -> (&'static str, &'st
     use namidb_query::exec::ExecError;
     match e {
         ExecError::Timeout => ("Neo.ClientError.Transaction.TransactionTimedOut", "57014"),
+        ExecError::Cancelled | ExecError::Storage(namidb_storage::Error::Cancelled) => {
+            ("Neo.TransientError.Transaction.Terminated", "57014")
+        }
         ExecError::RowCap(_) => ("Neo.ClientError.Statement.ResourceLimitExceeded", "54000"),
         ExecError::Constraint(_) => ("Neo.ClientError.Schema.ConstraintValidationFailed", "23000"),
         ExecError::Storage(
@@ -3078,9 +3091,20 @@ async fn cypher(
     Json(req): Json<CypherRequest>,
 ) -> Response {
     // The guard drops at the end of the handler, so the in-flight gauge is
-    // correct even on an early error return.
+    // correct even on an early error return. The registration guard does the
+    // same for the operator-visible query list, and its cancel flag scopes
+    // the whole run so /v0/admin/queries/:id/cancel aborts it cooperatively.
     let _in_flight = state.metrics.track_in_flight();
-    let obs = run_cypher(&state, &req, &principal).await;
+    let registered = state
+        .metrics
+        .queries()
+        .register(Protocol::Http, &state.namespace, &req.query);
+    let obs = namidb_storage::cancel::with_cancel_flag(
+        registered.cancel_flag(),
+        run_cypher(&state, &req, &principal),
+    )
+    .await;
+    drop(registered);
     state
         .metrics
         .observe_query(Protocol::Http, obs.kind, obs.ok, obs.elapsed, &req.query);
@@ -3485,6 +3509,111 @@ struct FlushResponse {
     ssts_written: usize,
     bloom_sidecars_written: usize,
     manifest_version: u64,
+}
+
+/// `GET /v0/admin/queries` — the in-flight query list (item 56). Role-gated
+/// like the other admin routes, and NEVER on the unauthenticated /v0/metrics:
+/// entries carry statement text.
+async fn admin_queries(
+    State(state): State<AppState>,
+    Extension(principal): Extension<Principal>,
+) -> Response {
+    if !principal.allows_write() {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(ErrorBody {
+                error: "this token is read-only; the query list is forbidden".into(),
+            }),
+        )
+            .into_response();
+    }
+    Json(serde_json::json!({ "queries": state.metrics.queries().list(None) })).into_response()
+}
+
+/// `POST /v0/admin/queries/:id/cancel` — flip one in-flight query's cancel
+/// flag. The query aborts at its next cooperative probe with "query
+/// cancelled by administrator" and its writer/session recovers through the
+/// same discard path an error takes. 404 = already finished or never
+/// existed (cancel is never retroactive).
+async fn admin_cancel_query(
+    State(state): State<AppState>,
+    Extension(principal): Extension<Principal>,
+    axum::extract::Path(id): axum::extract::Path<u64>,
+) -> Response {
+    if !principal.allows_write() {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(ErrorBody {
+                error: "this token is read-only; query cancel is forbidden".into(),
+            }),
+        )
+            .into_response();
+    }
+    if state.metrics.queries().cancel(id, None) {
+        Json(serde_json::json!({ "cancelled": id })).into_response()
+    } else {
+        (
+            StatusCode::NOT_FOUND,
+            Json(ErrorBody {
+                error: format!("no in-flight query with id {id}"),
+            }),
+        )
+            .into_response()
+    }
+}
+
+/// Multi-tenant twins: the view and the cancel are scoped to the request's
+/// namespace, so a tenant-scoped token can neither read nor kill another
+/// tenant's queries.
+async fn admin_queries_multi(
+    State(shared): State<SharedAppState>,
+    Extension(principal): Extension<Principal>,
+    axum::extract::Path(namespace): axum::extract::Path<String>,
+) -> Response {
+    if !principal.allows_write() {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(ErrorBody {
+                error: "this token is read-only; the query list is forbidden".into(),
+            }),
+        )
+            .into_response();
+    }
+    Json(serde_json::json!({
+        "queries": shared.metrics.queries().list(Some(namespace.as_str()))
+    }))
+    .into_response()
+}
+
+async fn admin_cancel_query_multi(
+    State(shared): State<SharedAppState>,
+    Extension(principal): Extension<Principal>,
+    axum::extract::Path((namespace, id)): axum::extract::Path<(String, u64)>,
+) -> Response {
+    if !principal.allows_write() {
+        return (
+            StatusCode::FORBIDDEN,
+            Json(ErrorBody {
+                error: "this token is read-only; query cancel is forbidden".into(),
+            }),
+        )
+            .into_response();
+    }
+    if shared
+        .metrics
+        .queries()
+        .cancel(id, Some(namespace.as_str()))
+    {
+        Json(serde_json::json!({ "cancelled": id })).into_response()
+    } else {
+        (
+            StatusCode::NOT_FOUND,
+            Json(ErrorBody {
+                error: format!("no in-flight query with id {id} in this namespace"),
+            }),
+        )
+            .into_response()
+    }
 }
 
 async fn admin_flush(
@@ -3959,7 +4088,16 @@ async fn dispatch_cypher_multi(
         }
     };
 
-    let obs = run_cypher_multi(&ns_state, shared, &req, principal).await;
+    let registered = shared
+        .metrics
+        .queries()
+        .register(Protocol::Http, namespace, &req.query);
+    let obs = namidb_storage::cancel::with_cancel_flag(
+        registered.cancel_flag(),
+        run_cypher_multi(&ns_state, shared, &req, principal),
+    )
+    .await;
+    drop(registered);
     shared
         .metrics
         .observe_query(Protocol::Http, obs.kind, obs.ok, obs.elapsed, &req.query);
@@ -4688,6 +4826,274 @@ mod tests {
         let writer = WriterSession::open(store, paths).await.unwrap();
         let state = AppState::new(writer, auth_token.map(|s| s.to_string()), "test".into());
         build_router(state)
+    }
+
+    async fn post_json(app: &Router, uri: &str, body: serde_json::Value) -> (StatusCode, String) {
+        let bytes = serde_json::to_vec(&body).unwrap();
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri(uri)
+                    .header("content-type", "application/json")
+                    .header(axum::http::header::CONTENT_LENGTH, bytes.len().to_string())
+                    .body(Body::from(bytes))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let status = response.status();
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        (status, String::from_utf8_lossy(&body).into_owned())
+    }
+
+    async fn get_json(app: &Router, uri: &str) -> (StatusCode, String) {
+        let response = app
+            .clone()
+            .oneshot(Request::builder().uri(uri).body(Body::empty()).unwrap())
+            .await
+            .unwrap();
+        let status = response.status();
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        (status, String::from_utf8_lossy(&body).into_owned())
+    }
+
+    /// Item 56 end-to-end: a runaway write is listed with its statement and
+    /// growing elapsed, POST cancel aborts it with the cancelled error, the
+    /// writer is immediately usable, no partial rows leak, and the registry
+    /// drains to empty.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn admin_can_list_and_cancel_a_runaway_write() {
+        let app = fixture(None).await;
+
+        let runaway = "UNWIND range(1, 4000000) AS i CREATE (:Runaway {v: i})";
+        let app_for_write = app.clone();
+        let write = tokio::spawn(async move {
+            post_json(
+                &app_for_write,
+                "/v0/cypher",
+                serde_json::json!({ "query": runaway }),
+            )
+            .await
+        });
+
+        // Poll until the write shows up in the list.
+        let deadline = std::time::Instant::now() + Duration::from_secs(10);
+        let id = loop {
+            let (status, body) = get_json(&app, "/v0/admin/queries").await;
+            assert_eq!(status, StatusCode::OK, "{body}");
+            let parsed: serde_json::Value = serde_json::from_str(&body).unwrap();
+            let queries = parsed["queries"].as_array().unwrap();
+            if let Some(entry) = queries
+                .iter()
+                .find(|q| q["statement"].as_str().unwrap().contains("Runaway"))
+            {
+                assert_eq!(entry["protocol"], "http");
+                break entry["id"].as_u64().unwrap();
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "runaway write never appeared in the list"
+            );
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        };
+
+        let (status, body) = post_json(
+            &app,
+            &format!("/v0/admin/queries/{id}/cancel"),
+            serde_json::json!({}),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{body}");
+
+        let (status, body) = write.await.unwrap();
+        assert_eq!(status, StatusCode::CONFLICT, "cancelled write: {body}");
+        assert!(
+            body.contains("cancelled") && body.contains("Terminated"),
+            "cancel must be named with its taxonomy: {body}"
+        );
+
+        // No partial rows: the staged batch was discarded, not committed.
+        let (status, body) = post_json(
+            &app,
+            "/v0/cypher",
+            serde_json::json!({ "query": "MATCH (r:Runaway) RETURN count(r) AS n" }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{body}");
+        assert!(body.contains("\"n\":0"), "no partial rows may leak: {body}");
+
+        // The writer is immediately usable and the registry drains.
+        let (status, body) = post_json(
+            &app,
+            "/v0/cypher",
+            serde_json::json!({ "query": "CREATE (:After {ok: true})" }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{body}");
+        let (_, body) = get_json(&app, "/v0/admin/queries").await;
+        let parsed: serde_json::Value = serde_json::from_str(&body).unwrap();
+        assert!(
+            parsed["queries"].as_array().unwrap().is_empty(),
+            "registry must drain: {body}"
+        );
+
+        // Cancelling a finished id is a 404, never a cross-query kill.
+        let (status, _) = post_json(
+            &app,
+            &format!("/v0/admin/queries/{id}/cancel"),
+            serde_json::json!({}),
+        )
+        .await;
+        assert_eq!(status, StatusCode::NOT_FOUND);
+    }
+
+    /// Multi-tenant scoping: a namespace's admin surface neither lists nor
+    /// cancels another tenant's queries.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn multi_tenant_query_admin_is_namespace_scoped() {
+        let app = multi_tenant_app("default").await;
+
+        let runaway = "UNWIND range(1, 4000000) AS i CREATE (:Runaway {v: i})";
+        let app_for_write = app.clone();
+        let write = tokio::spawn(async move {
+            post_json(
+                &app_for_write,
+                "/acme/v0/cypher",
+                serde_json::json!({ "query": runaway }),
+            )
+            .await
+        });
+
+        let deadline = std::time::Instant::now() + Duration::from_secs(10);
+        let id = loop {
+            let (_, body) = get_json(&app, "/acme/v0/admin/queries").await;
+            let parsed: serde_json::Value = serde_json::from_str(&body).unwrap();
+            if let Some(entry) = parsed["queries"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .find(|q| q["statement"].as_str().unwrap().contains("Runaway"))
+            {
+                assert_eq!(entry["namespace"], "acme");
+                break entry["id"].as_u64().unwrap();
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "write never listed in its namespace"
+            );
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        };
+
+        // Another namespace sees nothing and cannot cancel it.
+        let (_, body) = get_json(&app, "/beta/v0/admin/queries").await;
+        let parsed: serde_json::Value = serde_json::from_str(&body).unwrap();
+        assert!(parsed["queries"].as_array().unwrap().is_empty(), "{body}");
+        let (status, _) = post_json(
+            &app,
+            &format!("/beta/v0/admin/queries/{id}/cancel"),
+            serde_json::json!({}),
+        )
+        .await;
+        assert_eq!(
+            status,
+            StatusCode::NOT_FOUND,
+            "cross-namespace cancel must 404"
+        );
+
+        // The owning namespace can.
+        let (status, _) = post_json(
+            &app,
+            &format!("/acme/v0/admin/queries/{id}/cancel"),
+            serde_json::json!({}),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        let (status, body) = write.await.unwrap();
+        assert_eq!(status, StatusCode::CONFLICT, "{body}");
+    }
+
+    /// A long READ cancels through the same probes (the scan/expand loops).
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn admin_can_cancel_a_runaway_read() {
+        let app = fixture(None).await;
+        let runaway =
+            "UNWIND range(1, 4000) AS a UNWIND range(1, 4000) AS b RETURN count(a * b) AS n";
+        let app_for_read = app.clone();
+        let read = tokio::spawn(async move {
+            post_json(
+                &app_for_read,
+                "/v0/cypher",
+                serde_json::json!({ "query": runaway }),
+            )
+            .await
+        });
+        let deadline = std::time::Instant::now() + Duration::from_secs(10);
+        let id = loop {
+            let (_, body) = get_json(&app, "/v0/admin/queries").await;
+            let parsed: serde_json::Value = serde_json::from_str(&body).unwrap();
+            if let Some(entry) = parsed["queries"]
+                .as_array()
+                .unwrap()
+                .iter()
+                .find(|q| q["statement"].as_str().unwrap().contains("UNWIND"))
+            {
+                break entry["id"].as_u64().unwrap();
+            }
+            assert!(
+                std::time::Instant::now() < deadline,
+                "read never appeared in the list"
+            );
+            tokio::time::sleep(Duration::from_millis(5)).await;
+        };
+        let (status, _) = post_json(
+            &app,
+            &format!("/v0/admin/queries/{id}/cancel"),
+            serde_json::json!({}),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK);
+        let (status, body) = read.await.unwrap();
+        assert_eq!(status, StatusCode::CONFLICT, "{body}");
+        assert!(body.contains("cancelled"), "{body}");
+    }
+
+    /// The query list carries statement text: read-only tokens get 403 on
+    /// both routes, and the unauthenticated /v0/metrics never exposes it.
+    #[tokio::test]
+    async fn query_admin_requires_the_write_role() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("tokens.json");
+        std::fs::write(
+            &path,
+            r#"{ "tokens": [{ "name": "ro", "token": "ro-key", "role": "read-only" }] }"#,
+        )
+        .unwrap();
+        let auth = Arc::new(AuthConfig::load_file(&path).unwrap());
+        let app = multi_tenant_app_auth(auth, "default").await;
+        for (method, uri) in [
+            ("GET", "/acme/v0/admin/queries"),
+            ("POST", "/acme/v0/admin/queries/1/cancel"),
+        ] {
+            let response = app
+                .clone()
+                .oneshot(
+                    Request::builder()
+                        .method(method)
+                        .uri(uri)
+                        .header("authorization", "Bearer ro-key")
+                        .body(Body::empty())
+                        .unwrap(),
+                )
+                .await
+                .unwrap();
+            assert_eq!(
+                response.status(),
+                StatusCode::FORBIDDEN,
+                "{method} {uri} must be write-role gated"
+            );
+        }
     }
 
     /// Plan item 28: the HTTP JSON parameter route had no unit tests and no

--- a/crates/namidb-server/src/main.rs
+++ b/crates/namidb-server/src/main.rs
@@ -457,11 +457,16 @@ mod tests {
     use clap::CommandFactory;
     use clap::Parser;
 
+    /// Both tests parse the environment, so they serialize on one lock —
+    /// clap reads the NAMIDB_* vars on every try_parse_from.
+    static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
     /// The three boolean flags accept `1/0/yes/no/on/off` on the CLI and —
     /// the field-report case — through their env vars, while garbage stays
     /// an error (NAMIDB_NO_AUTH must never coerce junk to true).
     #[test]
     fn boolean_flags_accept_boolish_values() {
+        let _guard = ENV_LOCK.lock().unwrap();
         Cli::command().debug_assert();
         let base = ["namidb-server", "--store", "memory://t"];
         let parse = |extra: &[&str]| {
@@ -508,7 +513,6 @@ mod tests {
     /// Serialized: env is process-global.
     #[test]
     fn boolean_envs_accept_boolish_values() {
-        static ENV_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
         let _guard = ENV_LOCK.lock().unwrap();
         let base = ["namidb-server", "--store", "memory://t"];
         for (value, expected) in [("1", true), ("0", false), ("yes", true), ("off", false)] {

--- a/crates/namidb-server/src/metrics.rs
+++ b/crates/namidb-server/src/metrics.rs
@@ -332,6 +332,7 @@ pub struct Metrics {
     bolt: ProtoMetrics,
     writer_locks: [WriterLockMetrics; WriterLockKind::ALL.len()],
     compactions: [CompactionMetrics; CompactionTrigger::ALL.len()],
+    queries: Arc<QueryRegistry>,
 }
 
 impl Metrics {
@@ -348,7 +349,13 @@ impl Metrics {
             bolt: ProtoMetrics::new(),
             writer_locks: std::array::from_fn(|_| WriterLockMetrics::new()),
             compactions: std::array::from_fn(|_| CompactionMetrics::new()),
+            queries: Arc::new(QueryRegistry::default()),
         })
+    }
+
+    /// The in-flight query registry (list + cancel admin surface).
+    pub fn queries(&self) -> &Arc<QueryRegistry> {
+        &self.queries
     }
 
     fn proto(&self, protocol: Protocol) -> &ProtoMetrics {
@@ -1047,6 +1054,142 @@ impl Metrics {
 
 /// RAII guard returned by [`Metrics::track_in_flight`]; decrements the
 /// in-flight gauge on drop.
+/// One in-flight query visible to operators: registered when a statement
+/// enters a serving path, deregistered by RAII when it finishes (guard drop
+/// is airtight through panic and early return). The cancel flag is the
+/// operator's handle into the executor's cooperative probe sites.
+struct QueryEntry {
+    protocol: Protocol,
+    namespace: String,
+    statement: String,
+    started: Instant,
+    cancel: Arc<std::sync::atomic::AtomicBool>,
+}
+
+/// A listed in-flight query, as served by `GET /v0/admin/queries`.
+#[derive(Debug, Clone, serde::Serialize)]
+pub struct QueryInfo {
+    pub id: u64,
+    pub protocol: &'static str,
+    pub namespace: String,
+    pub statement: String,
+    pub elapsed_ms: u64,
+}
+
+/// Registry of in-flight queries (field report 3, item 56). Lives on
+/// [`Metrics`] because every serving path already holds it; statement text
+/// is operator-visible, so the routes exposing this sit behind auth and the
+/// write-role gate.
+#[derive(Default)]
+pub struct QueryRegistry {
+    next_id: AtomicU64,
+    entries: std::sync::Mutex<std::collections::HashMap<u64, QueryEntry>>,
+}
+
+impl std::fmt::Debug for QueryRegistry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("QueryRegistry").finish_non_exhaustive()
+    }
+}
+
+impl QueryRegistry {
+    /// Register one query; the returned guard deregisters on Drop and
+    /// carries the cancel flag to scope over the execution.
+    pub fn register(
+        self: &Arc<Self>,
+        protocol: Protocol,
+        namespace: &str,
+        statement: &str,
+    ) -> RegisteredQuery {
+        let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+        let cancel = Arc::new(std::sync::atomic::AtomicBool::new(false));
+        self.entries.lock().expect("query registry lock").insert(
+            id,
+            QueryEntry {
+                protocol,
+                namespace: namespace.to_string(),
+                statement: sanitize_query(statement),
+                started: Instant::now(),
+                cancel: Arc::clone(&cancel),
+            },
+        );
+        RegisteredQuery {
+            registry: Arc::clone(self),
+            id,
+            cancel,
+        }
+    }
+
+    /// Snapshot of in-flight queries, longest-running first. `None` lists
+    /// every namespace (the single-tenant admin surface); `Some(ns)` scopes
+    /// the view to one tenant so a namespace-scoped token can never read
+    /// another tenant's statements.
+    pub fn list(&self, namespace: Option<&str>) -> Vec<QueryInfo> {
+        let entries = self.entries.lock().expect("query registry lock");
+        let mut out: Vec<QueryInfo> = entries
+            .iter()
+            .filter(|(_, e)| namespace.is_none_or(|ns| e.namespace == ns))
+            .map(|(id, e)| QueryInfo {
+                id: *id,
+                protocol: match e.protocol {
+                    Protocol::Http => "http",
+                    Protocol::Bolt => "bolt",
+                },
+                namespace: e.namespace.clone(),
+                statement: e.statement.clone(),
+                elapsed_ms: e.started.elapsed().as_millis() as u64,
+            })
+            .collect();
+        out.sort_by_key(|q| std::cmp::Reverse(q.elapsed_ms));
+        out
+    }
+
+    /// Flip a query's cancel flag. `false` = unknown id (already finished
+    /// or never existed) — cancel is NOT retroactive and cannot cross into
+    /// another query by construction: the flag lives on the entry's own Arc
+    /// and the entry leaves the map when the query completes.
+    pub fn cancel(&self, id: u64, namespace: Option<&str>) -> bool {
+        let entries = self.entries.lock().expect("query registry lock");
+        match entries
+            .get(&id)
+            .filter(|e| namespace.is_none_or(|ns| e.namespace == ns))
+        {
+            Some(entry) => {
+                entry
+                    .cancel
+                    .store(true, std::sync::atomic::Ordering::Relaxed);
+                true
+            }
+            None => false,
+        }
+    }
+
+}
+
+/// RAII registration: deregisters on Drop; exposes the cancel flag for the
+/// execution scope.
+pub struct RegisteredQuery {
+    registry: Arc<QueryRegistry>,
+    id: u64,
+    cancel: Arc<std::sync::atomic::AtomicBool>,
+}
+
+impl RegisteredQuery {
+    pub fn cancel_flag(&self) -> Arc<std::sync::atomic::AtomicBool> {
+        Arc::clone(&self.cancel)
+    }
+}
+
+impl Drop for RegisteredQuery {
+    fn drop(&mut self) {
+        self.registry
+            .entries
+            .lock()
+            .expect("query registry lock")
+            .remove(&self.id);
+    }
+}
+
 pub struct InFlightGuard(Arc<Metrics>);
 
 impl Drop for InFlightGuard {

--- a/crates/namidb-storage/src/cancel.rs
+++ b/crates/namidb-storage/src/cancel.rs
@@ -14,41 +14,109 @@
 //! its baseline cost.
 
 use std::future::Future;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 use std::time::Instant;
 
 use crate::error::{Error, Result};
 
+/// What interrupted a cooperative probe: the wall clock, or an operator.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Interrupt {
+    Timeout,
+    Cancelled,
+}
+
+/// The guards a task runs under: an optional wall-clock deadline and an
+/// optional operator-flippable cancel flag. Both are probed by the same
+/// ~hundred cooperative check sites, so an admin cancel aborts exactly
+/// where a timeout would.
+#[derive(Debug, Clone, Default)]
+struct CancelCtx {
+    deadline: Option<Instant>,
+    cancel: Option<Arc<AtomicBool>>,
+}
+
 tokio::task_local! {
-    static DEADLINE: Instant;
+    static CTX: CancelCtx;
 }
 
 /// Run `fut` with `deadline` scoped on the current task, so any read this
-/// task performs can probe it. `None` runs `fut` unguarded: no task-local is
-/// installed, so [`check`] and [`deadline_exceeded`] stay no-ops.
+/// task performs can probe it. `None` runs `fut` unguarded (an
+/// already-scoped cancel flag from an enclosing [`with_cancel_flag`] stays
+/// visible). A `Some` deadline inherits any enclosing cancel flag rather
+/// than masking it.
 pub async fn with_deadline<F: Future>(deadline: Option<Instant>, fut: F) -> F::Output {
     match deadline {
-        Some(at) => DEADLINE.scope(at, fut).await,
+        Some(at) => {
+            let cancel = CTX.try_with(|ctx| ctx.cancel.clone()).ok().flatten();
+            CTX.scope(
+                CancelCtx {
+                    deadline: Some(at),
+                    cancel,
+                },
+                fut,
+            )
+            .await
+        }
         None => fut.await,
     }
 }
 
-/// `true` when a deadline is in scope and has passed.
-#[inline]
-pub fn deadline_exceeded() -> bool {
-    DEADLINE
-        .try_with(|at| Instant::now() >= *at)
-        .unwrap_or(false)
+/// Run `fut` with an operator cancel flag scoped on the current task. The
+/// server registers one per in-flight query; flipping it makes every
+/// cooperative probe under this scope return [`Error::Cancelled`]. Inherits
+/// any enclosing deadline; an inner [`with_deadline`] inherits this flag.
+pub async fn with_cancel_flag<F: Future>(flag: Arc<AtomicBool>, fut: F) -> F::Output {
+    let deadline = CTX.try_with(|ctx| ctx.deadline).ok().flatten();
+    CTX.scope(
+        CancelCtx {
+            deadline,
+            cancel: Some(flag),
+        },
+        fut,
+    )
+    .await
 }
 
-/// `Err(Error::Timeout)` when a deadline is in scope and has passed, else
-/// `Ok(())`. Call it periodically inside a long CPU-bound loop so the work
-/// aborts cooperatively instead of pinning a worker until it returns.
+/// The active interrupt, if any. Operator cancel wins over the clock so the
+/// surfaced error names the actual cause.
+#[inline]
+pub fn interrupted() -> Option<Interrupt> {
+    CTX.try_with(|ctx| {
+        if ctx
+            .cancel
+            .as_ref()
+            .is_some_and(|flag| flag.load(Ordering::Relaxed))
+        {
+            Some(Interrupt::Cancelled)
+        } else if ctx.deadline.is_some_and(|at| Instant::now() >= at) {
+            Some(Interrupt::Timeout)
+        } else {
+            None
+        }
+    })
+    .ok()
+    .flatten()
+}
+
+/// `true` when a guard is in scope and has fired (deadline passed OR the
+/// query was cancelled). The historical name predates operator cancel.
+#[inline]
+pub fn deadline_exceeded() -> bool {
+    interrupted().is_some()
+}
+
+/// `Err(Error::Timeout)` / `Err(Error::Cancelled)` when a guard in scope has
+/// fired, else `Ok(())`. Call it periodically inside a long CPU-bound loop
+/// so the work aborts cooperatively instead of pinning a worker until it
+/// returns.
 #[inline]
 pub fn check() -> Result<()> {
-    if deadline_exceeded() {
-        Err(Error::Timeout)
-    } else {
-        Ok(())
+    match interrupted() {
+        None => Ok(()),
+        Some(Interrupt::Timeout) => Err(Error::Timeout),
+        Some(Interrupt::Cancelled) => Err(Error::Cancelled),
     }
 }
 

--- a/crates/namidb-storage/src/error.rs
+++ b/crates/namidb-storage/src/error.rs
@@ -52,6 +52,12 @@ pub enum Error {
     #[error("read query exceeded its deadline")]
     Timeout,
 
+    /// The query was cancelled by an administrator while this crate was
+    /// decoding or merging (same cooperative probes as [`Self::Timeout`],
+    /// different cause — see [`crate::cancel::with_cancel_flag`]).
+    #[error("query cancelled by administrator")]
+    Cancelled,
+
     /// A valid monolithic search accelerator cannot fit inside the configured
     /// decoded-index cache pool. This is intentionally not treated as
     /// "index absent": silently selecting the exact O(corpus) fallback would


### PR DESCRIPTION
In a single-writer engine a runaway write is a write outage with no recourse. The cooperative-cancellation plumbing already existed (~100 deadline probe sites); this PR makes it operator-reachable.

- Storage cancel task-local widens to {deadline, cancel flag} with scope inheritance; probes distinguish `Timeout` from `Cancelled` (HTTP 409 `cancelled`, Bolt `Neo.TransientError.Transaction.Terminated`). Cancel surfaces as an executor error → the existing discard/recovery path cleans up; never a future-drop.
- `QueryRegistry` on `Metrics`, RAII-registered at the four serving chokepoints (HTTP + Bolt, single + multi-tenant), sanitized statement text.
- `GET /v0/admin/queries` + `POST /v0/admin/queries/:id/cancel` on both routers, write-role gated, namespace-scoped in multi-tenant.
- **Bug found by the test**: a giant bare `UNWIND range(...)` had no probes — it could neither time out nor be cancelled. Both Unwind arms now probe at the standard stride (cancel aborts in ~10ms where it previously ran 14s to completion).

Tests: write-cancel end-to-end (no partial rows, writer immediately usable, registry drains, finished id 404s), read-cancel, multi-tenant scoping, role gate. Gate: full workspace green (89 binaries), fmt, clippy.