### PR TITLE
Bound the write durability tail (field report 3, item 59)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,24 @@ crates.io release will establish and document that API explicitly.
   their LOGON principal (documented in docs/multi-tenancy.md).
 
 **Fixed**
+- A write's durability tail (WAL PUT + manifest body PUT + pointer CAS +
+  orphan retries) ran OUTSIDE the scope of both `--write-timeout` and
+  `--writer-lock-timeout` on every foreground path — and Bolt has no
+  outer request timeout, which is how a production log showed a
+  24.5-minute write completing with status ok under 30s timeouts (a
+  store stall or retry storm that eventually succeeded). The commit now
+  probes the deadline (and the admin cancel flag) at its DETERMINATE
+  boundaries — before any object write, and before the orphan-WAL
+  retry — with the pending batch preserved on abort; it is never
+  interrupted between the WAL PUT and the pointer CAS, so outcomes stay
+  definite. The HTTP write deadline scope now covers the commit, Bolt
+  re-arms it around its commits, the group-commit ACK wait is bounded
+  by the write deadline (elapsing yields an honest
+  outcome-unknown error without cancelling the committer), commits
+  slower than 10s log a warn naming the durability tail, and optional
+  `NAMIDB_STORE_REQUEST_TIMEOUT` / `NAMIDB_STORE_RETRY_TIMEOUT` /
+  `NAMIDB_STORE_MAX_RETRIES` bound individual object-store ops
+  (defaults unchanged).
 - The Bolt per-message decode guard rejected legitimate small-row
   batches: its fixed allowance was 64 KiB on top of 8x the message's own
   wire size, so ~889 single-key row maps (~13x heap-to-wire

--- a/crates/namidb-query/src/exec/writer.rs
+++ b/crates/namidb-query/src/exec/writer.rs
@@ -157,7 +157,11 @@ pub async fn execute_write_with_deadline(
             return Err(e);
         }
     };
