### PR TITLE
Engine-level schema introspection + constraint-backed SHOW INDEXES (field report 4, items 66/67c)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,27 @@ crates.io release will establish and document that API explicitly.
 
 ## [Unreleased]
 
+**Added**
+- Schema introspection now works on every surface: `CALL db.labels()`,
+  `CALL db.relationshipTypes()`, `CALL db.propertyKeys()`, and
+  `CALL db.schema.visualization()` are dispatched in the query engine
+  (previously the first three existed only as a Bolt connection shim and
+  HTTP/Python/CLI/MCP got "unknown procedure namespace `db`";
+  visualization existed nowhere). Served from manifest-cheap snapshot
+  data — no scans; visualization emits virtual nodes with stable ids so
+  tooling can diff successive draws; propertyKeys includes unflushed
+  memtable data. The CLI also gained `SHOW CONSTRAINTS` / `SHOW INDEXES`
+  interception (previously errored).
+
+**Fixed**
+- `SHOW INDEXES` returned `[]` on a database whose only declarations are
+  unique constraints, so tooling could not discover the keys. A
+  single-property unique constraint IS index-backed (one equality
+  sidecar); it now appears as its backing `RANGE` index under the
+  constraint's name. Composite unique constraints stay absent on
+  purpose: they are enforced by tuple scan on write and have no backing
+  lookup structure to advertise.
+
 ## [2.5.1] - 2026-08-30
 
 **Fixed**

--- a/crates/namidb-cli/src/main.rs
+++ b/crates/namidb-cli/src/main.rs
@@ -565,6 +565,20 @@ async fn run_statement(writer: &mut WriterSession, statement: &str) -> anyhow::R
         return Ok(());
     }
 
+    // SHOW CONSTRAINTS / SHOW INDEXES never lower to a plan; intercept them
+    // like every other surface does (the CLI previously errored on them).
+    if let Some(c) = q.as_show_schema() {
+        use namidb_query::parser::ast::ShowKind;
+        let snap = writer.snapshot();
+        let manifest = &snap.manifest().manifest;
+        let rows = match c.kind {
+            ShowKind::Constraints => namidb_query::show_constraints_rows(&manifest.schema),
+            ShowKind::Indexes => namidb_query::show_indexes_rows(manifest),
+        };
+        print_rows(&rows);
+        return Ok(());
+    }
+
     // The catalog is rebuilt per statement: an earlier DDL or write in the
     // same script changes what the optimizer should know.
     let catalog = StatsCatalog::from_manifest(&writer.snapshot().manifest().manifest);

