### PR TITLE
Bound UNWIND range materialization; shield HTTP writes from handler drop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,32 @@ crates.io release will establish and document that API explicitly.
 
 ## [Unreleased]
 
+**Fixed**
+- A single `UNWIND range(1, N)` read could OOM-kill the whole process:
+  `range()` materialised its full list and the unwind loop expanded every
+  row BEFORE the row cap was evaluated, so on a 4 GB container ~3M rows
+  errored cleanly, ~4M dropped the connection, and ~5M died with exit
+  137 — a full write outage from one statement. Two guards close the
+  class: when a row cap is in scope, `range()` longer than the cap is
+  rejected before it allocates (with the interrupt taxonomy preserved —
+  a timeout/cancel that fires inside a long range build surfaces as
+  timeout/cancelled, not an argument error), and the unwind expansion
+  checks the cap incrementally so memory is bounded at cap + one stride
+  for any N. Embedded/CLI use without a scoped cap is unchanged.
+- The item-59 deferred hazard is closed: the HTTP write section (lock →
+  stage → commit → recovery) now runs on a shielded task, so the request
+  TimeoutLayer firing or the client disconnecting can no longer drop the
+  handler future mid-durability — the commit reaches its definite
+  outcome, the snapshot republishes, and the writer is released cleanly
+  even when nobody is left to read the response. The admin cancel flag
+  is re-scoped onto the shielded task, so item-56 cancellation still
+  works.
+- Multi-tenant deployments gained the unprefixed
+  (`X-NamiDB-Namespace`/default-namespace) twins of
+  `/v0/admin/queries[/:id/cancel]` — polling the bare path returned 404
+  while every other admin route accepted the header form.
+
+
 ## [2.5.0] - 2026-08-29
 
 **Added**

--- a/crates/namidb-query/src/exec/expr.rs
+++ b/crates/namidb-query/src/exec/expr.rs
@@ -23,6 +23,23 @@ pub enum EvalErrorKind {
     /// A feature the engine does not support (unknown function, unsupported
     /// expression form). Maps to a "not supported" error on every transport.
     Unsupported,
+    /// The query deadline fired inside expression evaluation (a long
+    /// `range()` build). Converted to [`ExecError::Timeout`] so the
+    /// taxonomy matches every other timeout site.
+    Timeout,
+    /// The operator cancel flag fired inside expression evaluation.
+    /// Converted to [`ExecError::Cancelled`].
+    Cancelled,
+}
+
+impl EvalError {
+    pub(crate) fn interrupted(kind: EvalErrorKind, span: SourceSpan) -> Self {
+        Self {
+            message: "expression evaluation interrupted".into(),
+            span,
+            kind,
+        }
+    }
 }
 
 /// Runtime error returned by expression / executor code. Carries a span
@@ -1434,11 +1451,45 @@ fn range_fn(args: &[RuntimeValue], span: SourceSpan) -> Result<RuntimeValue, Eva
     if step == 0 {
         return Err(EvalError::new("range(): step must be non-zero", span));
     }