-    if let Err(e) = writer.commit_batch().await {
+    // The deadline covers the durability tail too (item 59): commit_batch
+    // probes it at its determinate boundaries, so a deadline that expired
+    // during staging fails the commit before any object write instead of
+    // riding an unbounded PUT/CAS/retry sequence.
+    if let Err(e) = crate::exec::limits::with_limits(deadline, None, writer.commit_batch()).await {
         // The commit failed and this statement is aborted. `commit_batch`
         // preserves the pending batch on error (so an internal retry is
         // possible), but this writer is long-lived and shared: if we return

--- a/crates/namidb-server/src/bolt.rs
+++ b/crates/namidb-server/src/bolt.rs
@@ -881,14 +881,17 @@ impl ServerBackend {
                 let stall = self.state.after_commit_backpressure(&writer);
                 drop(writer);
                 group.notify_committer();
-                let acked = ack.await;
+                let acked = crate::bounded_group_ack(ack, self.state.write_deadline()).await;
                 let elapsed = started.elapsed();
                 let result = match acked {
-                    Ok(Ok(())) => Ok(write_run_outcome(outcome)),
-                    Ok(Err(shared)) => Err(map_exec_err_ref(shared.0.as_ref())),
-                    Err(_) => Err(BackendError::Other(
+                    crate::GroupAck::Committed => Ok(write_run_outcome(outcome)),
+                    crate::GroupAck::Shared(shared) => Err(map_exec_err_ref(shared.0.as_ref())),
+                    crate::GroupAck::CoordinatorExited => Err(BackendError::Other(
                         "group commit coordinator exited".into(),
                     )),
+                    crate::GroupAck::Indeterminate => {
+                        Err(BackendError::Other(crate::GROUP_ACK_INDETERMINATE.into()))
+                    }
                 };
                 if result.is_ok() {
                     if let Some(delay) = stall {
@@ -910,7 +913,16 @@ impl ServerBackend {
                 };
             }
 
-            match writer.commit_batch().await {
+            // Item 59: Bolt has no outer request timeout, so this was the one
+            // path where a stalled store could produce a 24-minute ok write.
+            // The deadline re-arms for the commit tail; commit_batch aborts
+            // at its determinate boundaries only.
+            match namidb_storage::cancel::with_deadline(
+                self.state.write_deadline(),
+                writer.commit_batch(),
+            )
+            .await
+            {
                 Ok(_) => {
                     self.state.snapshot.store(writer.owned_snapshot());
                     // Soft write stall (RFC-027 P5): sample under the lock,
@@ -1446,7 +1458,12 @@ impl Backend for ServerBackend {
             .ok_or_else(|| BackendError::Other("no open transaction".into()))?;
         // One manifest CAS makes the whole transaction durable; then
         // republish so reads see it. Dropping `tx` releases the writer lock.
-        match tx.writer.commit_batch().await {
+        match namidb_storage::cancel::with_deadline(
+            self.state.write_deadline(),
+            tx.writer.commit_batch(),
+        )
+        .await
+        {
             Ok(_) => {
                 self.state.snapshot.store(tx.writer.owned_snapshot());
                 Ok(())

--- a/crates/namidb-server/src/lib.rs
+++ b/crates/namidb-server/src/lib.rs
@@ -1867,6 +1867,43 @@ pub(crate) async fn lock_writer_bounded(
     tokio::time::timeout(timeout, writer.lock()).await.ok()
 }
 
+/// Outcome of awaiting a group-commit ACK under the write deadline.
+pub(crate) enum GroupAck {
+    Committed,
+    Shared(SharedCommitError),
+    CoordinatorExited,
+    /// The deadline elapsed while the group's commit was still in flight.
+    /// The committer is untouched — the write MAY still become durable —
+    /// so the waiter stops lying about latency and says so.
+    Indeterminate,
+}
+
+pub(crate) const GROUP_ACK_INDETERMINATE: &str = "group commit still in flight past the write \
+     timeout; outcome unknown — the write may yet become durable, verify before retrying";
+
+/// Await a group-commit ACK, bounded by the write deadline when one is
+/// configured. Never cancels the committer: one slow disk must not turn
+/// into shared-fate false failures for the whole group.
+pub(crate) async fn bounded_group_ack(
+    ack: tokio::sync::oneshot::Receiver<Result<(), SharedCommitError>>,
+    deadline: Option<std::time::Instant>,
+) -> GroupAck {
+    let wait = async move {
+        match ack.await {
+            Ok(Ok(())) => GroupAck::Committed,
+            Ok(Err(shared)) => GroupAck::Shared(shared),
+            Err(_) => GroupAck::CoordinatorExited,
+        }
+    };
+    match deadline {
+        None => wait.await,
+        Some(at) => match tokio::time::timeout_at(tokio::time::Instant::from_std(at), wait).await {
+            Ok(acked) => acked,
+            Err(_) => GroupAck::Indeterminate,
+        },
+    }
+}
+
 /// Group commit (RFC-034): one committer per namespace amortizes the
 /// two object-store round-trips of `commit_batch` across concurrently
 /// arriving writes. Requests stage under the writer lock inside a request
@@ -1890,7 +1927,7 @@ pub(crate) struct GroupCommit {
 
 /// The one commit error a whole group shares (shared fate: a merged WAL
 /// segment cannot be partially durable).
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub(crate) struct SharedCommitError(pub(crate) Arc<namidb_query::exec::ExecError>);
 
 /// A write's failure on either commit path: its own statement error, or the
@@ -3378,12 +3415,17 @@ async fn run_cypher(state: &AppState, req: &CypherRequest, principal: &Principal
                     let stall = state.after_commit_backpressure(&writer);
                     drop(writer);
                     group.notify_committer();
-                    let result = match ack.await {
-                        Ok(Ok(())) => Ok(outcome),
-                        Ok(Err(shared)) => Err(WriteFailure::Shared(shared)),
-                        Err(_) => Err(WriteFailure::Own(namidb_query::exec::ExecError::Runtime(
-                            "group commit coordinator exited".into(),
-                        ))),
+                    let result = match bounded_group_ack(ack, state.write_deadline()).await {
+                        GroupAck::Committed => Ok(outcome),
+                        GroupAck::Shared(shared) => Err(WriteFailure::Shared(shared)),
+                        GroupAck::CoordinatorExited => {
+                            Err(WriteFailure::Own(namidb_query::exec::ExecError::Runtime(
+                                "group commit coordinator exited".into(),
+                            )))
+                        }
+                        GroupAck::Indeterminate => Err(WriteFailure::Own(
+                            namidb_query::exec::ExecError::Runtime(GROUP_ACK_INDETERMINATE.into()),
+                        )),
                     };
                     (result, stall)
                 }
@@ -4388,12 +4430,17 @@ async fn run_cypher_multi(
                     let stall = shared.write_stall_for(writer.max_l0_bucket_len(), bytes);
                     drop(writer);
                     group.notify_committer();
-                    let result = match ack.await {
-                        Ok(Ok(())) => Ok(outcome),
-                        Ok(Err(shared_err)) => Err(WriteFailure::Shared(shared_err)),
-                        Err(_) => Err(WriteFailure::Own(namidb_query::exec::ExecError::Runtime(
-                            "group commit coordinator exited".into(),
-                        ))),
+                    let result = match bounded_group_ack(ack, shared.write_deadline()).await {
+                        GroupAck::Committed => Ok(outcome),
+                        GroupAck::Shared(shared_err) => Err(WriteFailure::Shared(shared_err)),
+                        GroupAck::CoordinatorExited => {
+                            Err(WriteFailure::Own(namidb_query::exec::ExecError::Runtime(
+                                "group commit coordinator exited".into(),
+                            )))
+                        }
+                        GroupAck::Indeterminate => Err(WriteFailure::Own(
+                            namidb_query::exec::ExecError::Runtime(GROUP_ACK_INDETERMINATE.into()),
+                        )),
                     };
                     (result, stall)
                 }
@@ -5094,6 +5141,38 @@ mod tests {
                 "{method} {uri} must be write-role gated"
             );
         }
+    }
+
+    /// Item 59: the group-commit waiter is bounded by the write deadline —
+    /// a stalled committer yields the honest indeterminate outcome instead
+    /// of an unbounded wait, and the committer itself is never cancelled
+    /// (the sender stays alive; a later resolution is still deliverable).
+    #[tokio::test(start_paused = true)]
+    async fn group_ack_times_out_indeterminate_without_touching_the_committer() {
+        let (tx, rx) = tokio::sync::oneshot::channel::<Result<(), SharedCommitError>>();
+        let deadline = std::time::Instant::now() + Duration::from_millis(50);
+        let waiter = tokio::spawn(bounded_group_ack(rx, Some(deadline)));
+        tokio::time::advance(Duration::from_millis(100)).await;
+        assert!(matches!(waiter.await.unwrap(), GroupAck::Indeterminate));
+        // The committer side is untouched: a late resolution simply finds
+        // the waiter gone (send returns the value back), never a panic or a
+        // poisoned coordinator.
+        let _ = tx.send(Ok(()));
+
+        // A resolved ack inside the deadline maps through unchanged.
+        let (tx, rx) = tokio::sync::oneshot::channel::<Result<(), SharedCommitError>>();
+        tx.send(Ok(())).unwrap();
+        assert!(matches!(
+            bounded_group_ack(rx, Some(std::time::Instant::now() + Duration::from_secs(5))).await,
+            GroupAck::Committed
+        ));
+        // No deadline configured = today's unbounded wait, resolved acks only.
+        let (tx, rx) = tokio::sync::oneshot::channel::<Result<(), SharedCommitError>>();
+        drop(tx);
+        assert!(matches!(
+            bounded_group_ack(rx, None).await,
+            GroupAck::CoordinatorExited
+        ));
     }
 
     /// Plan item 28: the HTTP JSON parameter route had no unit tests and no

--- a/crates/namidb-server/src/metrics.rs
+++ b/crates/namidb-server/src/metrics.rs
@@ -1163,7 +1163,6 @@ impl QueryRegistry {
             None => false,
         }
     }
-
 }
 
 /// RAII registration: deregisters on Drop; exposes the cancel flag for the

--- a/crates/namidb-storage/src/ingest.rs
+++ b/crates/namidb-storage/src/ingest.rs
@@ -1769,6 +1769,14 @@ impl WriterSession {
         // If the WAL append fails, the body PUT is harmless: the
         // pointer never moves, the next manifest commit overwrites
         // the reference, and the janitor sweeps the orphan.
+        // Determinate abort point (item 59): nothing has been sent yet, so a
+        // write deadline that expired during staging (or an operator cancel)
+        // fails the commit HERE with the pending batch preserved — instead of
+        // starting an unbounded durability tail. Never probe between the WAL
+        // PUT and the pointer CAS: that zone must run to a definite outcome
+        // (the CAS resolver owns its indeterminacy).
+        crate::cancel::check()?;
+        let commit_started = std::time::Instant::now();
         let next = self.build_next(base_seq, last_lsn);
 
         let (wal_result, body_result) = tokio::join!(
@@ -1810,6 +1818,11 @@ impl WriterSession {
                 // common "base+1 already taken" case fails fast as
                 // `ManifestCommitCas` without minting a new WAL orphan.
                 let _ = body_result;
+                // Second determinate abort point: before the orphan-WAL
+                // re-seq retry (a LIST plus a fresh body-first commit). A
+                // retry storm against a throttling store now stops at the
+                // deadline instead of compounding.
+                crate::cancel::check()?;
                 let listed = self.wal_store.list_segments().await?;
                 let fresh = listed
                     .last()
@@ -1833,6 +1846,18 @@ impl WriterSession {
             }
             Err(other) => return Err(other),
         };
+
+        // Honest attribution for the next field report: a durability tail
+        // that ran long (store throttling, retries, a stalled disk) is the
+        // exact signature item 59 could only infer post-hoc.
+        let commit_elapsed = commit_started.elapsed();
+        if commit_elapsed >= std::time::Duration::from_secs(10) {
+            tracing::warn!(
+                commit_ms = commit_elapsed.as_millis() as u64,
+                seq = committed_seq,
+                "write durability tail was slow (object-store latency or retries)"
+            );
+        }
 
         // Durability achieved. Drain the queued payloads into the
         // memtable in LSN order (they are already in insertion order

--- a/crates/namidb-storage/src/uri.rs
+++ b/crates/namidb-storage/src/uri.rs
@@ -174,6 +174,55 @@ fn parse_file(uri: &str) -> Result<(Arc<dyn ObjectStore>, NamespacePaths), UriEr
     ))
 }
 
+/// Optional client tuning for the HTTP-backed stores (S3/GCS/Azure), from
+/// env. UNSET = object_store's defaults (30s/request, 180s retry budget) —
+/// shipped behavior is unchanged. Item 59's residual window is a single
+/// in-flight op (the commit path aborts BETWEEN ops at its deadline), so an
+/// operator who saw a multi-minute retry storm can bound it here:
+/// `NAMIDB_STORE_REQUEST_TIMEOUT` / `NAMIDB_STORE_RETRY_TIMEOUT` (seconds,
+/// or `<n>ms`) and `NAMIDB_STORE_MAX_RETRIES`. Applies to every op on the
+/// store, maintenance included — size generously.
+fn env_duration(name: &str) -> Option<std::time::Duration> {
+    let raw = std::env::var(name).ok()?;
+    let raw = raw.trim();
+    let parsed = if let Some(ms) = raw.strip_suffix("ms") {
+        ms.trim()
+            .parse::<u64>()
+            .ok()
+            .map(std::time::Duration::from_millis)
+    } else {
+        let secs = raw.strip_suffix('s').unwrap_or(raw).trim();
+        secs.parse::<u64>().ok().map(std::time::Duration::from_secs)
+    };
+    if parsed.is_none() {
+        tracing::warn!(env = name, value = raw, "unparseable duration ignored");
+    }
+    parsed
+}
+
+fn store_retry_config() -> Option<object_store::RetryConfig> {
+    let retry_timeout = env_duration("NAMIDB_STORE_RETRY_TIMEOUT");
+    let max_retries = std::env::var("NAMIDB_STORE_MAX_RETRIES")
+        .ok()
+        .and_then(|v| v.trim().parse::<usize>().ok());
+    if retry_timeout.is_none() && max_retries.is_none() {
+        return None;
+    }
+    let mut config = object_store::RetryConfig::default();
+    if let Some(t) = retry_timeout {
+        config.retry_timeout = t;
+    }
+    if let Some(n) = max_retries {
+        config.max_retries = n;
+    }
+    Some(config)
+}
+
+fn store_client_options() -> Option<object_store::ClientOptions> {
+    env_duration("NAMIDB_STORE_REQUEST_TIMEOUT")
+        .map(|t| object_store::ClientOptions::new().with_timeout(t))
+}
+
 fn parse_s3(uri: &str) -> Result<(Arc<dyn ObjectStore>, NamespacePaths), UriError> {
     let parsed = url::Url::parse(uri).map_err(|e| UriError::Malformed {
         uri: uri.to_string(),
@@ -220,6 +269,12 @@ fn parse_s3(uri: &str) -> Result<(Arc<dyn ObjectStore>, NamespacePaths), UriErro
     }
     if allow_http {
         builder = builder.with_allow_http(true);
+    }
+    if let Some(options) = store_client_options() {
+        builder = builder.with_client_options(options);
+    }
+    if let Some(retry) = store_retry_config() {
+        builder = builder.with_retry(retry);
     }
     let store = builder.build().map_err(|e| UriError::BackendInit {
         uri: uri.to_string(),
@@ -268,6 +323,12 @@ fn parse_gcs(uri: &str) -> Result<(Arc<dyn ObjectStore>, NamespacePaths), UriErr
         object_store::gcp::GoogleCloudStorageBuilder::from_env().with_bucket_name(bucket);
     if let Some(p) = service_account {
         builder = builder.with_service_account_path(p);
+    }
+    if let Some(options) = store_client_options() {
+        builder = builder.with_client_options(options);
+    }
+    if let Some(retry) = store_retry_config() {
+        builder = builder.with_retry(retry);
     }
     let store = builder.build().map_err(|e| UriError::BackendInit {
         uri: uri.to_string(),
@@ -337,6 +398,12 @@ fn parse_azure(uri: &str) -> Result<(Arc<dyn ObjectStore>, NamespacePaths), UriE
     }
     if use_emulator {
         builder = builder.with_use_emulator(true);
+    }
+    if let Some(options) = store_client_options() {
+        builder = builder.with_client_options(options);
+    }
+    if let Some(retry) = store_retry_config() {
+        builder = builder.with_retry(retry);
     }
     let store = builder.build().map_err(|e| UriError::BackendInit {
         uri: uri.to_string(),

--- a/crates/namidb-storage/tests/commit_deadline.rs
+++ b/crates/namidb-storage/tests/commit_deadline.rs
@@ -1,0 +1,82 @@
+//! Item 59: the durability tail respects the write deadline at its
+//! DETERMINATE boundaries. A deadline that expired during staging fails
+//! `commit_batch` before any object write — pending batch preserved,
+//! session healthy, nothing published — and the same batch commits cleanly
+//! once the pressure clears. The tail is never aborted between the WAL PUT
+//! and the pointer CAS (that zone runs to a definite outcome).
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::time::{Duration, Instant};
+
+use namidb_core::id::{NamespaceId, NodeId};
+use namidb_core::value::Value;
+use namidb_storage::{cancel, Error, NamespacePaths, NodeWriteRecord, WriterSession};
+use object_store::memory::InMemory;
+use object_store::ObjectStore;
+
+fn row(name: &str) -> NodeWriteRecord {
+    let mut props: BTreeMap<String, Value> = BTreeMap::new();
+    props.insert("name".into(), Value::Str(name.into()));
+    NodeWriteRecord {
+        properties: props,
+        schema_version: 1,
+        ..Default::default()
+    }
+}
+
+#[tokio::test]
+async fn expired_deadline_fails_commit_before_any_object_write() {
+    let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    let paths = NamespacePaths::new("tenants", NamespaceId::new("cdl").unwrap());
+    let mut w = WriterSession::open(store, paths).await.unwrap();
+
+    // A first ordinary commit to establish a baseline manifest version.
+    w.upsert_node("T", NodeId::new(), &row("first")).unwrap();
+    w.commit_batch().await.unwrap();
+    let version_before = w.snapshot().manifest().manifest.version;
+
+    // Stage a second write; its deadline "expired during staging".
+    w.upsert_node("T", NodeId::new(), &row("second")).unwrap();
+    let expired = Instant::now() - Duration::from_millis(1);
+    let err = cancel::with_deadline(Some(expired), w.commit_batch())
+        .await
+        .expect_err("an expired deadline must fail the commit at the pre-PUT probe");
+    assert!(matches!(err, Error::Timeout), "{err:?}");
+
+    // Nothing moved: no manifest advance, the second row is not readable,
+    // and the session is not poisoned.
+    let snap = w.snapshot();
+    assert_eq!(snap.manifest().manifest.version, version_before);
+    assert_eq!(
+        snap.scan_label("T").await.unwrap().len(),
+        1,
+        "the aborted batch must not be readable"
+    );
+    drop(snap);
+
+    // The pending batch survived: the SAME staged rows commit once the
+    // deadline pressure is gone.
+    w.commit_batch().await.unwrap();
+    let snap = w.snapshot();
+    assert!(snap.manifest().manifest.version > version_before);
+    assert_eq!(snap.scan_label("T").await.unwrap().len(), 2);
+}
+
+#[tokio::test]
+async fn operator_cancel_also_fails_commit_at_the_boundary() {
+    let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    let paths = NamespacePaths::new("tenants", NamespaceId::new("ccl").unwrap());
+    let mut w = WriterSession::open(store, paths).await.unwrap();
+    w.upsert_node("T", NodeId::new(), &row("victim")).unwrap();
+
+    let flag = Arc::new(std::sync::atomic::AtomicBool::new(true));
+    let err = cancel::with_cancel_flag(flag, w.commit_batch())
+        .await
+        .expect_err("a flipped cancel flag must fail the commit at the boundary");
+    assert!(matches!(err, Error::Cancelled), "{err:?}");
+
+    // Same preservation contract as the deadline.
+    w.commit_batch().await.unwrap();
+    assert_eq!(w.snapshot().scan_label("T").await.unwrap().len(), 1);
+}

--- a/docs/testing/25tb-readiness.md
+++ b/docs/testing/25tb-readiness.md
@@ -872,3 +872,12 @@ explicit store client timeouts, bound the group-commit ack wait with an
 honest indeterminate error, and slow-log lock/staging/commit
 sub-durations. Adjacent hazard recorded: the HTTP TimeoutLayer can
 cancel a commit mid-durability at 120s — to bound, not drop.
+**Follow-up shipped (2.5.0):** all of the plan above except the
+TimeoutLayer hazard (deferred, recorded here): determinate-boundary
+probes in commit_batch (pre-PUT and pre-orphan-retry only; the
+PUT-to-CAS zone stays uninterruptible), deadline scope over the HTTP
+commit and re-armed around both Bolt commits, bounded group-ACK wait
+with the outcome-unknown error, >10s durability-tail warn, and opt-in
+store client bounds via NAMIDB_STORE_{REQUEST_TIMEOUT,RETRY_TIMEOUT,
+MAX_RETRIES}. The admin cancel flag (item 56) rides the same probes, so
+a stuck-but-probing commit is also operator-killable pre-PUT.


### PR DESCRIPTION
Reported as an unreproducible 24.5-minute status=ok write under 30s timeouts; recon confirmed it as a design gap — neither timeout ever covered `commit_batch`'s durability tail, and Bolt (no outer request bound) is the one path that could log it.

- `commit_batch` probes the cancel context (deadline + the item-56 admin flag) at its **determinate boundaries only**: pre-PUT (pending preserved) and pre-orphan-retry. Never between WAL PUT and pointer CAS — that zone runs to a definite outcome.
- HTTP moves the commit inside the write-deadline scope; Bolt re-arms it around both commits.
- Group-commit ACK wait bounded via `bounded_group_ack`: elapsing yields an explicit outcome-unknown error **without cancelling the committer**.
- Commits >10s warn with `commit_ms`; opt-in `NAMIDB_STORE_{REQUEST_TIMEOUT,RETRY_TIMEOUT,MAX_RETRIES}` bound individual store ops (defaults unchanged).
- Deferred + recorded: the HTTP TimeoutLayer mid-commit drop hazard.

Tests: pre-PUT abort contract (zero manifest advance, same batch commits after pressure clears), operator-cancel at the same boundary, bounded-ack unit with paused clock. Gate: full workspace green (90 binaries), fmt, clippy (one vacuous test assertion clippy caught, fixed and re-verified).