--- a/crates/namidb-query/src/exec/show.rs
+++ b/crates/namidb-query/src/exec/show.rs
@@ -75,12 +75,31 @@ pub fn show_indexes_rows(manifest: &Manifest) -> Vec<Row> {
     let mut entries: Vec<(String, &'static str, String, Vec<String>)> = Vec::new();
     for (label, def) in &manifest.schema.labels {
         for p in &def.properties {
-            if p.indexed {
+            // A unique property IS index-backed (flush unions
+            // `indexed || unique` into one equality sidecar and the planner
+            // point-lookup relies on it), so it belongs in SHOW INDEXES —
+            // previously a database with only unique constraints reported
+            // `[]` and tooling could not discover its keys. One sidecar,
+            // one row: the constraint-named row wins over the flag row.
+            if p.unique {
+                let props = vec![p.name.clone()];
+                let name = manifest
+                    .schema
+                    .constraint_matching(label, &props, ConstraintKind::Unique)
+                    .map(|c| c.name.clone())
+                    .unwrap_or_else(|| {
+                        Constraint::default_name(label, &props, ConstraintKind::Unique)
+                    });
+                entries.push((name, "RANGE", label.clone(), props));
+            } else if p.indexed {
                 let name = format!("index_{label}_{}", p.name);
                 entries.push((name, "RANGE", label.clone(), vec![p.name.clone()]));
             }
         }
     }
+    // Composite UNIQUE constraints are deliberately absent: they are
+    // enforced by tuple scan on write and have no backing lookup structure,
+    // so listing them would advertise a plan route that does not exist.
     // Composite equality indexes carry their persisted name and their
     // DECLARATION-ordered property list.
     for index in &manifest.schema.indexes {

--- a/crates/namidb-query/src/exec/walker.rs
+++ b/crates/namidb-query/src/exec/walker.rs
@@ -2564,10 +2564,17 @@ async fn flat_call_procedure(
     if namespace == Some("db.index.vector") {
         return db_index_vector_procedure(name, args, yield_items, snapshot, params).await;
     }
+    // Neo4j-compatible schema introspection. These serve every surface
+    // (HTTP, Bolt, embedded Python, CLI, MCP) from the same manifest-cheap
+    // observed_* snapshot methods the Bolt pre-parse shim uses, so a GUI
+    // that draws the schema no longer needs the graph model out of band.
+    if matches!(namespace, Some("db") | Some("db.schema")) {
+        return db_schema_procedure(namespace, name, args, yield_items, snapshot).await;
+    }
     if !matches!(namespace, Some("algo") | None) {
         return Err(proc_unsupported(format!(
             "unknown procedure namespace `{}` \
-             (supported: `algo`, `search`, `db.index.vector`)",
+             (supported: `algo`, `db`, `db.schema`, `db.index.vector`, `search`)",
             namespace.unwrap_or("")
         )));
     }
@@ -2811,6 +2818,133 @@ async fn flat_call_procedure(
     };
 
     project_proc_rows(&format!("algo.{name}"), &cols, raw, yield_items)
+}
+
+/// Deterministic virtual node id for one schema entity, so
+/// `db.schema.visualization()` emits stable ids across calls and releases
+/// without touching storage. Plain FNV-1a folded into 128 bits.
+fn virtual_schema_node_id(label: &str) -> NodeId {
+    let mut lo: u64 = 0xcbf2_9ce4_8422_2325;
+    let mut hi: u64 = 0x8422_2325_cbf2_9ce4;
+    for b in label.bytes() {
+        lo = (lo ^ u64::from(b)).wrapping_mul(0x0000_0100_0000_01b3);
+        hi = (hi ^ u64::from(b).rotate_left(17)).wrapping_mul(0x0000_0100_0000_01b3);
+    }
+    NodeId::from_uuid(uuid::Uuid::from_u64_pair(hi, lo))
+}
+
+/// `CALL db.*` / `CALL db.schema.*` — Neo4j-style schema introspection.
+/// All manifest-cheap (label dict, schema, SST scopes; one sampled edge per
+/// type for endpoint inference); no data scans.
+async fn db_schema_procedure(
+    namespace: Option<&str>,
+    name: &str,
+    args: &[Expression],
+    yield_items: &[(String, String)],
+    snapshot: &Snapshot<'_>,
+) -> Result<Vec<Row>, ExecError> {
+    let qualified = format!("{}.{name}", namespace.unwrap_or(""));
+    if !args.is_empty() {
+        return Err(proc_unsupported(format!(
+            "procedure `{qualified}` takes no arguments"
+        )));
+    }
+    let (cols, raw): (Vec<&'static str>, Vec<Vec<RuntimeValue>>) = match (namespace, name) {
+        (Some("db"), "labels") => (
+            vec!["label"],
+            snapshot
+                .observed_labels()
+                .into_iter()
+                .map(|l| vec![RuntimeValue::String(l)])
+                .collect(),
+        ),
+        (Some("db"), "relationshipTypes") => (
+            vec!["relationshipType"],
+            snapshot
+                .observed_edge_types()
+                .into_iter()
+                .map(|t| vec![RuntimeValue::String(t)])
+                .collect(),
+        ),
+        (Some("db"), "propertyKeys") => (
+            vec!["propertyKey"],
+            snapshot
+                .observed_property_keys()
+                .map_err(ExecError::Storage)?
+                .into_iter()
+                .map(|k| vec![RuntimeValue::String(k)])
+                .collect(),
+        ),
+        (Some("db.schema"), "visualization") => {
+            let schema = &snapshot.manifest().manifest.schema;
+            let nodes: Vec<RuntimeValue> = snapshot
+                .observed_labels()
+                .into_iter()
+                .map(|label| {
+                    let mut properties = std::collections::BTreeMap::new();
+                    properties.insert("name".to_string(), RuntimeValue::String(label.clone()));
+                    let indexes: Vec<RuntimeValue> = schema
+                        .labels
+                        .get(&label)
+                        .map(|def| {
+                            def.properties
+                                .iter()
+                                .filter(|p| p.indexed)
+                                .map(|p| RuntimeValue::String(p.name.clone()))
+                                .collect()
+                        })
+                        .unwrap_or_default();
+                    let constraints: Vec<RuntimeValue> = schema
+                        .constraints()
+                        .iter()
+                        .filter(|c| c.label == label)
+                        .map(|c| RuntimeValue::String(c.name.clone()))
+                        .collect();
+                    properties.insert("indexes".to_string(), RuntimeValue::List(indexes));
+                    properties.insert("constraints".to_string(), RuntimeValue::List(constraints));
+                    RuntimeValue::Node(Box::new(NodeValue {
+                        id: virtual_schema_node_id(&label),
+                        labels: BTreeSet::from([label]),
+                        properties,
+                    }))
+                })
+                .collect();
+            let endpoints = snapshot
+                .observed_edge_endpoints()
+                .await
+                .map_err(ExecError::Storage)?;
+            let relationships: Vec<RuntimeValue> = endpoints
+                .into_iter()
+                .filter_map(|e| {
+                    // A rel needs both endpoint labels; a type whose sample
+                    // could not be resolved is omitted rather than pointed
+                    // at a fabricated label.
+                    let src = e.src_label?;
+                    let dst = e.dst_label?;
+                    Some(RuntimeValue::Rel(Box::new(RelValue {
+                        edge_type: e.edge_type,
+                        src: virtual_schema_node_id(&src),
+                        dst: virtual_schema_node_id(&dst),
+                        properties: std::collections::BTreeMap::new(),
+                    })))
+                })
+                .collect();
+            (
+                vec!["nodes", "relationships"],
+                vec![vec![
+                    RuntimeValue::List(nodes),
+                    RuntimeValue::List(relationships),
+                ]],
+            )
+        }
+        _ => {
+            return Err(proc_unsupported(format!(
+                "unknown procedure `{qualified}` (available: db.labels, \
+                 db.relationshipTypes, db.propertyKeys, db.schema.visualization)"
+            )));
+        }
+    };
+    project_proc_rows(&qualified, &cols, raw, yield_items)
 }
 
 /// Project a procedure's canonical columns (`cols`) and per-row values (`raw`)

--- a/crates/namidb-query/tests/exec_call.rs
+++ b/crates/namidb-query/tests/exec_call.rs
@@ -1700,3 +1700,162 @@ async fn prefix_expansion_beyond_the_cap_is_identical_on_every_route() {
         "a prefix under the cap returns every matching term"
     );
 }
+
+/// Fourth field report, item 66: schema introspection must work through the
+/// ENGINE dispatch (every surface), not only the Bolt pre-parse shim.
+#[tokio::test]
+async fn db_introspection_procedures_serve_from_the_engine() {
+    let mut writer = WriterSession::open(store(), paths("call-db"))
+        .await
+        .unwrap();
+    let mut props: BTreeMap<String, namidb_core::value::Value> = BTreeMap::new();
+    props.insert("name".into(), namidb_core::value::Value::Str("ana".into()));
+    let a = NodeId::new();
+    let b = NodeId::new();
+    writer
+        .upsert_node(
+            "Person",
+            a,
+            &NodeWriteRecord {
+                properties: props,
+                schema_version: 1,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+    writer.upsert_node("City", b, &node()).unwrap();
+    writer.upsert_edge("LIVES_IN", a, b, &edge()).unwrap();
+    writer.commit_batch().await.unwrap();
+    let snapshot = writer.snapshot();
+
+    let rows = run(&snapshot, "CALL db.labels() YIELD label").await;
+    let labels: Vec<String> = rows
+        .iter()
+        .map(|r| match r.get("label") {
+            Some(RuntimeValue::String(s)) => s.clone(),
+            other => panic!("label must be a string, got {other:?}"),
+        })
+        .collect();
+    assert!(labels.contains(&"Person".to_string()), "{labels:?}");
+    assert!(labels.contains(&"City".to_string()), "{labels:?}");
+
+    let rows = run(&snapshot, "CALL db.relationshipTypes()").await;
+    assert!(rows.iter().any(|r| matches!(
+        r.get("relationshipType"),
+        Some(RuntimeValue::String(t)) if t == "LIVES_IN"
+    )));
+
+    let rows = run(&snapshot, "CALL db.propertyKeys() YIELD propertyKey AS key").await;
+    assert!(
+        rows.iter().any(|r| matches!(
+            r.get("key"),
+            Some(RuntimeValue::String(k)) if k == "name"
+        )),
+        "YIELD aliasing must project the canonical column"
+    );
+
+    // visualization: one row, virtual nodes carry the label + stable ids,
+    // rels connect the endpoint labels' virtual nodes.
+    let rows = run(&snapshot, "CALL db.schema.visualization()").await;
+    assert_eq!(rows.len(), 1);
+    let nodes = match rows[0].get("nodes") {
+        Some(RuntimeValue::List(nodes)) => nodes.clone(),
+        other => panic!("nodes must be a list, got {other:?}"),
+    };
+    let mut label_to_id: BTreeMap<String, namidb_core::id::NodeId> = BTreeMap::new();
+    for n in &nodes {
+        match n {
+            RuntimeValue::Node(node) => {
+                let label = node.labels.iter().next().unwrap().clone();
+                label_to_id.insert(label, node.id);
+            }
+            other => panic!("virtual node expected, got {other:?}"),
+        }
+    }
+    assert!(label_to_id.contains_key("Person") && label_to_id.contains_key("City"));
+    match rows[0].get("relationships") {
+        Some(RuntimeValue::List(rels)) => {
+            let rel = rels
+                .iter()
+                .find_map(|r| match r {
+                    RuntimeValue::Rel(rel) if rel.edge_type == "LIVES_IN" => Some(rel),
+                    _ => None,
+                })
+                .expect("LIVES_IN must appear");
+            assert_eq!(rel.src, label_to_id["Person"]);
+            assert_eq!(rel.dst, label_to_id["City"]);
+        }
+        other => panic!("relationships must be a list, got {other:?}"),
+    }
+
+    // Stable ids across calls (tooling diffs successive draws).
+    let again = run(&snapshot, "CALL db.schema.visualization()").await;
+    assert_eq!(rows[0].get("nodes"), again[0].get("nodes"));
+}
+
+/// Item 67c: a database whose only declarations are unique constraints must
+/// not report `SHOW INDEXES` as `[]` — the unique property IS index-backed
+/// (one equality sidecar) and tooling discovers keys through this surface.
+/// Composite unique constraints stay absent: tuple-scan enforced, no
+/// backing lookup structure to advertise.
+#[tokio::test]
+async fn show_indexes_lists_constraint_backed_entries() {
+    let mut writer = WriterSession::open(store(), paths("show-cx"))
+        .await
+        .unwrap();
+    let mut props: BTreeMap<String, namidb_core::value::Value> = BTreeMap::new();
+    props.insert("email".into(), namidb_core::value::Value::Str("a@x".into()));
+    props.insert("a".into(), namidb_core::value::Value::Str("1".into()));
+    props.insert("b".into(), namidb_core::value::Value::Str("2".into()));
+    writer
+        .upsert_node(
+            "Person",
+            NodeId::new(),
+            &NodeWriteRecord {
+                properties: props,
+                schema_version: 1,
+                ..Default::default()
+            },
+        )
+        .unwrap();
+    writer.commit_batch().await.unwrap();
+    writer
+        .create_unique_constraint_named(Some("person_email"), "Person", &["email".into()], false)
+        .await
+        .unwrap();
+    writer
+        .create_unique_constraint_named(
+            Some("person_pair"),
+            "Person",
+            &["a".into(), "b".into()],
+            false,
+        )
+        .await
+        .unwrap();
+
+    let snap = writer.snapshot();
+    let rows = namidb_query::show_indexes_rows(&snap.manifest().manifest);
+    let names: Vec<String> = rows
+        .iter()
+        .map(|r| match r.get("name") {
+            Some(RuntimeValue::String(n)) => n.clone(),
+            other => panic!("name must be a string: {other:?}"),
+        })
+        .collect();
+    assert!(
+        names.contains(&"person_email".to_string()),
+        "the unique constraint's backing index must be listed: {names:?}"
+    );
+    assert!(
+        !names.contains(&"person_pair".to_string()),
+        "composite unique constraints have no backing structure: {names:?}"
+    );
+    let email_row = rows
+        .iter()
+        .find(|r| matches!(r.get("name"), Some(RuntimeValue::String(n)) if n == "person_email"))
+        .unwrap();
+    assert!(matches!(
+        email_row.get("type"),
+        Some(RuntimeValue::String(t)) if t == "RANGE"
+    ));
+}

--- a/crates/namidb-server/src/introspect.rs
+++ b/crates/namidb-server/src/introspect.rs
@@ -295,6 +295,10 @@ fn show_procedures() -> RunOutcome {
         ),
         ("db.propertyKeys", "db.propertyKeys() :: (propertyKey :: STRING)"),
         (
+            "db.schema.visualization",
+            "db.schema.visualization() :: (nodes :: LIST, relationships :: LIST)",
+        ),
+        (
             "apoc.meta.nodeTypeProperties",
             "apoc.meta.nodeTypeProperties() :: (nodeType :: STRING, nodeLabels :: LIST, propertyName :: STRING, propertyTypes :: LIST, mandatory :: BOOLEAN)",
         ),
@@ -489,6 +493,10 @@ fn mg_procedures() -> RunOutcome {
         (
             "schema.rel_type_properties",
             "schema.rel_type_properties() :: (relType :: STRING, mandatory :: BOOLEAN, propertyName :: STRING, propertyTypes :: STRING)",
+        ),
+        (
+            "db.schema.visualization",
+            "db.schema.visualization() :: (nodes :: LIST, relationships :: LIST)",
         ),
         ("mg.procedures", "mg.procedures() :: (name :: STRING, signature :: STRING)"),
         ("mg.functions", "mg.functions() :: (name :: STRING, signature :: STRING)"),

--- a/crates/namidb-storage/src/read.rs
+++ b/crates/namidb-storage/src/read.rs
@@ -3276,6 +3276,30 @@ impl<'mt> Snapshot<'mt> {
     /// rather than into typed columns, so the manifest has no type
     /// information to surface. Schema-introspection callers that need
     /// those still have to sample the actual data.
+    /// Every property key observable through this snapshot: declared schema
+    /// properties, SST column stats, and the memtable delta (a key written
+    /// but never flushed still counts — `db.propertyKeys()` serves this).
+    pub fn observed_property_keys(&self) -> Result<Vec<String>> {
+        use std::collections::BTreeSet;
+        let mut set: BTreeSet<String> = BTreeSet::new();
+        for label in self.observed_labels() {
+            for key in self.observed_property_types_for_label(&label).keys() {
+                set.insert(key.clone());
+            }
+        }
+        for (key, entry) in self.node_entries() {
+            let MemKey::Node { .. } = key else { continue };
+            let MemOp::Upsert(payload) = &entry.op else {
+                continue;
+            };
+            let record = NodeWriteRecord::decode(payload)?;
+            for key in record.properties.keys() {
+                set.insert(key.clone());
+            }
+        }
+        Ok(set.into_iter().collect())
+    }
+
     pub fn observed_property_types_for_label(
         &self,
         label: &str,

--- a/docs/testing/25tb-readiness.md
+++ b/docs/testing/25tb-readiness.md
@@ -903,3 +903,103 @@ any N. Also from this report follow-up: the multi-tenant unprefixed
 `/v0/admin/queries` twins existed for flush/backup but not queries —
 added (the reporter's "never appeared in the list" is otherwise
 unreproduced: HTTP single-tenant listing verified live at 3M/5M).
+
+## Fourth field report (2026-09-09) — seven findings
+
+Recon-before-fix once more; verdicts: three CORRECTED on mechanism, the
+rest confirmed. Fix cycle targets 2.6.0.
+
+### 61. [CORRECTED — fix in progress] Process dies silently: exit 0, no log, restarts cluster in write bursts
+
+The binary has NO self-exit path and NO exit-under-memory-pressure path
+(panic=abort → 134; kernel OOM → 137/OOMKilled). Exit 0 is reachable ONLY
+through graceful shutdown, so 29 clean exits = something external (a
+userspace OOM responder / autoheal restarter) sends SIGTERM when memory
+climbs. What IS ours: that drain is near-silent (info-level only, no
+cause, no RSS/governor telemetry), always exits 0 even for a non-signal
+shutdown (swallowed ctrl_c registration errors, closed watch channels),
+and ABANDONS in-flight Bolt sessions (detached spawns nobody joins —
+the embedding-ingest path, hence "mid-query during write bursts"). And
+the documented memory-pressure 503 rail is opt-in
+(NAMIDB_MEMORY_MAX_BYTES defaults to 0=disabled) and mute (counters, no
+logs). Fix: ShutdownCause attribution at WARN with governor telemetry;
+exit 1 for non-signal shutdowns; a bounded Bolt drain barrier (connection
+permits) + awaiting the listener handle; rate-limited warns on pressure
+rejections; boot WARN when the governor is disabled under a finite
+cgroup limit.
+
+### 62. [CORRECTED — fix in progress] adjacency_cache_bytes=0; 53k-degree reverse expand doesn't finish in 300s
+
+The 0 is deliberate: adjacency is the only OPT-IN cache tier
+(NAMIDB_ADJACENCY, requests 0 bytes unless enabled) by object-native
+design; the proportional split is correct and reproduces the boot log to
+the byte. The 300s is mostly ALGORITHMIC: execute_expand re-fetches and
+re-property-decodes the full partner list per input row with no
+memoization (159,804 rows x degree 53,473 ≈ 8.5e9 row-decodes — the same
+pattern NDB-09 fixed for shortestPath), and the no-CSR inverse fallback
+hydrates O(deg) property rows even for topology-only queries. Fix: boot
+log names the disabled tier + env var; per-operator-invocation partner
+memo in both expand paths; topology-mode skips property hydration in
+edge_lookup_via_sst.
+
+### 63. [CONFIRMED — fix in progress] CREATE INDEX point lookup 70x slower than unique constraint; 4.8GB vs 574MB store
+
+The unique arm batches an entire statement into ONE storage call
+(claimant pass + one multi-value paged probe + one batch confirm); the
+non-unique arm runs PER ROW, and each lookup pays a fresh store.head() +
+a new pinned source + 4-5 SEQUENTIAL page reads with the shared range
+cache OFF by default — ~6-9 round trips per lookup, zero cross-lookup
+reuse. The 8.4x store size is CHURN FROM THE SLOWNESS itself (33min vs
+47s of periodic flush/compaction generations retained until the sweep
+horizon), not per-SST index bytes (unique writes the identical dual
+legacy+paged sidecar set). Fix: cache pinned sidecar sources per
+snapshot (kills the per-call HEAD); default-on 64MiB RAM range cache;
+batch the multi arm like the unique arm. Legacy-body default flip
+deferred (2.0.4 rollback contract); flush.rs doc contradiction fixed.
+
+### 64. [CONFIRMED — fix in progress] Nine parallel read aggregations kill the server; no admission queue
+
+No bound on concurrent query execution exists in the default config: the
+memory governor defaults OFF, the scan gate (4) meters only plans
+containing NodeScan (lookup+expand aggregations pass free), row cap is
+per-operator rows not bytes. Fix: --max-concurrent-queries semaphore
+(default max(4, cores); 0 disables) at the four read chokepoints with a
+bounded wait then retryable 503 (HTTP) / transient Bolt error; scan-gate
+waits raced against client cancellation while there.
+
+### 65. [CORRECTED — fix in progress] file:// on macOS bind mounts: Precondition failures
+
+Real, but the unstable field is the INODE, not the size (etag format is
+{inode:x}-{mtime:x}-{size:x}; the failing pair differs in field one —
+gRPC-FUSE synthesizes inode numbers and churns them across attr-cache
+evictions). Our objects are create-only UUID paths (temp+rename, never
+appended), so etag pinning adds nothing there: fix marks local stores'
+pinned sources as ImmutablePath (no If-Match), keeping the manifest-size
+integrity check and the shared cache; escape hatch env to restore
+pinning.
+
+### 66. [CORRECTED — shipped in 2.6.0] No schema introspection
+
+db.labels()/relationshipTypes()/propertyKeys() already existed — but
+only as a Bolt pre-parse shim; HTTP/Python/CLI/MCP got "unknown
+procedure namespace db", and db.schema.visualization() existed nowhere.
+Now dispatched in the ENGINE (one chokepoint serves every surface) from
+manifest-cheap observed_* snapshot data, with stable virtual node ids;
+propertyKeys unions the memtable delta.
+
+### 67. [minor gaps — fixes staged] Docker features, write-timeout, SHOW INDEXES
+
+(a) REFUTED as packaging: every 2.x tag's Dockerfile bakes
+vector-index,text-index (verified per tag), and CALL even lists
+db.index.vector on the reported image. The parse error is DIALECT: our
+DDL grammar is `CREATE VECTOR INDEX name ON :Label(prop) ...`; the
+Neo4j spelling `... FOR (n:L) ON n.prop OPTIONS {...}` fails at
+expect(ON). Fix: accept the Neo4j form too + a feature-aware message
+when built without the feature. (b) --write-timeout has no own default
+(inherits --query-timeout=30s); gets its own 60s default + README rows
+(the durability tail is bounded since 2.5.x, so a longer default is
+safe). (c) SHOW INDEXES returned [] when only unique constraints exist —
+shipped in 2.6.0: single-property unique constraints appear as their
+backing RANGE index (constraint-named; one sidecar one row); composite
+unique constraints deliberately absent (tuple-scan enforced, no backing
+structure).


### PR DESCRIPTION
Item 66 corrected from the report: `db.labels()`/`relationshipTypes()`/`propertyKeys()` existed only as the Bolt pre-parse shim — every other surface got "unknown procedure namespace `db`", and `db.schema.visualization()` existed nowhere. Now dispatched in the engine (one chokepoint, all surfaces), manifest-cheap, with stable virtual ids for visualization; propertyKeys includes memtable-only data.

Item 67c: databases with only unique constraints reported `SHOW INDEXES` as `[]`; the constraint-backed RANGE index now lists under the constraint's name (composite unique deliberately absent — no backing structure). CLI gains the SHOW intercept.

Also records items 61-67 (recon verdicts) in the readiness doc.

Gate: full workspace green (90 binaries), fmt, clippy.