+    // Deterministic materialization guard (field report 3 follow-up, item
+    // 60): `range()` allocates its whole list before any operator-level
+    // check can run, so a single `UNWIND range(1, huge)` used to OOM the
+    // process before the row cap fired. When a cap is in scope, a range
+    // longer than the cap is rejected BEFORE it allocates — such a list
+    // could never be unwound legally anyway, and the cap's contract is a
+    // bound on what one statement may materialise.
+    if let Some(cap) = crate::exec::limits::scoped_row_cap() {
+        let distance = i128::from(end) - i128::from(start);
+        let steps = distance / i128::from(step);
+        // Opposite-direction ranges are empty; same-direction ones hold
+        // `steps + 1` items.
+        let len: u128 = if steps < 0 { 0 } else { steps as u128 + 1 };
+        if len > cap as u128 {
+            return Err(EvalError::new(
+                format!(
+                    "range() of {len} items exceeds the configured row cap of {cap}; \
+                     use a smaller range or batch the work"
+                ),
+                span,
+            ));
+        }
+    }
     let mut out = Vec::new();
     let mut i = start;
     loop {
         if (step > 0 && i > end) || (step < 0 && i < end) {
             break;
+        }
+        if out.len() % namidb_storage::cancel::CHECK_STRIDE == 0 {
+            match namidb_storage::cancel::interrupted() {
+                None => {}
+                Some(namidb_storage::cancel::Interrupt::Timeout) => {
+                    return Err(EvalError::interrupted(EvalErrorKind::Timeout, span));
+                }
+                Some(namidb_storage::cancel::Interrupt::Cancelled) => {
+                    return Err(EvalError::interrupted(EvalErrorKind::Cancelled, span));
+                }
+            }
         }
         out.push(RuntimeValue::Integer(i));
         match i.checked_add(step) {

--- a/crates/namidb-query/src/exec/limits.rs
+++ b/crates/namidb-query/src/exec/limits.rs
@@ -68,6 +68,13 @@ pub(crate) fn check_deadline() -> Result<(), ExecError> {
 /// `Err(ExecError::RowCap)` when a row cap is in scope and `len` exceeds it,
 /// `Ok(())` otherwise. `len` is the row count an operator produced (or is
 /// about to produce). A no-op when no cap is scoped.
+/// The row cap in scope, if any — for expression-level materialization
+/// guards (a `range()` longer than the cap is rejected before it allocates).
+#[inline]
+pub(crate) fn scoped_row_cap() -> Option<usize> {
+    ROW_CAP.try_with(|cap| *cap).ok()
+}
+
 #[inline]
 pub(crate) fn check_row_cap(len: usize) -> Result<(), ExecError> {
     ROW_CAP

--- a/crates/namidb-query/src/exec/walker.rs
+++ b/crates/namidb-query/src/exec/walker.rs
@@ -86,7 +86,14 @@ impl ExecError {
 
 impl From<EvalError> for ExecError {
     fn from(e: EvalError) -> Self {
-        ExecError::Eval(e)
+        // Interrupts that fired INSIDE expression evaluation keep the same
+        // taxonomy as every other probe site (409 cancelled / 504 timeout),
+        // instead of masquerading as a client argument error.
+        match e.kind {
+            crate::exec::expr::EvalErrorKind::Timeout => ExecError::Timeout,
+            crate::exec::expr::EvalErrorKind::Cancelled => ExecError::Cancelled,
+            _ => ExecError::Eval(e),
+        }
     }
 }
 
@@ -970,6 +977,12 @@ pub(crate) fn execute_inner_with_routing<'a>(
                             for item in items {
                                 if out.len() % namidb_storage::cancel::CHECK_STRIDE == 0 {
                                     crate::exec::limits::check_deadline()?;
+                                    // Incremental: the cap must bound MEMORY,
+                                    // not merely veto the result after the
+                                    // full expansion materialised (item 60 —
+                                    // the post-loop check let a 4 GB
+                                    // container OOM between 3M and 5M rows).
+                                    crate::exec::limits::check_row_cap(out.len())?;
                                 }
                                 let mut new_row = row.clone();
                                 new_row.set(alias.clone(), item);
@@ -7979,6 +7992,12 @@ pub(crate) fn execute_factor_inner_with_routing<'a>(
                             for item in items {
                                 if out.len() % namidb_storage::cancel::CHECK_STRIDE == 0 {
                                     crate::exec::limits::check_deadline()?;
+                                    // Incremental: the cap must bound MEMORY,
+                                    // not merely veto the result after the
+                                    // full expansion materialised (item 60 —
+                                    // the post-loop check let a 4 GB
+                                    // container OOM between 3M and 5M rows).
+                                    crate::exec::limits::check_row_cap(out.len())?;
                                 }
                                 let mut new_row = row.clone();
                                 new_row.set(alias.clone(), item);

--- a/crates/namidb-query/tests/exec_limits.rs
+++ b/crates/namidb-query/tests/exec_limits.rs
@@ -125,3 +125,74 @@ async fn row_cap_rejects_a_cross_product_before_materialising() {
         .expect_err("a cross product over the cap must abort");
     assert!(matches!(err, ExecError::RowCap(5)), "got {err:?}");
 }
+
+/// Item 60: the row cap must bound MEMORY, not merely veto the result
+/// after the full expansion — a bare `UNWIND range(1, 5M)` used to
+/// materialise every row (and the whole range list) before the cap was
+/// evaluated, OOM-killing a 4 GB container. The range() guard now rejects
+/// the list before it allocates, and the unwind loop checks incrementally.
+#[tokio::test]
+async fn giant_unwind_range_is_rejected_before_it_materialises() {
+    let writer = seed("unwind-cap").await;
+    let snap = writer.snapshot();
+
+    // The range() materialization guard fires first: the list itself would
+    // exceed the cap, so nothing multi-million-sized is ever allocated.
+    let plan =
+        lower(&parse("UNWIND range(1, 5000000) AS i RETURN count(i) AS n").unwrap()).unwrap();
+    let err = execute_with_limits(&plan, &snap, &Params::new(), None, Some(1000))
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(&err, ExecError::Eval(e) if e.message.contains("row cap")),
+        "range() must be rejected at construction: {err:?}"
+    );
+
+    // Per-row lists individually UNDER the cap still trip the INCREMENTAL
+    // unwind check once the produced rows multiply past it: 3 rows x
+    // 400-item lists = 1200 produced rows against a 1000 cap (each range()
+    // passes its own construction guard).
+    let plan =
+        lower(&parse("MATCH (p:Person) UNWIND range(1, 400) AS i RETURN count(i) AS n").unwrap())
+            .unwrap();
+    let err = execute_with_limits(&plan, &snap, &Params::new(), None, Some(1000))
+        .await
+        .unwrap_err();
+    assert!(matches!(err, ExecError::RowCap(1000)), "got {err:?}");
+
+    // Without a cap in scope (embedded / CLI), behavior is unchanged.
+    let plan = lower(&parse("UNWIND range(1, 5000) AS i RETURN count(i) AS n").unwrap()).unwrap();
+    let rows = execute_with_limits(&plan, &snap, &Params::new(), None, None)
+        .await
+        .unwrap();
+    assert_eq!(rows.len(), 1);
+}
+
+/// The guard extends to non-UNWIND range() uses when a cap is scoped: a
+/// list the statement may not materialise as rows may not be materialised
+/// as one giant value either.
+#[tokio::test]
+async fn range_materialization_respects_the_scoped_cap() {
+    let writer = seed("range-cap").await;
+    let snap = writer.snapshot();
+    let plan = lower(&parse("RETURN size(range(1, 100000)) AS n").unwrap()).unwrap();
+    let err = execute_with_limits(&plan, &snap, &Params::new(), None, Some(1000))
+        .await
+        .unwrap_err();
+    assert!(
+        matches!(&err, ExecError::Eval(e) if e.message.contains("row cap")),
+        "{err:?}"
+    );
+    // Under the cap: exact size still returned.
+    let plan = lower(&parse("RETURN size(range(1, 500)) AS n").unwrap()).unwrap();
+    let rows = execute_with_limits(&plan, &snap, &Params::new(), None, Some(1000))
+        .await
+        .unwrap();
+    assert_eq!(rows.len(), 1);
+    // Opposite-direction ranges are empty, never rejected.
+    let plan = lower(&parse("RETURN size(range(10, 1)) AS n").unwrap()).unwrap();
+    let rows = execute_with_limits(&plan, &snap, &Params::new(), None, Some(5))
+        .await
+        .unwrap();
+    assert_eq!(rows.len(), 1);
+}

--- a/crates/namidb-server/src/lib.rs
+++ b/crates/namidb-server/src/lib.rs
@@ -802,6 +802,11 @@ pub fn build_multi_tenant_router(shared: SharedAppState) -> Router {
             "/:namespace/v0/admin/queries/:id/cancel",
             post(admin_cancel_query_multi),
         )
+        .route("/v0/admin/queries", get(admin_queries_multi_unprefixed))
+        .route(
+            "/v0/admin/queries/:id/cancel",
+            post(admin_cancel_query_multi_unprefixed),
+        )
         .layer(middleware::from_fn_with_state(
             shared.clone(),
             require_auth_multi,
@@ -3148,6 +3153,117 @@ async fn cypher(
     obs.response
 }
 
+/// Outcome of the shielded write section.
+enum WriteSection {
+    /// The bounded writer-lock wait timed out.
+    Busy,
+    Done {
+        result: Result<namidb_query::exec::WriteOutcome, WriteFailure>,
+        stall: Option<Duration>,
+    },
+}
+
+/// The single-tenant HTTP write section — lock, stage, commit, recover —
+/// factored out so [`run_cypher`] can run it on a SHIELDED task: hyper
+/// drops the handler future on client disconnect and the request
+/// TimeoutLayer drops it at its deadline, and a drop mid-durability would
+/// cancel a commit in flight (the hazard deferred from item 59). On its own
+/// task the section always reaches a definite outcome and releases the
+/// writer cleanly; the abandoned handler simply never reads the result.
+async fn run_write_section(
+    state: AppState,
+    plan: namidb_query::LogicalPlan,
+    params: Params,
+) -> WriteSection {
+    let Some(mut writer) = state.lock_writer_bounded(WriterLockKind::Http).await else {
+        return WriteSection::Busy;
+    };
+    let (result, stall) = if let Some(group) = state.group_commit.clone() {
+        // RFC-034 group commit: stage inside a request scope and let the
+        // namespace committer make the whole group durable with ONE
+        // commit. The waiter registers while still holding the lock so
+        // the committer cannot slip between staging and registration;
+        // the ACK arrives only after the merged commit is durable and
+        // the snapshot republished (RFC-021 preserved).
+        let mark = writer.begin_staged_request();
+        match execute_write_staged_with_deadline(
+            &plan,
+            &mut writer,
+            &params,
+            state.write_deadline(),
+        )
+        .await
+        {
+            Ok(outcome) => {
+                writer.commit_staged_request();
+                let lsn = writer.staged_last_lsn().unwrap_or(0);
+                let ack = group.register(lsn);
+                let stall = state.after_commit_backpressure(&writer);
+                drop(writer);
+                group.notify_committer();
+                let result = match bounded_group_ack(ack, state.write_deadline()).await {
+                    GroupAck::Committed => Ok(outcome),
+                    GroupAck::Shared(shared) => Err(WriteFailure::Shared(shared)),
+                    GroupAck::CoordinatorExited => {
+                        Err(WriteFailure::Own(namidb_query::exec::ExecError::Runtime(
+                            "group commit coordinator exited".into(),
+                        )))
+                    }
+                    GroupAck::Indeterminate => Err(WriteFailure::Own(
+                        namidb_query::exec::ExecError::Runtime(GROUP_ACK_INDETERMINATE.into()),
+                    )),
+                };
+                (result, stall)
+            }
+            Err(e) => {
+                // Roll back ONLY this request; earlier group members'
+                // staged rows survive for their commit.
+                writer.rollback_staged_request(mark);
+                recovery::recover_after_write_error(
+                    &mut writer,
+                    &state.snapshot,
+                    &state.writer_health,
+                    &state.namespace,
+                    &e,
+                )
+                .await;
+                drop(writer);
+                (Err(WriteFailure::Own(e)), None)
+            }
+        }
+    } else {
+        let result =
+            execute_write_with_deadline(&plan, &mut writer, &params, state.write_deadline()).await;
+        // Sample the soft write-stall decision while still holding the lock
+        // (RFC-027 P5), then release it and sleep — backpressure applies to
+        // this request, not to the writer mutex other connections need.
+        let stall = match &result {
+            Ok(_) => {
+                // Refresh the published snapshot so subsequent reads see the
+                // just-committed records (RFC-021).
+                state.snapshot.store(writer.owned_snapshot());
+                state.after_commit_backpressure(&writer)
+            }
+            Err(e) => {
+                // A fenced/poisoned session would fail every later write;
+                // reopen it in place under the lock we already hold.
+                recovery::recover_after_write_error(
+                    &mut writer,
+                    &state.snapshot,
+                    &state.writer_health,
+                    &state.namespace,
+                    e,
+                )
+                .await;
+                None
+            }
+        };
+        drop(writer);
+        (result.map_err(WriteFailure::Own), stall)
+    };
+    WriteSection::Done { result, stall }
+}
+
 /// Run one HTTP Cypher request and classify it for metrics. Mirrors the Bolt
 /// `ServerBackend::run` path; the two do not share a chokepoint, so the
 /// parse/plan/execute logic is intentionally parallel.
@@ -3384,97 +3500,44 @@ async fn run_cypher(state: &AppState, req: &CypherRequest, principal: &Principal
                 response: rejection,
             };
         }
-        let Some(mut writer) = state.lock_writer_bounded(WriterLockKind::Http).await else {
-            return ObservedQuery {
-                kind: Some(QueryKind::Write),
-                ok: false,
-                elapsed: started.elapsed(),
-                response: writer_busy_response(),
-            };
+        // Shielded from handler drop (client disconnect / TimeoutLayer): the
+        // commit reaches a definite outcome even if nobody is left to read
+        // it. The operator-cancel flag is re-scoped onto the task because
+        // task-locals do not cross tokio::spawn.
+        let cancel_flag = namidb_storage::cancel::current_cancel_flag();
+        let section = {
+            let state = state.clone();
+            let plan = plan.clone();
+            let params = params.clone();
+            tokio::spawn(async move {
+                match cancel_flag {
+                    Some(flag) => {
+                        namidb_storage::cancel::with_cancel_flag(
+                            flag,
+                            run_write_section(state, plan, params),
+                        )
+                        .await
+                    }
+                    None => run_write_section(state, plan, params).await,
+                }
+            })
         };
-        let (result, stall) = if let Some(group) = state.group_commit.clone() {
-            // RFC-034 group commit: stage inside a request scope and let the
-            // namespace committer make the whole group durable with ONE
-            // commit. The waiter registers while still holding the lock so
-            // the committer cannot slip between staging and registration;
-            // the ACK arrives only after the merged commit is durable and
-            // the snapshot republished (RFC-021 preserved).
-            let mark = writer.begin_staged_request();
-            match execute_write_staged_with_deadline(
-                &plan,
-                &mut writer,
-                &params,
-                state.write_deadline(),
-            )
-            .await
-            {
-                Ok(outcome) => {
-                    writer.commit_staged_request();
-                    let lsn = writer.staged_last_lsn().unwrap_or(0);
-                    let ack = group.register(lsn);
-                    let stall = state.after_commit_backpressure(&writer);
-                    drop(writer);
-                    group.notify_committer();
-                    let result = match bounded_group_ack(ack, state.write_deadline()).await {
-                        GroupAck::Committed => Ok(outcome),
-                        GroupAck::Shared(shared) => Err(WriteFailure::Shared(shared)),
-                        GroupAck::CoordinatorExited => {
-                            Err(WriteFailure::Own(namidb_query::exec::ExecError::Runtime(
-                                "group commit coordinator exited".into(),
-                            )))
-                        }
-                        GroupAck::Indeterminate => Err(WriteFailure::Own(
-                            namidb_query::exec::ExecError::Runtime(GROUP_ACK_INDETERMINATE.into()),
-                        )),
-                    };
-                    (result, stall)
-                }
-                Err(e) => {
-                    // Roll back ONLY this request; earlier group members'
-                    // staged rows survive for their commit.
-                    writer.rollback_staged_request(mark);
-                    recovery::recover_after_write_error(
-                        &mut writer,
-                        &state.snapshot,
-                        &state.writer_health,
-                        &state.namespace,
-                        &e,
-                    )
-                    .await;
-                    drop(writer);
-                    (Err(WriteFailure::Own(e)), None)
-                }
+        let (result, stall) = match section.await {
+            Ok(WriteSection::Done { result, stall }) => (result, stall),
+            Ok(WriteSection::Busy) => {
+                return ObservedQuery {
+                    kind: Some(QueryKind::Write),
+                    ok: false,
+                    elapsed: started.elapsed(),
+                    response: writer_busy_response(),
+                };
             }
-        } else {
-            let result =
-                execute_write_with_deadline(&plan, &mut writer, &params, state.write_deadline())
-                    .await;
-            // Sample the soft write-stall decision while still holding the lock
-            // (RFC-027 P5), then release it and sleep — backpressure applies to
-            // this request, not to the writer mutex other connections need.
-            let stall = match &result {
-                Ok(_) => {
-                    // Refresh the published snapshot so subsequent reads see the
-                    // just-committed records (RFC-021).
-                    state.snapshot.store(writer.owned_snapshot());
-                    state.after_commit_backpressure(&writer)
-                }
-                Err(e) => {
-                    // A fenced/poisoned session would fail every later write;
-                    // reopen it in place under the lock we already hold.
-                    recovery::recover_after_write_error(
-                        &mut writer,
-                        &state.snapshot,
-                        &state.writer_health,
-                        &state.namespace,
-                        e,
-                    )
-                    .await;
-                    None
-                }
-            };
-            drop(writer);
-            (result.map_err(WriteFailure::Own), stall)
+            Err(join_error) => (
+                Err(WriteFailure::Own(namidb_query::exec::ExecError::Runtime(
+                    format!("write section task failed: {join_error}"),
+                ))),
+                None,
+            ),
         };
         // Stop the clock before the backpressure sleep: the stall is
         // intentional throttling, not query cost, so it must not inflate the
@@ -3625,6 +3688,38 @@ async fn admin_queries_multi(
         "queries": shared.metrics.queries().list(Some(namespace.as_str()))
     }))
     .into_response()
+}
+
+/// Header/default-namespace twins, matching every other admin route (an
+/// operator polling `/v0/admin/queries` on a multi-tenant server got a 404
+/// before these existed — third field report follow-up).
+async fn admin_queries_multi_unprefixed(
+    State(shared): State<SharedAppState>,
+    Extension(principal): Extension<Principal>,
+    headers: axum::http::HeaderMap,
+) -> Response {
+    let namespace = namespace_from_header(&shared, &headers);
+    admin_queries_multi(
+        State(shared),
+        Extension(principal),
+        axum::extract::Path(namespace),
+    )
+    .await
+}
+
+async fn admin_cancel_query_multi_unprefixed(
+    State(shared): State<SharedAppState>,
+    Extension(principal): Extension<Principal>,
+    headers: axum::http::HeaderMap,
+    axum::extract::Path(id): axum::extract::Path<u64>,
+) -> Response {
+    let namespace = namespace_from_header(&shared, &headers);
+    admin_cancel_query_multi(
+        State(shared),
+        Extension(principal),
+        axum::extract::Path((namespace, id)),
+    )
+    .await
 }
 
 async fn admin_cancel_query_multi(
@@ -4146,9 +4241,137 @@ async fn dispatch_cypher_multi(
     obs.response
 }
 
+/// Multi-tenant twin of [`WriteSection`].
+enum WriteSectionMulti {
+    Busy,
+    Retired,
+    Done {
+        result: Result<namidb_query::exec::WriteOutcome, WriteFailure>,
+        stall: Option<Duration>,
+    },
+}
+
+/// Multi-tenant twin of [`run_write_section`] — same drop-shield rationale.
+async fn run_write_section_multi(
+    ns_state: Arc<NamespaceState>,
+    shared: SharedAppState,
+    plan: namidb_query::LogicalPlan,
+    params: Params,
+) -> WriteSectionMulti {
+    let lock_started = std::time::Instant::now();
+    let writer = lock_writer_bounded(&ns_state.writer, shared.writer_lock_timeout).await;
+    shared.metrics.observe_writer_lock(
+        WriterLockKind::Http,
+        lock_started.elapsed(),
+        writer.is_some(),
+    );
+    let Some(mut writer) = writer else {
+        return WriteSectionMulti::Busy;
+    };
+    // Eviction marks the incarnation retired before it waits for this
+    // mutex. Revalidate only after acquisition: an Arc cloned before
+    // eviction may have spent arbitrary time in the mutex's FIFO queue.
+    if ns_state.is_retired() {
+        drop(writer);
+        return WriteSectionMulti::Retired;
+    }
+    let (result, stall) = if let Some(group) = ns_state.group_commit.clone() {
+        // RFC-034 grouped write, multi-tenant flavour: stage inside a
+        // request scope, register under the lock, and let this
+        // namespace's committer (spawned by the registry, cancelled on
+        // eviction) make the group durable with one commit.
+        let mark = writer.begin_staged_request();
+        match execute_write_staged_with_deadline(
+            &plan,
+            &mut writer,
+            &params,
+            shared.write_deadline(),
+        )
+        .await
+        {
+            Ok(outcome) => {
+                writer.commit_staged_request();
+                let lsn = writer.staged_last_lsn().unwrap_or(0);
+                let ack = group.register(lsn);
+                let bytes = writer.memtable_bytes();
+                if shared.memtable_flush_bytes > 0 && bytes >= shared.memtable_flush_bytes {
+                    ns_state.flush_notify.notify_one();
+                }
+                let stall = shared.write_stall_for(writer.max_l0_bucket_len(), bytes);
+                drop(writer);
+                group.notify_committer();
+                let result = match bounded_group_ack(ack, shared.write_deadline()).await {
+                    GroupAck::Committed => Ok(outcome),
+                    GroupAck::Shared(shared_err) => Err(WriteFailure::Shared(shared_err)),
+                    GroupAck::CoordinatorExited => {
+                        Err(WriteFailure::Own(namidb_query::exec::ExecError::Runtime(
+                            "group commit coordinator exited".into(),
+                        )))
+                    }
+                    GroupAck::Indeterminate => Err(WriteFailure::Own(
+                        namidb_query::exec::ExecError::Runtime(GROUP_ACK_INDETERMINATE.into()),
+                    )),
+                };
+                (result, stall)
+            }
+            Err(e) => {
+                // Roll back ONLY this request; earlier group members'
+                // staged rows survive. Never recover a retired
+                // incarnation (see the inline arm).
+                writer.rollback_staged_request(mark);
+                if !ns_state.is_retired() {
+                    recovery::recover_after_write_error(
+                        &mut writer,
+                        &ns_state.snapshot,
+                        &ns_state.writer_health,
+                        &ns_state.namespace,
+                        &e,
+                    )
+                    .await;
+                }
+                drop(writer);
+                (Err(WriteFailure::Own(e)), None)
+            }
+        }
+    } else {
+        let result =
+            execute_write_with_deadline(&plan, &mut writer, &params, shared.write_deadline()).await;
+        let stall = match &result {
+            Ok(_) => {
+                ns_state.snapshot.store(writer.owned_snapshot());
+                let bytes = writer.memtable_bytes();
+                if shared.memtable_flush_bytes > 0 && bytes >= shared.memtable_flush_bytes {
+                    ns_state.flush_notify.notify_one();
+                }
+                shared.write_stall_for(writer.max_l0_bucket_len(), bytes)
+            }
+            Err(e) => {
+                // Reopen a fenced/poisoned namespace writer in place, under
+                // the lock we already hold (mirrors the single-tenant path).
+                // Never recover a retired incarnation: doing so after
+                // eviction could claim a newer epoch and fence its successor.
+                if !ns_state.is_retired() {
+                    recovery::recover_after_write_error(
+                        &mut writer,
+                        &ns_state.snapshot,
+                        &ns_state.writer_health,
+                        &ns_state.namespace,
+                        e,
+                    )
+                    .await;
+                }
+                None
+            }
+        };
+        drop(writer);
+        (result.map_err(WriteFailure::Own), stall)
+    };
+    WriteSectionMulti::Done { result, stall }
+}
+
 /// Run one HTTP Cypher request in multi-tenant mode.
 async fn run_cypher_multi(
-    ns_state: &NamespaceState,
+    ns_state: &Arc<NamespaceState>,
     shared: &SharedAppState,
     req: &CypherRequest,
     principal: &Principal,
@@ -4383,119 +4606,43 @@ async fn run_cypher_multi(
                 response: rejection,
             };
         }
-        let lock_started = std::time::Instant::now();
-        let writer = lock_writer_bounded(&ns_state.writer, shared.writer_lock_timeout).await;
-        shared.metrics.observe_writer_lock(
-            WriterLockKind::Http,
-            lock_started.elapsed(),
-            writer.is_some(),
-        );
-        let Some(mut writer) = writer else {
-            return ObservedQuery {
-                kind: Some(QueryKind::Write),
-                ok: false,
-                elapsed: started.elapsed(),
-                response: writer_busy_response(),
-            };
+        // Shielded from handler drop, mirroring the single-tenant path.
+        let cancel_flag = namidb_storage::cancel::current_cancel_flag();
+        let section = {
+            let ns_state = Arc::clone(ns_state);
+            let shared = shared.clone();
+            let plan = plan.clone();
+            let params = params.clone();
+            tokio::spawn(async move {
+                match cancel_flag {
+                    Some(flag) => {
+                        namidb_storage::cancel::with_cancel_flag(
+                            flag,
+                            run_write_section_multi(ns_state, shared, plan, params),
+                        )
+                        .await
+                    }
+                    None => run_write_section_multi(ns_state, shared, plan, params).await,
+                }
+            })
         };
-        // Eviction marks the incarnation retired before it waits for this
-        // mutex. Revalidate only after acquisition: an Arc cloned before
-        // eviction may have spent arbitrary time in the mutex's FIFO queue.
-        if ns_state.is_retired() {
-            drop(writer);
-            return namespace_retired_observation(started);
-        }
-        let (result, stall) = if let Some(group) = ns_state.group_commit.clone() {
-            // RFC-034 grouped write, multi-tenant flavour: stage inside a
-            // request scope, register under the lock, and let this
-            // namespace's committer (spawned by the registry, cancelled on
-            // eviction) make the group durable with one commit.
-            let mark = writer.begin_staged_request();
-            match execute_write_staged_with_deadline(
-                &plan,
-                &mut writer,
-                &params,
-                shared.write_deadline(),
-            )
-            .await
-            {
-                Ok(outcome) => {
-                    writer.commit_staged_request();
-                    let lsn = writer.staged_last_lsn().unwrap_or(0);
-                    let ack = group.register(lsn);
-                    let bytes = writer.memtable_bytes();
-                    if shared.memtable_flush_bytes > 0 && bytes >= shared.memtable_flush_bytes {
-                        ns_state.flush_notify.notify_one();
-                    }
-                    let stall = shared.write_stall_for(writer.max_l0_bucket_len(), bytes);
-                    drop(writer);
-                    group.notify_committer();
-                    let result = match bounded_group_ack(ack, shared.write_deadline()).await {
-                        GroupAck::Committed => Ok(outcome),
-                        GroupAck::Shared(shared_err) => Err(WriteFailure::Shared(shared_err)),
-                        GroupAck::CoordinatorExited => {
-                            Err(WriteFailure::Own(namidb_query::exec::ExecError::Runtime(
-                                "group commit coordinator exited".into(),
-                            )))
-                        }
-                        GroupAck::Indeterminate => Err(WriteFailure::Own(
-                            namidb_query::exec::ExecError::Runtime(GROUP_ACK_INDETERMINATE.into()),
-                        )),
-                    };
-                    (result, stall)
-                }
-                Err(e) => {
-                    // Roll back ONLY this request; earlier group members'
-                    // staged rows survive. Never recover a retired
-                    // incarnation (see the inline arm).
-                    writer.rollback_staged_request(mark);
-                    if !ns_state.is_retired() {
-                        recovery::recover_after_write_error(
-                            &mut writer,
-                            &ns_state.snapshot,
-                            &ns_state.writer_health,
-                            &ns_state.namespace,
-                            &e,
-                        )
-                        .await;
-                    }
-                    drop(writer);
-                    (Err(WriteFailure::Own(e)), None)
-                }
+        let (result, stall) = match section.await {
+            Ok(WriteSectionMulti::Done { result, stall }) => (result, stall),
+            Ok(WriteSectionMulti::Busy) => {
+                return ObservedQuery {
+                    kind: Some(QueryKind::Write),
+                    ok: false,
+                    elapsed: started.elapsed(),
+                    response: writer_busy_response(),
+                };
             }
-        } else {
-            let result =
-                execute_write_with_deadline(&plan, &mut writer, &params, shared.write_deadline())
-                    .await;
-            let stall = match &result {
-                Ok(_) => {
-                    ns_state.snapshot.store(writer.owned_snapshot());
-                    let bytes = writer.memtable_bytes();
-                    if shared.memtable_flush_bytes > 0 && bytes >= shared.memtable_flush_bytes {
-                        ns_state.flush_notify.notify_one();
-                    }
-                    shared.write_stall_for(writer.max_l0_bucket_len(), bytes)
-                }
-                Err(e) => {
-                    // Reopen a fenced/poisoned namespace writer in place, under
-                    // the lock we already hold (mirrors the single-tenant path).
-                    // Never recover a retired incarnation: doing so after
-                    // eviction could claim a newer epoch and fence its successor.
-                    if !ns_state.is_retired() {
-                        recovery::recover_after_write_error(
-                            &mut writer,
-                            &ns_state.snapshot,
-                            &ns_state.writer_health,
-                            &ns_state.namespace,
-                            e,
-                        )
-                        .await;
-                    }
-                    None
-                }
-            };
-            drop(writer);
-            (result.map_err(WriteFailure::Own), stall)
+            Ok(WriteSectionMulti::Retired) => return namespace_retired_observation(started),
+            Err(join_error) => (
+                Err(WriteFailure::Own(namidb_query::exec::ExecError::Runtime(
+                    format!("write section task failed: {join_error}"),
+                ))),
+                None,
+            ),
         };
         let elapsed = started.elapsed();
         if let Some(delay) = stall {
@@ -5033,6 +5180,26 @@ mod tests {
             tokio::time::sleep(Duration::from_millis(5)).await;
         };
 
+        // The unprefixed (header/default-ns) admin route exists too — an
+        // operator polling /v0/admin/queries on a multi-tenant server got a
+        // 404 before the twins were added.
+        let response = app
+            .clone()
+            .oneshot(
+                Request::builder()
+                    .uri("/v0/admin/queries")
+                    .header("x-namidb-namespace", "acme")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(
+            response.status(),
+            StatusCode::OK,
+            "unprefixed multi-tenant query admin must route"
+        );
+
         // Another namespace sees nothing and cannot cancel it.
         let (_, body) = get_json(&app, "/beta/v0/admin/queries").await;
         let parsed: serde_json::Value = serde_json::from_str(&body).unwrap();
@@ -5141,6 +5308,58 @@ mod tests {
                 "{method} {uri} must be write-role gated"
             );
         }
+    }
+
+    /// Item 59's deferred hazard, now closed: hyper dropping the handler
+    /// future (client disconnect, request TimeoutLayer) must NOT cancel a
+    /// write mid-durability. The section runs on a shielded task, so the
+    /// commit reaches its definite outcome and the writer is released
+    /// cleanly even when nobody is left to read the response.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn dropped_write_handler_still_reaches_a_definite_outcome() {
+        let app = fixture(None).await;
+        let write = post_json(
+            &app,
+            "/v0/cypher",
+            serde_json::json!({ "query": "UNWIND range(1, 200000) AS i CREATE (:D {v: i})" }),
+        );
+        // Drop the request future mid-write — exactly what the TimeoutLayer
+        // or a vanished client does.
+        let _ = tokio::time::timeout(Duration::from_millis(30), write).await;
+
+        // The shielded section still commits; poll until the full batch is
+        // visible (bounded).
+        let deadline = std::time::Instant::now() + Duration::from_secs(30);
+        loop {
+            let (status, body) = post_json(
+                &app,
+                "/v0/cypher",
+                serde_json::json!({ "query": "MATCH (d:D) RETURN count(d) AS n" }),
+            )
+            .await;
+            assert_eq!(status, StatusCode::OK, "{body}");
+            if body.contains("\"n\":200000") {
+                break;
+            }
+            assert!(
+                body.contains("\"n\":0"),
+                "no partial state may ever be visible: {body}"
+            );
+            assert!(
+                std::time::Instant::now() < deadline,
+                "abandoned write never completed: {body}"
+            );
+            tokio::time::sleep(Duration::from_millis(20)).await;
+        }
+        // And the writer is immediately usable (no stuck lock, no leaked
+        // staged rows sealed into the next commit).
+        let (status, body) = post_json(
+            &app,
+            "/v0/cypher",
+            serde_json::json!({ "query": "CREATE (:After {ok: true})" }),
+        )
+        .await;
+        assert_eq!(status, StatusCode::OK, "{body}");
     }
 
     /// Item 59: the group-commit waiter is bounded by the write deadline —

--- a/crates/namidb-storage/src/cancel.rs
+++ b/crates/namidb-storage/src/cancel.rs
@@ -79,6 +79,12 @@ pub async fn with_cancel_flag<F: Future>(flag: Arc<AtomicBool>, fut: F) -> F::Ou
     .await
 }
 
+/// The operator cancel flag in scope, if any — for re-scoping onto a
+/// spawned task (task-locals do not cross `tokio::spawn`).
+pub fn current_cancel_flag() -> Option<Arc<AtomicBool>> {
+    CTX.try_with(|ctx| ctx.cancel.clone()).ok().flatten()
+}
+
 /// The active interrupt, if any. Operator cancel wins over the clock so the
 /// surfaced error names the actual cause.
 #[inline]

--- a/docs/testing/25tb-readiness.md
+++ b/docs/testing/25tb-readiness.md
@@ -873,7 +873,10 @@ honest indeterminate error, and slow-log lock/staging/commit
 sub-durations. Adjacent hazard recorded: the HTTP TimeoutLayer can
 cancel a commit mid-durability at 120s — to bound, not drop.
 **Follow-up shipped (2.5.0):** all of the plan above except the
-TimeoutLayer hazard (deferred, recorded here): determinate-boundary
+TimeoutLayer hazard (closed in 2.5.1: the HTTP write section runs on a
+shielded task — handler drops, whether from the TimeoutLayer or a client
+disconnect, can no longer cancel a commit mid-durability; the cancel flag
+re-scopes onto the task): determinate-boundary
 probes in commit_batch (pre-PUT and pre-orphan-retry only; the
 PUT-to-CAS zone stays uninterruptible), deadline scope over the HTTP
 commit and re-armed around both Bolt commits, bounded group-ACK wait
@@ -881,3 +884,22 @@ with the outcome-unknown error, >10s durability-tail warn, and opt-in
 store client bounds via NAMIDB_STORE_{REQUEST_TIMEOUT,RETRY_TIMEOUT,
 MAX_RETRIES}. The admin cancel flag (item 56) rides the same probes, so
 a stuck-but-probing commit is also operator-killable pre-PUT.
+
+### 60. [CONFIRMED — fixed in 2.5.1] One `UNWIND range(N)` read OOM-kills the process past ~4M
+
+Reported against 2.5.0 (4 GB container): range(3M) → clean
+ResourceLimitExceeded at 2.2s; range(4M) → connection dropped; range(5M)
+→ exit 137 at 10.5s. Reproduced: the row cap (default 1M) was evaluated
+only AFTER the unwind loop fully materialised its output, and `range()`
+itself allocated the whole list before any operator check — so the cap
+vetoed the result without ever bounding memory, and headroom decided
+whether the process survived. (The 2.5.0 probes added under item 56 were
+deadline/cancel probes only — the cap stayed post-loop.) Fixed with two
+guards: `range()` longer than a scoped row cap is rejected before
+allocating (interrupt taxonomy preserved through EvalErrorKind::
+Timeout/Cancelled → ExecError), and the unwind expansion checks the cap
+incrementally at the standard stride, bounding memory at cap + stride for
+any N. Also from this report follow-up: the multi-tenant unprefixed
+`/v0/admin/queries` twins existed for flush/backup but not queries —
+added (the reporter's "never appeared in the list" is otherwise
+unreproduced: HTTP single-tenant listing verified live at 3M/5M).


### PR DESCRIPTION
Both reproduced against the published 2.5.0 image before fixing (items 59/60 in 25tb-readiness.md).

**Item 60**: `UNWIND range(1, N)` OOM-killed the process past ~4M rows on a 4 GB container — the row cap was evaluated only AFTER full materialization, and `range()` allocated its entire list before any check. Now: `range()` beyond a scoped cap is rejected **before allocating** (with interrupt taxonomy preserved through a central `EvalErrorKind::{Timeout,Cancelled}` mapping), and both unwind loops check the cap incrementally — memory bounded at cap + one stride for any N. Uncapped embedded/CLI unchanged.

**Item 59 (deferred hazard, closed)**: the HTTP write section runs on a shielded task — TimeoutLayer expiry or client disconnect can no longer cancel a commit mid-durability; the operator-cancel flag re-scopes onto the task so item-56 kill still works.

**Bonus**: multi-tenant unprefixed `/v0/admin/queries` twins were missing (404 on the bare path; likely the reporter's "never listed").

Gate: full workspace green (90 binaries), fmt, clippy.