### PR TITLE
Batch non-unique equality lookups; memoize expand partners (field report 4, items 62/63)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,26 @@ crates.io release will establish and document that API explicitly.
   interception (previously errored).
 
 **Fixed**
+- Non-unique `CREATE INDEX` point lookups were ~70x slower than unique
+  constraints on identical data (fourth field report: 14.1ms vs 0.2ms,
+  33min vs 47s for a 160k-fact load — and the load-time churn inflated
+  the store 8.4x). The labeled non-unique equality arm now batches the
+  WHOLE statement like the unique arm always did (one claimant pass, one
+  multi-value sidecar probe per SST, one batched confirm), and pinned
+  sidecar sources are cached per snapshot so repeated probes stop paying
+  a fresh HEAD each. Results are unchanged, including duplicate lookup
+  values and mixed-type UNWIND lists.
+- A topology-only reverse expansion into a high-degree node could run
+  for minutes (53k-degree: >300s): with no CSR cache configured, the
+  fallback hydrated O(degree) property rows per probe for edges whose
+  properties the query never reads, and the expand executor re-fetched
+  the full partner list for EVERY input row binding the same node
+  (159,804 rows x 53,473 degree never terminated). Topology mode now
+  serves from a slim identity merge (no property hydration), and the
+  expand operator memoizes partner lists across its input rows (bounded
+  at 1M memoized edges; Arc-shared, so a repeated tail is O(1)). The
+  boot log also explains `adjacency_cache_bytes=0` (the CSR tier is
+  opt-in via NAMIDB_ADJACENCY) instead of looking like a budget bug.
 - `SHOW INDEXES` returned `[]` on a database whose only declarations are
   unique constraints, so tooling could not discover the keys. A
   single-property unique constraint IS index-backed (one equality

--- a/crates/namidb-query/src/exec/walker.rs
+++ b/crates/namidb-query/src/exec/walker.rs
@@ -618,20 +618,64 @@ pub(crate) fn execute_inner_with_routing<'a>(
                     return Ok(out);
                 }
 
+                // Labeled non-unique String lookups batch the WHOLE input:
+                // one claimant pass + one multi-value probe per SST + one
+                // batched confirm, mirroring the unique arm (item 63 — the
+                // per-row loop was 70x slower on identical data). Non-String
+                // values keep the per-row exact route below.
+                let batched_multi: Option<Vec<Vec<namidb_storage::NodeView>>> =
+                    if *multi && !label.is_empty() {
+                        let string_values: Vec<String> = input_rows
+                            .iter()
+                            .filter_map(|row| match evaluate(value, row, params) {
+                                Ok(RuntimeValue::String(s)) => Some(s),
+                                _ => None,
+                            })
+                            .collect();
+                        if string_values.is_empty() {
+                            None
+                        } else {
+                            Some(
+                                snapshot
+                                    .batch_lookup_nodes_by_property_multi(
+                                        label,
+                                        property,
+                                        &string_values,
+                                    )
+                                    .await
+                                    .map_err(ExecError::Storage)?,
+                            )
+                        }
+                    } else {
+                        None
+                    };
+                let mut batched_multi = batched_multi.map(|groups| groups.into_iter());
+
                 let mut out = Vec::with_capacity(input_rows.len());
                 for row in input_rows {
                     let lookup_val = evaluate(value, &row, params)?;
                     if *multi {
                         // Non-unique indexed property: fan out one row per
                         // matching node.
-                        for view in lookup_nodes_by_property_via_scan(
-                            snapshot,
-                            label,
-                            property,
-                            &lookup_val,
-                        )
-                        .await?
-                        {
+                        let views = match (&lookup_val, &mut batched_multi) {
+                            (RuntimeValue::String(_), Some(groups)) => {
+                                groups.next().ok_or_else(|| {
+                                    ExecError::Runtime(
+                                        "batched property lookup alignment was lost".into(),
+                                    )
+                                })?
+                            }
+                            _ => {
+                                lookup_nodes_by_property_via_scan(
+                                    snapshot,
+                                    label,
+                                    property,
+                                    &lookup_val,
+                                )
+                                .await?
+                            }
+                        };
+                        for view in views {
                             let mut new_row = row.clone();
                             new_row.set(
                                 alias.clone(),
@@ -1523,6 +1567,17 @@ pub(crate) async fn execute_expand(
     }
 
     let mut out = Vec::new();
+    // Partner-list memo shared across ALL input rows of this operator
+    // invocation (item 62): a workload whose rows repeatedly bind the same
+    // high-degree tail used to re-fetch and re-materialise the full partner
+    // list per row — 159,804 rows x degree 53,473 never terminated. Edge
+    // types, direction, and read mode are constant per operator, so the
+    // tail alone keys it; Arc sharing keeps a memo hit O(1). Bounded by
+    // total memoized edges so a scan across millions of DISTINCT tails
+    // cannot hold the whole graph resident.
+    const NEIGHBOUR_MEMO_MAX_EDGES: usize = 1_000_000;
+    let mut neighbour_memo: HashMap<NodeId, Arc<Vec<EdgeView>>> = HashMap::new();
+    let mut neighbour_memo_edges: usize = 0;
     for row in rows {
         // Deadline + row-cap guards: a multi-seed (or variable-length)
         // expansion is the most expensive operator, so bound it at every
@@ -1693,14 +1748,14 @@ pub(crate) async fn execute_expand(
             // Without this, each (step, edge) pair issues its own
             // `lookup_node` SST decode — the dominant cost in cold IC09
             // (2 k+ uncached lookups × 4.2 ms each in the SF1 profile).
-            let mut step_neighbours: Vec<(Step, Vec<EdgeView>)> =
+            let mut step_neighbours: Vec<(Step, Arc<Vec<EdgeView>>)> =
                 Vec::with_capacity(frontier.len());
             let mut unique_targets: Vec<NodeId> = Vec::new();
             let mut seen_targets: std::collections::HashSet<NodeId> =
                 std::collections::HashSet::new();
             for step in frontier.drain(..) {
-                let neighbours = if back_reference && max == 1 {
-                    match existing_target_id {
+                let neighbours: Arc<Vec<EdgeView>> = if back_reference && max == 1 {
+                    Arc::new(match existing_target_id {
                         Some(target) => {
                             exact_edges_between_any(
                                 snapshot,
@@ -1713,13 +1768,30 @@ pub(crate) async fn execute_expand(
                             .await?
                         }
                         None => Vec::new(),
-                    }
+                    })
+                } else if let Some(hit) = neighbour_memo.get(&step.tail) {
+                    Arc::clone(hit)
                 } else {
-                    neighbours_of_any(snapshot, &edge_types, direction, step.tail, edge_read_mode)
-                        .await?
+                    let fetched = Arc::new(
+                        neighbours_of_any(
+                            snapshot,
+                            &edge_types,
+                            direction,
+                            step.tail,
+                            edge_read_mode,
+                        )
+                        .await?,
+                    );
+                    if neighbour_memo_edges.saturating_add(fetched.len())
+                        <= NEIGHBOUR_MEMO_MAX_EDGES
+                    {
+                        neighbour_memo_edges += fetched.len();
+                        neighbour_memo.insert(step.tail, Arc::clone(&fetched));
+                    }
+                    fetched
                 };
                 if !back_reference {
-                    for edge in &neighbours {
+                    for edge in neighbours.iter() {
                         let tid = partner_id(edge, direction, step.tail);
                         if seen_targets.insert(tid) {
                             unique_targets.push(tid);
@@ -1741,7 +1813,7 @@ pub(crate) async fn execute_expand(
             )
             .await?;
             for (step, neighbours) in step_neighbours {
-                for edge in neighbours {
+                for edge in neighbours.iter() {
                     // Periodic in-loop guard: the (step × edge) space is the
                     // deg^hop blowup itself, so probe the budgets every few
                     // thousand edges rather than once per hop.
@@ -1752,7 +1824,7 @@ pub(crate) async fn execute_expand(
                             out.len() + hop_results.len() + next_frontier.len(),
                         )?;
                     }
-                    let target_id = partner_id(&edge, direction, step.tail);
+                    let target_id = partner_id(edge, direction, step.tail);
                     if prune_visits {
                         // Reached at an earlier level → any path through it now
                         // is longer than shortest (endpoint BFS: already
@@ -1848,7 +1920,7 @@ pub(crate) async fn execute_expand(
                             None => continue,
                         }
                     };
-                    let rel_value = RuntimeValue::Rel(Box::new(RelValue::from(edge)));
+                    let rel_value = RuntimeValue::Rel(Box::new(RelValue::from(edge.clone())));
                     let mut new_row = step.row.clone();
                     let mut new_rel_values = step.rel_values.clone();
                     if bind_rel_list {
@@ -6273,16 +6345,29 @@ async fn neighbours_of(
             }
         };
     }
+    // Topology mode: CSR when attached, else the SLIM identity fallback —
+    // never the property-hydrating SST path (item 62: an O(deg) property
+    // decode per probe on a 53k-degree node, for edges whose properties
+    // this mode is guaranteed never to read).
     match direction {
-        RelationshipDirection::Right => Ok(snapshot.out_edges(edge_type, node).await?.edges),
-        RelationshipDirection::Left => Ok(snapshot.in_edges(edge_type, node).await?.edges),
+        RelationshipDirection::Right => Ok(snapshot
+            .edge_lookup_topology(edge_type, node, EdgeDirection::Forward)
+            .await?
+            .edges),
+        RelationshipDirection::Left => Ok(snapshot
+            .edge_lookup_topology(edge_type, node, EdgeDirection::Inverse)
+            .await?
+            .edges),
         RelationshipDirection::Both => {
-            let mut out = snapshot.out_edges(edge_type, node).await?.edges;
-            // Drop self-loops from the in half — out_edges already yielded them
-            // (see the via_sst path above).
+            let mut out = snapshot
+                .edge_lookup_topology(edge_type, node, EdgeDirection::Forward)
+                .await?
+                .edges;
+            // Drop self-loops from the in half — the forward half already
+            // yielded them (see the via_sst path above).
             out.extend(
                 snapshot
-                    .in_edges(edge_type, node)
+                    .edge_lookup_topology(edge_type, node, EdgeDirection::Inverse)
                     .await?
                     .edges
                     .into_iter()

--- a/crates/namidb-query/src/exec/writer.rs
+++ b/crates/namidb-query/src/exec/writer.rs
@@ -919,18 +919,59 @@ fn execute_write_inner_mode<'a>(
                     return Ok(out);
                 }
 
+                // Same statement-level batching as the read walker's multi arm
+                // (item 63); the transactional overlay is handled inside the
+                // batched storage call.
+                let batched_multi: Option<Vec<Vec<namidb_storage::NodeView>>> =
+                    if *multi && !label.is_empty() {
+                        let string_values: Vec<String> = input_rows
+                            .iter()
+                            .filter_map(|row| match evaluate(value, row, params) {
+                                Ok(RuntimeValue::String(s)) => Some(s),
+                                _ => None,
+                            })
+                            .collect();
+                        if string_values.is_empty() {
+                            None
+                        } else {
+                            Some(
+                                snap.batch_lookup_nodes_by_property_multi(
+                                    label,
+                                    property,
+                                    &string_values,
+                                )
+                                .await
+                                .map_err(ExecError::Storage)?,
+                            )
+                        }
+                    } else {
+                        None
+                    };
+                let mut batched_multi = batched_multi.map(|groups| groups.into_iter());
+
                 let mut out = Vec::with_capacity(input_rows.len());
                 for row in input_rows {
                     let lookup_val = evaluate(value, &row, params)?;
                     if *multi {
-                        for view in crate::exec::walker::lookup_nodes_by_property_via_scan(
-                            &snap,
-                            label,
-                            property,
-                            &lookup_val,
-                        )
-                        .await?
-                        {
+                        let views = match (&lookup_val, &mut batched_multi) {
+                            (RuntimeValue::String(_), Some(groups)) => {
+                                groups.next().ok_or_else(|| {
+                                    ExecError::Runtime(
+                                        "batched property lookup alignment was lost".into(),
+                                    )
+                                })?
+                            }
+                            _ => {
+                                crate::exec::walker::lookup_nodes_by_property_via_scan(
+                                    &snap,
+                                    label,
+                                    property,
+                                    &lookup_val,
+                                )
+                                .await?
+                            }
+                        };
+                        for view in views {
                             let mut new_row = row.clone();
                             new_row.set(
                                 alias.clone(),

--- a/crates/namidb-query/tests/exec_batched_multi_lookup.rs
+++ b/crates/namidb-query/tests/exec_batched_multi_lookup.rs
@@ -1,0 +1,125 @@
+//! Item 63 executor half: the non-unique labeled equality arm batches the
+//! whole statement (mirroring the unique arm) — and the results are
+//! byte-identical to the per-row route, including duplicate lookup values,
+//! misses, and a mixed-type UNWIND list that forces the per-row fallback
+//! to interleave with the batch without losing alignment. Per the project
+//! reachability rule, the plan is asserted to carry the multi lookup
+//! operator, not just equal results.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use namidb_core::id::{NamespaceId, NodeId};
+use namidb_core::value::Value as CoreValue;
+use namidb_storage::{NamespacePaths, NodeWriteRecord, WriterSession};
+use object_store::memory::InMemory;
+use object_store::ObjectStore;
+
+use namidb_query::{
+    execute, lower, optimize, parse, LogicalPlan, Params, RuntimeValue, StatsCatalog,
+};
+
+fn person(team: &str, seq: i64) -> NodeWriteRecord {
+    let mut props: BTreeMap<String, CoreValue> = BTreeMap::new();
+    props.insert("team".into(), CoreValue::Str(team.into()));
+    props.insert("seq".into(), CoreValue::I64(seq));
+    NodeWriteRecord {
+        properties: props,
+        schema_version: 1,
+        ..Default::default()
+    }
+}
+
+fn plan_has_multi_lookup(plan: &LogicalPlan) -> bool {
+    matches!(plan, LogicalPlan::NodeByPropertyValue { multi: true, .. })
+        || plan.children().into_iter().any(plan_has_multi_lookup)
+}
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn batched_multi_arm_matches_expected_fanout() {
+    let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    let paths = NamespacePaths::new("tenants", NamespaceId::new("bml").unwrap());
+    let mut writer = WriterSession::open(store, paths).await.unwrap();
+    // teams: alpha x3, beta x2, gamma x1.
+    for (i, team) in ["alpha", "alpha", "alpha", "beta", "beta", "gamma"]
+        .iter()
+        .enumerate()
+    {
+        writer
+            .upsert_node("Person", NodeId::new(), &person(team, i as i64))
+            .unwrap();
+    }
+    writer.commit_batch().await.unwrap();
+    writer
+        .create_property_index_named(None, "Person", "team", false)
+        .await
+        .unwrap();
+    let schema = writer.snapshot().manifest().manifest.schema.clone();
+    writer.flush(schema).await.unwrap();
+    // Memtable delta: one more beta after the flush.
+    writer
+        .upsert_node("Person", NodeId::new(), &person("beta", 6))
+        .unwrap();
+    writer.commit_batch().await.unwrap();
+
+    let snapshot = writer.snapshot();
+    let catalog = StatsCatalog::from_manifest(&snapshot.manifest().manifest);
+    let query = "UNWIND $teams AS t MATCH (p:Person) WHERE p.team = t \
+                 RETURN t AS team, p.seq AS seq";
+    let plan = optimize(lower(&parse(query).unwrap()).unwrap(), &catalog);
+    assert!(
+        plan_has_multi_lookup(&plan),
+        "the indexed non-unique equality must plan the multi lookup: {plan:?}"
+    );
+
+    // Duplicates kept per input row, misses produce no rows, and the
+    // memtable delta is unioned in.
+    let mut params = Params::new();
+    params.insert(
+        "teams".to_string(),
+        RuntimeValue::List(vec![
+            RuntimeValue::String("alpha".into()),
+            RuntimeValue::String("beta".into()),
+            RuntimeValue::String("alpha".into()),
+            RuntimeValue::String("missing".into()),
+        ]),
+    );
+    let rows = execute(&plan, &snapshot, &params).await.unwrap();
+    let count_for = |team: &str| {
+        rows.iter()
+            .filter(|r| matches!(r.get("team"), Some(RuntimeValue::String(t)) if t == team))
+            .count()
+    };
+    assert_eq!(count_for("alpha"), 6, "3 matches x 2 duplicate inputs");
+    assert_eq!(count_for("beta"), 3, "2 flushed + 1 memtable");
+    assert_eq!(count_for("missing"), 0);
+    assert_eq!(rows.len(), 9);
+
+    // Mixed-type list: the non-String entries take the per-row exact route
+    // and alignment with the batched String groups must hold.
+    let mut params = Params::new();
+    params.insert(
+        "teams".to_string(),
+        RuntimeValue::List(vec![
+            RuntimeValue::String("gamma".into()),
+            RuntimeValue::Integer(42),
+            RuntimeValue::String("beta".into()),
+        ]),
+    );
+    let rows = execute(&plan, &snapshot, &params).await.unwrap();
+    let seqs_for = |team: &str| {
+        let mut seqs: Vec<i64> = rows
+            .iter()
+            .filter(|r| matches!(r.get("team"), Some(RuntimeValue::String(t)) if t == team))
+            .map(|r| match r.get("seq") {
+                Some(RuntimeValue::Integer(s)) => *s,
+                other => panic!("seq must be an integer: {other:?}"),
+            })
+            .collect();
+        seqs.sort_unstable();
+        seqs
+    };
+    assert_eq!(seqs_for("gamma"), vec![5]);
+    assert_eq!(seqs_for("beta"), vec![3, 4, 6]);
+    assert_eq!(rows.len(), 4, "the integer entry matches nothing");
+}

--- a/crates/namidb-storage/src/cache_budget.rs
+++ b/crates/namidb-storage/src/cache_budget.rs
@@ -460,6 +460,15 @@ pub fn shared_cache_capacities() -> CacheCapacities {
             adjacency_cache_bytes = capacities.adjacency_capacity_bytes(),
             "resolved process-wide cache capacities"
         );
+        // adjacency_cache_bytes=0 reads like a budget-split bug in the field
+        // (fourth field report, item 62); it is the opt-in tier's request.
+        if capacities.adjacency_capacity_bytes() == 0 {
+            tracing::info!(
+                "adjacency (CSR) cache disabled: it is opt-in by object-native \
+                 design; set NAMIDB_ADJACENCY=1 to enable and the split will \
+                 assign it a proportional share"
+            );
+        }
         capacities
     })
 }

--- a/crates/namidb-storage/src/flush.rs
+++ b/crates/namidb-storage/src/flush.rs
@@ -1443,11 +1443,8 @@ type UniquePropertySidecars = (
     Vec<(Path, SidecarPayload)>,
 );
 
-/// Explicit rolling-upgrade mode for old readers that require the monolithic
-/// bincode property map. Zero/default emits only PagedV2. A positive cap is a
-/// hard per-sidecar bound: crossing it fails the flush/compaction rather than
-/// silently dropping either authoritative representation.
-/// Size cap for the legacy bincode property sidecar.
+/// Size cap for the legacy bincode property sidecar (rolling-upgrade
+/// compatibility for pre-paged readers).
 ///
 /// The legacy body stays authoritative by default: it is the only shape a key
 /// too large to page can fall back to, and dropping it would leave such a

--- a/crates/namidb-storage/src/read.rs
+++ b/crates/namidb-storage/src/read.rs
@@ -737,6 +737,13 @@ pub struct Snapshot<'mt> {
     /// remain in the generation-pinned shared range cache. Both byte and entry
     /// ceilings prevent high query concurrency from multiplying metadata RAM.
     node_property_readers: Mutex<SnapshotByteCache<String, Arc<NodePropertyPageReader>>>,
+    /// Generation-pinned sidecar sources opened during this snapshot. Each
+    /// open costs one HEAD; a per-row lookup loop used to pay it on every
+    /// call (fourth field report, item 63 — the dominant term of the 14ms
+    /// non-unique point lookup). Pages stay in the shared range cache; this
+    /// holds only the tiny pinned handles.
+    pinned_sidecar_sources:
+        Mutex<SnapshotByteCache<String, crate::range_cache::PinnedObjectRangeSource>>,
     /// Read-your-own-writes overlay (RFC-026). A writer's staged-but-
     /// uncommitted batch, materialised as a second memtable and consulted
     /// alongside the committed `memtable`. The staged ops carry LSNs
@@ -832,6 +839,7 @@ impl<'mt> Snapshot<'mt> {
                 snapshot_local_cache_max_bytes(SNAPSHOT_NODE_PROPERTY_READER_CACHE_MAX_BYTES_ENV),
                 SNAPSHOT_NODE_PROPERTY_READER_CACHE_MAX_ENTRIES,
             )),
+            pinned_sidecar_sources: Mutex::new(SnapshotByteCache::new(64 * 1024, 64)),
             overlay: None,
         }
     }
@@ -2572,6 +2580,235 @@ impl<'mt> Snapshot<'mt> {
             .iter()
             .map(|value| confirmed.get(value).cloned().flatten())
             .collect())
+    }
+
+    /// Batched NON-unique twin of [`Self::batch_lookup_nodes_by_property`]:
+    /// resolve every value's FULL match set with one claimant pass, one
+    /// multi-value sidecar probe per SST, and one batched confirm — instead
+    /// of the per-row lookup loop that paid a fresh HEAD plus a sequential
+    /// page descent per value (fourth field report, item 63: 70x slower
+    /// than the unique arm on the same data). Same authoritative contract:
+    /// candidates are re-confirmed against the current view, so stale
+    /// postings never leak. Results per value are sorted by node id.
+    ///
+    /// `label` must be non-empty; the label-agnostic multi case already has
+    /// its own batched entry (`batch_lookup_nodes_by_property_any_label`).
+    pub async fn batch_lookup_nodes_by_property_multi(
+        &self,
+        label: &str,
+        property: &str,
+        values: &[String],
+    ) -> Result<Vec<Vec<NodeView>>> {
+        namidb_core::profile_scope!("Snapshot::batch_lookup_nodes_by_property_multi");
+        if values.is_empty() {
+            return Ok(Vec::new());
+        }
+        if let Some(cache) = &self.property_index_cache {
+            cache.record_equality_lookup();
+        }
+
+        let mut candidates: BTreeMap<String, BTreeSet<NodeId>> = values
+            .iter()
+            .cloned()
+            .map(|value| (value, BTreeSet::new()))
+            .collect();
+
+        // RYOW snapshots: the writer-private postings map is authoritative
+        // per value (first probe scans the overlay once).
+        if self.transactional_property_index.is_some() {
+            for (value, ids_out) in &mut candidates {
+                if let Some(ids) = self
+                    .transactional_property_candidates(label, property, &Value::Str(value.clone()))
+                    .await?
+                {
+                    ids_out.extend(ids);
+                }
+            }
+            return self
+                .batch_confirm_multi_candidates(label, property, values, candidates)
+                .await;
+        }
+
+        let node_sst_idxs: Vec<usize> = self.manifest.index.node_descriptors();
+        let have_node_ssts = !node_sst_idxs.is_empty();
+        let sst_idxs: Vec<usize> = node_sst_idxs
+            .into_iter()
+            .filter(|idx| node_sst_can_contain_label(&self.manifest.manifest, *idx, label))
+            .collect();
+        let sidecars: Option<Vec<_>> = sst_idxs
+            .iter()
+            .map(|idx| string_property_sidecar(&self.manifest.manifest.ssts[*idx], label, property))
+            .collect();
+
+        if have_node_ssts && sidecars.is_none() {
+            crate::route_telemetry::record_property(false);
+            let views = self.scan_label(label).await?;
+            return Ok(Self::group_multi_from_scan(property, values, views));
+        }
+        crate::route_telemetry::record_property(true);
+
+        let memtable_claimants = self.memtable_property_claimants(label, property)?;
+        for (value, ids_out) in &mut candidates {
+            let memtable_key =
+                crate::cache::encode_equality_property_value(&Value::Str(value.clone()))
+                    .expect("String values have an equality key");
+            if let Some(ids) = memtable_claimants.get(&memtable_key) {
+                ids_out.extend(ids.iter().copied());
+            }
+        }
+
+        for sidecar in sidecars.unwrap_or_default() {
+            match sidecar {
+                StringPropertySidecar::Unique(sidecar) => {
+                    // A legacy label-scoped unique map: at most one holder
+                    // per value from that generation — still a valid
+                    // candidate source (the property was unique when the
+                    // SST was written); newer duplicates live in newer
+                    // generations or the memtable.
+                    let absolute = format!(
+                        "{}/{}",
+                        self.paths.namespace_prefix().as_ref(),
+                        sidecar.path
+                    );
+                    let index = match self
+                        .probe_unique_property_sidecar(sidecar, &absolute, values)
+                        .await
+                    {
+                        Ok(index) => index,
+                        Err(error) if optional_accelerator_fallback(&error) => {
+                            tracing::warn!(
+                                path = %sidecar.path,
+                                error = %error,
+                                "unique property accelerator unavailable; falling back to one exact batch label scan"
+                            );
+                            crate::route_telemetry::record_property(false);
+                            let views = self.scan_label(label).await?;
+                            return Ok(Self::group_multi_from_scan(property, values, views));
+                        }
+                        Err(error) => return Err(error),
+                    };
+                    for (value, ids_out) in &mut candidates {
+                        if let Some(id) = index.get(value) {
+                            ids_out.insert(NodeId::from_uuid(Uuid::from_bytes(*id)));
+                        }
+                    }
+                }
+                StringPropertySidecar::Equality(sidecar) => {
+                    let absolute = format!(
+                        "{}/{}",
+                        self.paths.namespace_prefix().as_ref(),
+                        sidecar.path
+                    );
+                    let probes: Vec<String> = values
+                        .iter()
+                        .map(|value| {
+                            equality_sidecar_key(sidecar.key_encoding, &Value::Str(value.clone()))
+                                .expect("String sidecar compatibility checked during coverage")
+                        })
+                        .collect();
+                    let index = match self
+                        .probe_equality_property_sidecar(sidecar, &absolute, &probes)
+                        .await
+                    {
+                        Ok(index) => index,
+                        Err(error) if optional_accelerator_fallback(&error) => {
+                            tracing::warn!(
+                                path = %sidecar.path,
+                                error = %error,
+                                "equality property accelerator unavailable; falling back to one exact batch label scan"
+                            );
+                            crate::route_telemetry::record_property(false);
+                            let views = self.scan_label(label).await?;
+                            return Ok(Self::group_multi_from_scan(property, values, views));
+                        }
+                        Err(error) => return Err(error),
+                    };
+                    for (value, ids_out) in &mut candidates {
+                        let probe =
+                            equality_sidecar_key(sidecar.key_encoding, &Value::Str(value.clone()))
+                                .expect("String sidecar compatibility checked during coverage");
+                        if let Some(ids) = index.get(&probe) {
+                            ids_out.extend(
+                                ids.iter()
+                                    .map(|id| NodeId::from_uuid(Uuid::from_bytes(*id))),
+                            );
+                        }
+                    }
+                }
+            }
+        }
+
+        self.batch_confirm_multi_candidates(label, property, values, candidates)
+            .await
+    }
+
+    /// Confirm-all twin of [`Self::batch_confirm_unique_candidates`]: keep
+    /// EVERY candidate whose current view still holds the value, sorted by
+    /// node id per value.
+    async fn batch_confirm_multi_candidates(
+        &self,
+        label: &str,
+        property: &str,
+        values: &[String],
+        candidates: BTreeMap<String, BTreeSet<NodeId>>,
+    ) -> Result<Vec<Vec<NodeView>>> {
+        let ids: Vec<NodeId> = candidates
+            .values()
+            .flat_map(|ids| ids.iter().copied())
+            .collect::<BTreeSet<_>>()
+            .into_iter()
+            .collect();
+        let resolved = self.batch_lookup_nodes(label, &ids).await?;
+        let by_id: HashMap<NodeId, NodeView> = ids
+            .into_iter()
+            .zip(resolved)
+            .filter_map(|(id, view)| view.map(|view| (id, view)))
+            .collect();
+        let mut confirmed: HashMap<String, Vec<NodeView>> =
+            HashMap::with_capacity(candidates.len());
+        for (value, ids) in candidates {
+            let mut matches: Vec<NodeView> = ids
+                .into_iter()
+                .filter_map(|id| by_id.get(&id))
+                .filter(|view| {
+                    matches!(view.properties.get(property), Some(Value::Str(current)) if current == &value)
+                })
+                .cloned()
+                .collect();
+            matches.sort_by_key(|view| view.id);
+            confirmed.insert(value, matches);
+        }
+        Ok(values
+            .iter()
+            .map(|value| confirmed.get(value).cloned().unwrap_or_default())
+            .collect())
+    }
+
+    /// Scan-fallback grouping for the multi batch: one label scan, all
+    /// matches per value, sorted by node id.
+    fn group_multi_from_scan(
+        property: &str,
+        values: &[String],
+        views: Vec<NodeView>,
+    ) -> Vec<Vec<NodeView>> {
+        let mut by_value: HashMap<&str, Vec<NodeView>> = HashMap::new();
+        let wanted: std::collections::HashSet<&str> = values.iter().map(String::as_str).collect();
+        for view in views {
+            let Some(Value::Str(current)) = view.properties.get(property) else {
+                continue;
+            };
+            if let Some(key) = wanted.get(current.as_str()) {
+                by_value.entry(key).or_default().push(view);
+            }
+        }
+        values
+            .iter()
+            .map(|value| {
+                let mut matches = by_value.remove(value.as_str()).unwrap_or_default();
+                matches.sort_by_key(|view| view.id);
+                matches
+            })
+            .collect()
     }
 
     fn batch_unique_from_scan(
@@ -6385,6 +6622,48 @@ impl<'mt> Snapshot<'mt> {
         self.edge_lookup_via_sst(edge_type, key, direction).await
     }
 
+    /// Topology-only partner list: CSR when attached, else a SLIM SST
+    /// fallback built on the identity-only partner merge — no property
+    /// hydration. Before this, a topology-only reverse expand into a
+    /// 53k-degree node with no CSR configured paid an O(deg) property
+    /// decode per probe (fourth field report, item 62); the walker's
+    /// plan-aware routing already guarantees Topology-mode consumers never
+    /// read `EdgeView.properties`, matching the CSR route's slim contract.
+    pub async fn edge_lookup_topology(
+        &self,
+        edge_type: &str,
+        key: NodeId,
+        direction: EdgeDirection,
+    ) -> Result<EdgeListView> {
+        if adjacency_enabled() {
+            if let Some(cache) = self.adjacency_cache.clone() {
+                return self
+                    .edge_lookup_via_csr(cache, edge_type, key, direction)
+                    .await;
+            }
+        }
+        let partners = self
+            .sorted_partners_via_sst(edge_type, key, direction)
+            .await?;
+        let edges = partners
+            .into_iter()
+            .map(|partner| {
+                let (src, dst) = match direction {
+                    EdgeDirection::Forward => (key, partner),
+                    EdgeDirection::Inverse => (partner, key),
+                };
+                EdgeView {
+                    edge_type: edge_type.to_string(),
+                    src,
+                    dst,
+                    properties: BTreeMap::new(),
+                    lsn: 0,
+                }
+            })
+            .collect();
+        Ok(EdgeListView { edges })
+    }
+
     async fn edge_lookup_via_sst(
         &self,
         edge_type: &str,
@@ -8541,6 +8820,27 @@ impl<'mt> Snapshot<'mt> {
         absolute: &str,
         expected_size: Option<u64>,
     ) -> Result<crate::range_cache::PinnedObjectRangeSource> {
+        if let Some(source) = self
+            .pinned_sidecar_sources
+            .lock()
+            .unwrap()
+            .get(&absolute.to_string())
+        {
+            // The integrity envelope re-applies on a hit: the cached HEAD's
+            // size must still match the caller's manifest expectation.
+            if let Some(expected) = expected_size {
+                if source.object_size() != expected {
+                    return Err(Error::Corrupted {
+                        path: absolute.to_string(),
+                        detail: format!(
+                            "sidecar object size {} differs from manifest size {expected}",
+                            source.object_size()
+                        ),
+                    });
+                }
+            }
+            return Ok(source);
+        }
         let path = Path::from(absolute);
         let meta = self.store.head(&path).await?;
         if meta.location != path {
@@ -8563,8 +8863,19 @@ impl<'mt> Snapshot<'mt> {
                 });
             }
         }
-        crate::range_cache::PinnedObjectRangeSource::from_create_only_meta(self.store.clone(), meta)
-            .await
+        let source = crate::range_cache::PinnedObjectRangeSource::from_create_only_meta(
+            self.store.clone(),
+            meta,
+        )
+        .await?;
+        self.pinned_sidecar_sources.lock().unwrap().insert(
+            absolute.to_string(),
+            source.clone(),
+            absolute
+                .len()
+                .saturating_add(SNAPSHOT_CACHE_ENTRY_OVERHEAD_BYTES),
+        );
+        Ok(source)
     }
 
     /// Cache-aware fetch by absolute path. On hit, returns the cached

--- a/crates/namidb-storage/tests/batch_multi_and_topology.rs
+++ b/crates/namidb-storage/tests/batch_multi_and_topology.rs
@@ -1,0 +1,264 @@
+//! Fourth field report, items 62/63 storage halves.
+//!
+//! Item 63: `batch_lookup_nodes_by_property_multi` resolves a whole
+//! statement's non-unique String lookups with one claimant pass + one
+//! multi-value sidecar probe per SST + one batched confirm — and the
+//! per-snapshot pinned-source cache means repeated probes stop paying a
+//! fresh HEAD per call.
+//!
+//! Item 62: `edge_lookup_topology` with no CSR configured serves partner
+//! identity from the slim merge — no per-edge property hydration — while
+//! matching the property route's partner set exactly.
+
+use std::collections::BTreeMap;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+use namidb_core::id::{NamespaceId, NodeId};
+use namidb_core::value::Value;
+use namidb_storage::{EdgeWriteRecord, NamespacePaths, NodeWriteRecord, WriterSession};
+use object_store::memory::InMemory;
+use object_store::path::Path;
+use object_store::{
+    CopyOptions, GetOptions, GetResult, ListResult, ObjectMeta, ObjectStore, PutMultipartOptions,
+    PutOptions, PutPayload, PutResult,
+};
+
+/// Delegating spy that counts `head()` calls — the per-lookup cost item 63
+/// eliminated for repeated probes within one snapshot.
+#[derive(Debug)]
+struct HeadCountingStore {
+    inner: Arc<dyn ObjectStore>,
+    heads: AtomicU64,
+}
+
+impl std::fmt::Display for HeadCountingStore {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "HeadCountingStore({})", self.inner)
+    }
+}
+
+#[async_trait::async_trait]
+impl ObjectStore for HeadCountingStore {
+    async fn put_opts(
+        &self,
+        location: &Path,
+        payload: PutPayload,
+        opts: PutOptions,
+    ) -> object_store::Result<PutResult> {
+        self.inner.put_opts(location, payload, opts).await
+    }
+    async fn put_multipart_opts(
+        &self,
+        location: &Path,
+        opts: PutMultipartOptions,
+    ) -> object_store::Result<Box<dyn object_store::MultipartUpload>> {
+        self.inner.put_multipart_opts(location, opts).await
+    }
+    async fn get_opts(
+        &self,
+        location: &Path,
+        options: GetOptions,
+    ) -> object_store::Result<GetResult> {
+        // In object_store 0.13, `head()` is an extension method over
+        // `get_opts` with `head: true` — count it here.
+        if options.head {
+            self.heads.fetch_add(1, Ordering::Relaxed);
+        }
+        self.inner.get_opts(location, options).await
+    }
+    fn list(
+        &self,
+        prefix: Option<&Path>,
+    ) -> futures::stream::BoxStream<'static, object_store::Result<ObjectMeta>> {
+        self.inner.list(prefix)
+    }
+    async fn list_with_delimiter(&self, prefix: Option<&Path>) -> object_store::Result<ListResult> {
+        self.inner.list_with_delimiter(prefix).await
+    }
+    async fn copy_opts(
+        &self,
+        from: &Path,
+        to: &Path,
+        options: CopyOptions,
+    ) -> object_store::Result<()> {
+        self.inner.copy_opts(from, to, options).await
+    }
+    fn delete_stream(
+        &self,
+        locations: futures::stream::BoxStream<'static, object_store::Result<Path>>,
+    ) -> futures::stream::BoxStream<'static, object_store::Result<Path>> {
+        self.inner.delete_stream(locations)
+    }
+}
+
+fn person(team: &str, seq: i64) -> NodeWriteRecord {
+    let mut props: BTreeMap<String, Value> = BTreeMap::new();
+    props.insert("team".into(), Value::Str(team.into()));
+    props.insert("seq".into(), Value::I64(seq));
+    NodeWriteRecord {
+        properties: props,
+        schema_version: 1,
+        ..Default::default()
+    }
+}
+
+#[tokio::test]
+async fn batched_multi_lookup_groups_unions_and_confirms() {
+    let spy = Arc::new(HeadCountingStore {
+        inner: Arc::new(InMemory::new()),
+        heads: AtomicU64::new(0),
+    });
+    let store: Arc<dyn ObjectStore> = spy.clone();
+    let paths = NamespacePaths::new("tenants", NamespaceId::new("bm").unwrap());
+    let mut w = WriterSession::open(store, paths).await.unwrap();
+
+    let a1 = NodeId::new();
+    let a2 = NodeId::new();
+    let b1 = NodeId::new();
+    let moved = NodeId::new();
+    w.upsert_node("Person", a1, &person("alpha", 1)).unwrap();
+    w.upsert_node("Person", a2, &person("alpha", 2)).unwrap();
+    w.upsert_node("Person", b1, &person("beta", 3)).unwrap();
+    w.upsert_node("Person", moved, &person("beta", 4)).unwrap();
+    w.commit_batch().await.unwrap();
+    w.create_property_index_named(None, "Person", "team", false)
+        .await
+        .unwrap();
+    let schema = w.snapshot().manifest().manifest.schema.clone();
+    w.flush(schema).await.unwrap();
+
+    // Memtable delta: a NEW alpha claimant, and `moved` leaves beta — its
+    // flushed posting is now stale and must be dropped by confirmation.
+    let a3 = NodeId::new();
+    w.upsert_node("Person", a3, &person("alpha", 5)).unwrap();
+    w.upsert_node("Person", moved, &person("gamma", 4)).unwrap();
+    w.commit_batch().await.unwrap();
+
+    let snap = w.snapshot();
+    let values = vec![
+        "alpha".to_string(),
+        "beta".to_string(),
+        "alpha".to_string(),
+        "missing".to_string(),
+    ];
+    let groups = snap
+        .batch_lookup_nodes_by_property_multi("Person", "team", &values)
+        .await
+        .unwrap();
+    assert_eq!(
+        groups.len(),
+        4,
+        "one group per input value, duplicates kept"
+    );
+    let ids = |g: &Vec<namidb_storage::NodeView>| g.iter().map(|v| v.id).collect::<Vec<_>>();
+    let mut alpha_expected = vec![a1, a2, a3];
+    alpha_expected.sort();
+    assert_eq!(ids(&groups[0]), alpha_expected, "SST + memtable union");
+    assert_eq!(
+        ids(&groups[1]),
+        vec![b1],
+        "the superseded beta posting must be confirmed away"
+    );
+    assert_eq!(
+        groups[0].iter().map(|v| v.id).collect::<Vec<_>>(),
+        ids(&groups[2])
+    );
+    assert!(groups[3].is_empty(), "a missing value gets an empty group");
+
+    // Item 63's HEAD amortization: a second batch on the SAME snapshot must
+    // reuse every pinned sidecar source — zero additional HEADs.
+    let before = spy.heads.load(Ordering::Relaxed);
+    let again = snap
+        .batch_lookup_nodes_by_property_multi("Person", "team", &values)
+        .await
+        .unwrap();
+    assert_eq!(ids(&again[0]), alpha_expected);
+    assert_eq!(
+        spy.heads.load(Ordering::Relaxed),
+        before,
+        "repeat probes within one snapshot must not re-HEAD sidecars"
+    );
+}
+
+#[tokio::test]
+async fn batched_multi_lookup_falls_back_to_one_scan_without_a_sidecar() {
+    let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    let paths = NamespacePaths::new("tenants", NamespaceId::new("bmscan").unwrap());
+    let mut w = WriterSession::open(store, paths).await.unwrap();
+    let a = NodeId::new();
+    let b = NodeId::new();
+    w.upsert_node("Person", a, &person("alpha", 1)).unwrap();
+    w.upsert_node("Person", b, &person("alpha", 2)).unwrap();
+    w.commit_batch().await.unwrap();
+    // Flushed WITHOUT any index declaration: no sidecar coverage — the
+    // batch must serve exactly from one label scan, grouped per value.
+    let schema = w.snapshot().manifest().manifest.schema.clone();
+    w.flush(schema).await.unwrap();
+
+    let snap = w.snapshot();
+    let groups = snap
+        .batch_lookup_nodes_by_property_multi("Person", "team", &["alpha".into()])
+        .await
+        .unwrap();
+    let mut expected = vec![a, b];
+    expected.sort();
+    assert_eq!(groups[0].iter().map(|v| v.id).collect::<Vec<_>>(), expected);
+}
+
+#[tokio::test]
+async fn topology_fallback_matches_property_route_partners_without_hydration() {
+    let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    let paths = NamespacePaths::new("tenants", NamespaceId::new("topo").unwrap());
+    let mut w = WriterSession::open(store, paths).await.unwrap();
+
+    let hub = NodeId::new();
+    let s1 = NodeId::new();
+    let s2 = NodeId::new();
+    let s3 = NodeId::new();
+    for id in [hub, s1, s2, s3] {
+        w.upsert_node("N", id, &person("x", 0)).unwrap();
+    }
+    let mut edge_props: BTreeMap<String, Value> = BTreeMap::new();
+    edge_props.insert("weight".into(), Value::I64(7));
+    let edge = EdgeWriteRecord {
+        properties: edge_props,
+        schema_version: 1,
+    };
+    // Reverse-degree hub: s1,s2,s3 -> hub.
+    w.upsert_edge("VENTA", s1, hub, &edge).unwrap();
+    w.upsert_edge("VENTA", s2, hub, &edge).unwrap();
+    w.commit_batch().await.unwrap();
+    let schema = w.snapshot().manifest().manifest.schema.clone();
+    w.flush(schema).await.unwrap();
+    // Memtable delta: a third inbound edge, and s2's edge tombstoned.
+    w.upsert_edge("VENTA", s3, hub, &edge).unwrap();
+    w.tombstone_edge("VENTA", s2, hub).unwrap();
+    w.commit_batch().await.unwrap();
+
+    let snap = w.snapshot();
+    // The property route (authoritative comparison point).
+    let full = snap.in_edges_via_sst("VENTA", hub).await.unwrap().edges;
+    let mut full_partners: Vec<NodeId> = full.iter().map(|e| e.src).collect();
+    full_partners.sort();
+    // The slim topology route with NO CSR configured.
+    let slim = snap
+        .edge_lookup_topology("VENTA", hub, namidb_storage::EdgeDirection::Inverse)
+        .await
+        .unwrap()
+        .edges;
+    let mut slim_partners: Vec<NodeId> = slim.iter().map(|e| e.src).collect();
+    slim_partners.sort();
+    assert_eq!(slim_partners, full_partners, "partner sets must match");
+    assert!(
+        slim.iter().all(|e| e.properties.is_empty()),
+        "topology mode must not hydrate properties"
+    );
+    assert!(
+        full.iter().any(|e| !e.properties.is_empty()),
+        "the property route still hydrates (sanity check on the contrast)"
+    );
+    let mut expected = vec![s1, s3];
+    expected.sort();
+    assert_eq!(slim_partners, expected, "tombstone dropped, delta included");
+}


### PR DESCRIPTION
The two read-path performance findings, reproduced to the responsible loops.

**Item 63** (70x lookup gap): the non-unique arm ran per row with a fresh HEAD + sequential paged descent per lookup; now it batches whole statements like the unique arm always did (`batch_lookup_nodes_by_property_multi`), and pinned sidecar sources cache per snapshot. The 8.4x store blowup was churn from the slowness (generations retained during a 33-minute load), so it collapses with it.

**Item 62** (53k-degree reverse expand >300s): `execute_expand` memoizes partner lists across input rows (Arc-shared, 1M-edge bound), and topology-mode reads take a new SLIM identity route instead of hydrating O(degree) properties per probe. Boot log now explains `adjacency_cache_bytes=0` (opt-in tier).

Tests: counting-spy HEAD amortization, batch union/confirm/grouping semantics, topology-vs-property partner parity, executor fanout with plan-shape assertion and mixed-type alignment.

Gate (stepped, per host memory constraints): all workspace crates green (25+36+12+9+2 suites), clippy, fmt.