### PR TITLE
Field report 4: shutdown attribution, local etag pins, Neo4j DDL dialect, write-timeout default, read admission (items 61/64/65/67a-b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,19 @@ crates.io release will establish and document that API explicitly.
   memtable data. The CLI also gained `SHOW CONSTRAINTS` / `SHOW INDEXES`
   interception (previously errored).
 
+**Added**
+- Server-side read admission (fourth field report, item 64): every read
+  acquires a process-wide concurrency permit
+  (`NAMIDB_MAX_CONCURRENT_QUERIES`, default `max(4, cores)`, `0`
+  disables) with a bounded queue wait
+  (`NAMIDB_QUERY_ADMISSION_WAIT_MS`, default 5000) before executing;
+  waiting past the window returns a retryable 503 (Bolt: transient
+  error) naming the knob — nine parallel large aggregations used to
+  exhaust a container that handled them serialized, with nothing
+  bounding them. The scan gate stays nested inside; writes are
+  unaffected (they serialize on the writer); Bolt admission waits are
+  raced against client disconnect.
+
 **Fixed**
 - `file://` stores on macOS bind mounts (Docker Desktop's gRPC-FUSE) no
   longer fail reads with `Request precondition failure`. The local

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,33 @@ crates.io release will establish and document that API explicitly.
   purpose: they are enforced by tuple scan on write and have no backing
   lookup structure to advertise.
 
+- The search DDL now accepts the Neo4j 5 spellings alongside the native
+  syntax, so tutorials and driver snippets paste in unchanged:
+  `CREATE VECTOR INDEX name FOR (n:Label) ON n.prop OPTIONS {indexConfig:
+  {vector.dimensions: 768, vector.similarity_function: 'cosine'}}`
+  (keys bare or backtick-quoted, with or without the `indexConfig`
+  wrapper) and `CREATE FULLTEXT INDEX name FOR (n:Label) ON EACH
+  [n.title, n.body]`. Both dialects parse to the identical clause, so
+  `IF NOT EXISTS`, `SHOW INDEXES`, and the drop statements behave the
+  same regardless of the spelling used. An unknown OPTIONS key errors
+  naming the supported ones; an OPTIONS map missing the dimension or
+  similarity function errors with both spelled out instead of guessing.
+- A build compiled without `vector-index`/`text-index` now rejects the
+  corresponding CREATE/DROP statements with a message naming the missing
+  build feature (and noting the official Docker image and release
+  binaries include it), instead of a misleading "must be the sole
+  statement" complaint on a statement that was already sole.
+
+
+**Changed**
+- `--write-timeout` (`NAMIDB_WRITE_TIMEOUT`) gains its own 60s default
+  instead of inheriting the 30s `--query-timeout`: a legitimate bulk-load
+  statement outlives any sane read budget, and since 2.5.0 the durability
+  tail is deadline-bounded on its own, so the write timeout no longer
+  needs to double as that safety net. For bulk loads, set
+  `NAMIDB_WRITE_TIMEOUT=0s` (unbounded) or chunk the writes; `0s` keeps
+  meaning disabled.
+
 ## [2.5.1] - 2026-08-30
 
 **Fixed**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,15 @@ crates.io release will establish and document that API explicitly.
   interception (previously errored).
 
 **Fixed**
+- `file://` stores on macOS bind mounts (Docker Desktop's gRPC-FUSE) no
+  longer fail reads with `Request precondition failure`. The local
+  backend's ETag is stat-derived (`{inode:x}-{mtime:x}-{size:x}`) and
+  gRPC-FUSE churns the synthetic inode even for unmodified files, so the
+  `If-Match` pin on every SST range read rejected healthy data. Local
+  objects are create-only (written once under a fresh UUID name, never
+  modified), so `file://` reads now pin the immutable path instead of the
+  ETag — the shared range cache stays on, keyed per store instance.
+  `NAMIDB_LOCAL_ETAG_PIN=1` restores the previous ETag pin.
 - A dying server could exit 0 in near silence (fourth field report,
   item 61). Shutdown is now attributed: the signal handler logs
   SIGINT/SIGTERM at WARN with resident/max memory bytes and the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,21 @@ crates.io release will establish and document that API explicitly.
   interception (previously errored).
 
 **Fixed**
+- A dying server could exit 0 in near silence (fourth field report,
+  item 61). Shutdown is now attributed: the signal handler logs
+  SIGINT/SIGTERM at WARN with resident/max memory bytes and the
+  rejected-query count on the same line, so "shutdown under memory
+  pressure" is greppable. The shutdown channel closing without a real
+  signal — previously indistinguishable from a clean SIGTERM — now logs
+  at ERROR and exits nonzero, and a failed signal-handler registration
+  is logged once and never mistaken for a received signal. In-flight
+  Bolt sessions, which used to be abandoned the moment HTTP finished
+  draining, are drained behind a bounded permit barrier (25s, with the
+  abandoned count logged on timeout) before the process may return.
+  Memory-governor admission rejections, previously mute 503s/Bolt
+  failures, log at WARN rate-limited to one line per second, and a boot
+  with the governor disabled inside a container that has a finite
+  cgroup memory limit now warns to set `NAMIDB_MEMORY_MAX_BYTES=auto`.
 - Non-unique `CREATE INDEX` point lookups were ~70x slower than unique
   constraints on identical data (fourth field report: 14.1ms vs 0.2ms,
   33min vs 47s for a 160k-fact load — and the load-time churn inflated

--- a/README.md
+++ b/README.md
@@ -435,6 +435,15 @@ docker run --rm -p 8080:8080 -v namidb-data:/var/lib/namidb \
   namidb/namidb-server:2 --store "file:///var/lib/namidb?ns=prod"
 ```
 
+FUSE-backed bind mounts (macOS Docker Desktop's gRPC-FUSE, some network
+filesystems) are tolerated for `file://` stores: local objects are written
+exactly once under fresh UUID names, so reads pin the immutable path rather
+than sending `If-Match` on the stat-derived ETag — whose synthetic inode
+field such filesystems churn even for unmodified files, which used to fail
+reads with `Request precondition failure`. Set `NAMIDB_LOCAL_ETAG_PIN=1` to
+restore the ETag pin (e.g. if something other than NamiDB rewrites files
+under the store directory in place).
+
 For a full self-hosted stack (server + MinIO as the bucket) see [`docker-compose.yml`](docker-compose.yml). Or run it from source:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -759,6 +759,8 @@ The server also takes durability/backpressure knobs for critical workloads:
 | `--memtable-flush-bytes` (`NAMIDB_MEMTABLE_FLUSH_BYTES`) | 64 MiB | Flush as soon as a committed write crosses this — bounds the un-flushed working set by bytes, not just the flush interval. |
 | `--memtable-stall-bytes` (`NAMIDB_MEMTABLE_STALL_BYTES`) | 256 MiB | Soft write backpressure so a burst loader can't OOM the process between flushes. |
 | `--writer-lock-timeout` (`NAMIDB_WRITER_LOCK_TIMEOUT`) | 30s | Cap how long a foreground write/DDL waits for the writer; a stuck writer returns 503 fast instead of growing an unbounded queue. |
+| `--query-timeout` (`NAMIDB_QUERY_TIMEOUT`) | 30s | Wall-clock budget for a single read query (HTTP and Bolt); a runaway scan aborts with a timeout error instead of pinning a worker. `0s` = unbounded. |
+| `--write-timeout` (`NAMIDB_WRITE_TIMEOUT`) | 60s | Wall-clock budget for a single write statement — its own default, deliberately larger than the read budget. For a bulk load, set `NAMIDB_WRITE_TIMEOUT=0s` (unbounded) or chunk the writes into smaller statements. `0s` = unbounded. |
 
 A fenced or poisoned writer reopens itself automatically, and `/v0/health` reports `writer: degraded` (503) until it recovers — a rolling deploy or an accidental second replica on the same bucket drains cleanly instead of serving stale reads behind a green check.
 

--- a/crates/namidb-query/src/parser/ast.rs
+++ b/crates/namidb-query/src/parser/ast.rs
@@ -356,8 +356,10 @@ impl VectorQuantization {
     }
 }
 
-/// `CREATE VECTOR INDEX <name> FOR (<alias>:<Label>) ON <alias>.<property>
-/// METRIC <m> DIMENSION <n> [WITH {r, l_build, alpha, quantization}]` (RFC-030).
+/// `CREATE VECTOR INDEX <name> ON :<Label>(<property>) METRIC <m>
+/// DIMENSION <n> [WITH {r, l_build, alpha, quantization}]` (RFC-030), or the
+/// Neo4j 5 spelling `… FOR (<var>:<Label>) ON <var>.<property> OPTIONS {…}`
+/// — both parse to this clause.
 ///
 /// A standalone schema command: the parser only emits it as the sole clause
 /// of a query, and the server executes it out-of-band (see
@@ -386,7 +388,9 @@ pub struct CreateVectorIndexClause {
     pub span: SourceSpan,
 }
 
-/// `CREATE FULLTEXT INDEX <name> ON :<Label>(<prop1>[, <prop2>, …])`.
+/// `CREATE FULLTEXT INDEX <name> ON :<Label>(<prop1>[, <prop2>, …])`, or the
+/// Neo4j 5 spelling `… FOR (<var>:<Label>) ON EACH [<var>.<prop1>, …]` —
+/// both parse to this clause.
 ///
 /// A standalone schema command for the persistent BM25 index: the parser only
 /// emits it as the sole clause of a query, and the server executes it

--- a/crates/namidb-query/src/parser/grammar.rs
+++ b/crates/namidb-query/src/parser/grammar.rs
@@ -595,8 +595,13 @@ impl<'src> Parser<'src> {
         })
     }
 
-    /// `CREATE VECTOR INDEX <name> ON :<Label>(<property>) METRIC <m>
-    /// DIMENSION <n> [WITH { r: …, l_build: …, alpha: … }]` (RFC-030).
+    /// `CREATE VECTOR INDEX <name> [IF NOT EXISTS] ON :<Label>(<property>)
+    /// METRIC <m> DIMENSION <n> [WITH { r: …, l_build: …, alpha: … }]`
+    /// (RFC-030), or the Neo4j 5 dialect
+    /// `CREATE VECTOR INDEX <name> [IF NOT EXISTS] FOR (<var>:<Label>) ON
+    /// <var>.<property> OPTIONS {indexConfig: {vector.dimensions: <n>,
+    /// vector.similarity_function: '<m>'}}` — drivers and tutorials emit the
+    /// Neo4j spelling verbatim, and both forms produce the same clause.
     ///
     /// A standalone schema command — `parse_clause` only routes here for the
     /// `CREATE VECTOR` two-token prefix. The parsed clause never reaches the
@@ -607,9 +612,14 @@ impl<'src> Parser<'src> {
         self.expect_soft_keyword("VECTOR")?;
         self.expect_soft_keyword("INDEX")?;
         let name = self.expect_identifier()?;
-        // Optional `IF NOT EXISTS` (after the name, before `ON`) — the next token
-        // is either `IF` (Ident) or the hard `Token::On`, so this is unambiguous.
+        // Optional `IF NOT EXISTS` (after the name, before the target) — the
+        // next token is `IF` (Ident), the soft keyword `FOR`, or the hard
+        // `Token::On`, so this is unambiguous.
         let if_not_exists = self.parse_if_not_exists()?;
+        // Dialect fork: `ON` opens the native target, `FOR` the Neo4j one.
+        if matches!(self.peek(), Some(Token::Ident(n)) if n.eq_ignore_ascii_case("FOR")) {
+            return self.parse_create_vector_index_neo4j(start, name, if_not_exists);
+        }
         self.expect_in(&Token::On, "vector-index target")?;
         self.expect(&Token::Colon)?;
         let label = self.expect_identifier()?;
@@ -654,17 +664,203 @@ impl<'src> Parser<'src> {
         })
     }
 
-    /// `CREATE FULLTEXT INDEX <name> ON :Label(prop1[, prop2, …])`. Routed here
-    /// off the `CREATE FULLTEXT` two-token prefix. Never reaches the lowerer; the
-    /// server intercepts it via `Query::as_create_fulltext_index`.
+    /// Tail of the Neo4j-5 vector-index spelling: `FOR (<var>:<Label>) ON
+    /// <var>.<property> OPTIONS {…}` (the property is also accepted
+    /// parenthesized, matching `CREATE INDEX … ON (n.prop)`). Maps onto the
+    /// same [`CreateVectorIndexClause`] as the native form; the metric and
+    /// dimension have no defaults, so an OPTIONS map that omits them is an
+    /// error rather than a guess. The Vamana build overrides stay at their
+    /// engine defaults — Neo4j has no vocabulary for them.
+    fn parse_create_vector_index_neo4j(
+        &mut self,
+        start: usize,
+        name: Identifier,
+        if_not_exists: bool,
+    ) -> Result<CreateVectorIndexClause, ParseError> {
+        self.expect_soft_keyword("FOR")?;
+        let label = self.parse_ddl_node_target()?;
+        self.expect_in(&Token::On, "vector-index target")?;
+        let property = if self.eat(&Token::LParen).is_some() {
+            let p = self.parse_ddl_property_ref()?;
+            self.expect_in(&Token::RParen, "vector-index target")?;
+            p
+        } else {
+            self.parse_ddl_property_ref()?
+        };
+        let (metric, dim) = self.parse_vector_index_options()?;
+        let end = self
+            .tokens
+            .get(self.pos.wrapping_sub(1))
+            .map(|s| s.span.end)
+            .unwrap_or(start);
+        Ok(CreateVectorIndexClause {
+            name,
+            label,
+            property,
+            dim,
+            metric,
+            r: None,
+            l_build: None,
+            alpha: None,
+            quantization: crate::parser::ast::VectorQuantization::None,
+            if_not_exists,
+            span: SourceSpan::new(start, end),
+        })
+    }
+
+    /// `OPTIONS { … }` on the Neo4j vector-index form. The recognised keys —
+    /// bare, backtick-quoted, or nested one level under `indexConfig` as
+    /// Neo4j writes them — are `vector.dimensions` (an integer) and
+    /// `vector.similarity_function` (the native `METRIC` vocabulary). Both
+    /// are required, so a missing OPTIONS map is itself the error.
+    fn parse_vector_index_options(&mut self) -> Result<(VectorMetric, u32), ParseError> {
+        let options_span = self.peek_span();
+        let mut metric = None;
+        let mut dim = None;
+        if matches!(self.peek(), Some(Token::Ident(n)) if n.eq_ignore_ascii_case("OPTIONS")) {
+            self.bump(); // OPTIONS
+            self.parse_vector_options_map(&mut metric, &mut dim)?;
+        }
+        match (metric, dim) {
+            (Some(m), Some(d)) => Ok((m, d)),
+            _ => Err(ParseError::new(
+                ErrorCode::UnexpectedToken,
+                "vector index needs a dimension and a similarity function",
+                options_span,
+            )
+            .with_help(
+                "add OPTIONS {indexConfig: {`vector.dimensions`: <n>, \
+                 `vector.similarity_function`: 'cosine'}}, or use the native \
+                 `… ON :Label(prop) METRIC <m> DIMENSION <n>` form",
+            )),
+        }
+    }
+
+    /// One `{ … }` map of Neo4j vector-index options; `indexConfig` nests
+    /// the real keys one map deeper, so this recurses one level. `{}` is
+    /// accepted (the missing-key diagnostic fires afterwards).
+    fn parse_vector_options_map(
+        &mut self,
+        metric: &mut Option<VectorMetric>,
+        dim: &mut Option<u32>,
+    ) -> Result<(), ParseError> {
+        self.expect(&Token::LBrace)?;
+        if self.eat(&Token::RBrace).is_some() {
+            return Ok(());
+        }
+        loop {
+            let key = self.parse_vector_option_key()?;
+            match key.name.to_ascii_lowercase().as_str() {
+                "indexconfig" => self.parse_vector_options_map(metric, dim)?,
+                "vector.dimensions" => *dim = Some(self.parse_dimension()?),
+                "vector.similarity_function" => *metric = Some(self.parse_similarity_function()?),
+                other => {
+                    return Err(ParseError::new(
+                        ErrorCode::UnexpectedToken,
+                        format!(
+                            "unknown vector-index option `{other}` (expected \
+                             indexConfig, vector.dimensions, or \
+                             vector.similarity_function)"
+                        ),
+                        key.span,
+                    ));
+                }
+            }
+            if self.eat(&Token::Comma).is_some() {
+                continue;
+            }
+            break;
+        }
+        self.expect(&Token::RBrace)?;
+        Ok(())
+    }
+
+    /// A Neo4j option key up to its `:`. The dotted tail of a bare
+    /// `vector.dimensions` is folded into one name so it compares equal to
+    /// the backtick-quoted spelling (one `QuotedIdent` token).
+    fn parse_vector_option_key(&mut self) -> Result<Identifier, ParseError> {
+        let mut key = self.expect_identifier()?;
+        while self.eat(&Token::Dot).is_some() {
+            let seg = self.expect_identifier()?;
+            key = Identifier::new(
+                format!("{}.{}", key.name, seg.name),
+                SourceSpan::new(key.span.start, seg.span.end),
+            );
+        }
+        self.expect(&Token::Colon)?;
+        Ok(key)
+    }
+
+    /// `vector.similarity_function` value — Neo4j writes a quoted string
+    /// (`'cosine'`); a bare word is accepted too. Same vocabulary as the
+    /// native `METRIC` (see [`parse_vector_metric`](Self::parse_vector_metric)).
+    fn parse_similarity_function(&mut self) -> Result<VectorMetric, ParseError> {
+        let next = self.bump().ok_or_else(|| {
+            ParseError::new(
+                ErrorCode::UnexpectedEof,
+                "expected a similarity function (cosine, dot, or euclidean), \
+                 found end of input",
+                SourceSpan::point(self.src.len()),
+            )
+        })?;
+        let word = match &next.value {
+            Token::String(s) => Some(s.as_str()),
+            Token::Ident(s) => Some(s.as_str()),
+            _ => None,
+        };
+        if let Some(m) = word.and_then(VectorMetric::from_keyword) {
+            return Ok(m);
+        }
+        Err(ParseError::new(
+            ErrorCode::UnexpectedToken,
+            format!(
+                "expected a similarity function (cosine, dot, or euclidean), \
+                 found `{}`",
+                next.value.label()
+            ),
+            next.span,
+        ))
+    }
+
+    /// `CREATE FULLTEXT INDEX <name> [IF NOT EXISTS] ON :Label(prop1[, prop2,
+    /// …])`, or the Neo4j 5 dialect `CREATE FULLTEXT INDEX <name> [IF NOT
+    /// EXISTS] FOR (<var>:<Label>) ON EACH [<var>.prop1[, <var>.prop2, …]]` —
+    /// both forms produce the same clause. Routed here off the `CREATE
+    /// FULLTEXT` two-token prefix. Never reaches the lowerer; the server
+    /// intercepts it via `Query::as_create_fulltext_index`.
     fn parse_create_fulltext_index(&mut self) -> Result<CreateFulltextIndexClause, ParseError> {
         let start = self.peek_span().start;
         self.expect(&Token::Create)?;
         self.expect_soft_keyword("FULLTEXT")?;
         self.expect_soft_keyword("INDEX")?;
         let name = self.expect_identifier()?;
-        // Optional `IF NOT EXISTS` (after the name, before `ON`).
+        // Optional `IF NOT EXISTS` (after the name, before the target).
         let if_not_exists = self.parse_if_not_exists()?;
+        // Dialect fork, as for the vector index: `FOR` opens the Neo4j form.
+        if matches!(self.peek(), Some(Token::Ident(n)) if n.eq_ignore_ascii_case("FOR")) {
+            self.bump(); // FOR
+            let label = self.parse_ddl_node_target()?;
+            self.expect_in(&Token::On, "fulltext-index target")?;
+            self.expect_soft_keyword("EACH")?;
+            self.expect(&Token::LBracket)?;
+            let mut properties = vec![self.parse_ddl_property_ref()?];
+            while self.eat(&Token::Comma).is_some() {
+                properties.push(self.parse_ddl_property_ref()?);
+            }
+            self.expect_in(&Token::RBracket, "fulltext-index property list")?;
+            let end = self
+                .tokens
+                .get(self.pos.wrapping_sub(1))
+                .map(|s| s.span.end)
+                .unwrap_or(start);
+            return Ok(CreateFulltextIndexClause {
+                name,
+                label,
+                properties,
+                if_not_exists,
+                span: SourceSpan::new(start, end),
+            });
+        }
         self.expect_in(&Token::On, "fulltext-index target")?;
         self.expect(&Token::Colon)?;
         let label = self.expect_identifier()?;
@@ -3101,6 +3297,135 @@ mod tests {
             q.as_create_vector_index().is_none(),
             "a non-standalone DDL must not be intercepted"
         );
+    }
+
+    #[test]
+    fn create_vector_index_neo4j_form_matches_native() {
+        // The Neo4j 5 spelling maps onto the identical clause its native
+        // twin produces — field by field (spans aside).
+        let native = ok("CREATE VECTOR INDEX doc_emb ON :Doc(emb) METRIC cosine DIMENSION 16");
+        let neo = ok(
+            "CREATE VECTOR INDEX doc_emb FOR (d:Doc) ON d.emb \
+             OPTIONS {indexConfig: {`vector.dimensions`: 16, \
+             `vector.similarity_function`: 'cosine'}}",
+        );
+        let (n, m) = match (&native.head.clauses[0], &neo.head.clauses[0]) {
+            (Clause::CreateVectorIndex(n), Clause::CreateVectorIndex(m)) => (n, m),
+            other => panic!("expected two CreateVectorIndex clauses, got {other:?}"),
+        };
+        assert_eq!(n.name.name, m.name.name);
+        assert_eq!(n.label.name, m.label.name);
+        assert_eq!(n.property.name, m.property.name);
+        assert_eq!(n.dim, m.dim);
+        assert_eq!(n.metric, m.metric);
+        assert_eq!((n.r, n.l_build, n.alpha), (m.r, m.l_build, m.alpha));
+        assert_eq!(n.quantization, m.quantization);
+        assert_eq!(n.if_not_exists, m.if_not_exists);
+        // The server-side DDL hook recognises the Neo4j spelling too.
+        assert!(neo.as_create_vector_index().is_some());
+    }
+
+    #[test]
+    fn create_vector_index_neo4j_form_variants() {
+        // IF NOT EXISTS sits in the same slot as natively, the option keys
+        // may be bare (unquoted) and given without the indexConfig wrapper,
+        // and the property reference may be parenthesized.
+        let q = ok(
+            "CREATE VECTOR INDEX doc_emb IF NOT EXISTS FOR (d:Doc) ON (d.emb) \
+             OPTIONS {vector.dimensions: 8, vector.similarity_function: 'euclidean'}",
+        );
+        let c = match &q.head.clauses[0] {
+            Clause::CreateVectorIndex(c) => c,
+            other => panic!("expected CreateVectorIndex, got {other:?}"),
+        };
+        assert!(c.if_not_exists);
+        assert_eq!(c.label.name, "Doc");
+        assert_eq!(c.property.name, "emb");
+        assert_eq!(c.dim, 8);
+        assert_eq!(c.metric, VectorMetric::Euclidean);
+    }
+
+    #[test]
+    fn create_vector_index_neo4j_unknown_option_errors_helpfully() {
+        let errs = parse(
+            "CREATE VECTOR INDEX ix FOR (d:Doc) ON d.emb \
+             OPTIONS {indexConfig: {`vector.wrong`: 1}}",
+        )
+        .expect_err("unknown option key must not parse");
+        assert_eq!(errs[0].code, ErrorCode::UnexpectedToken);
+        assert!(
+            errs[0].message.contains("vector.dimensions")
+                && errs[0].message.contains("vector.similarity_function"),
+            "error must name the supported keys, got: {}",
+            errs[0].message
+        );
+    }
+
+    #[test]
+    fn create_vector_index_neo4j_requires_dimension_and_metric() {
+        // The clause has no defaults for METRIC/DIMENSION, so an omitted (or
+        // incomplete) OPTIONS map errors with the required keys spelled out.
+        for src in [
+            "CREATE VECTOR INDEX ix FOR (d:Doc) ON d.emb",
+            "CREATE VECTOR INDEX ix FOR (d:Doc) ON d.emb \
+             OPTIONS {indexConfig: {`vector.dimensions`: 16}}",
+        ] {
+            let errs = parse(src).expect_err("incomplete vector DDL must not parse");
+            assert_eq!(errs[0].code, ErrorCode::UnexpectedToken, "{src}");
+            assert!(
+                errs[0].help.as_deref().unwrap_or("").contains("vector.dimensions"),
+                "help must list the required options, got: {:?}",
+                errs[0].help
+            );
+        }
+    }
+
+    #[test]
+    fn create_fulltext_index_neo4j_form_matches_native() {
+        // `FOR (d:Doc) ON EACH [d.title, d.body]` maps onto the identical
+        // clause the native `ON :Doc(title, body)` produces.
+        let native = ok("CREATE FULLTEXT INDEX body_ix ON :Doc(title, body)");
+        let neo = ok("CREATE FULLTEXT INDEX body_ix FOR (d:Doc) ON EACH [d.title, d.body]");
+        let (n, m) = match (&native.head.clauses[0], &neo.head.clauses[0]) {
+            (Clause::CreateFulltextIndex(n), Clause::CreateFulltextIndex(m)) => (n, m),
+            other => panic!("expected two CreateFulltextIndex clauses, got {other:?}"),
+        };
+        assert_eq!(n.name.name, m.name.name);
+        assert_eq!(n.label.name, m.label.name);
+        assert_eq!(
+            n.properties.iter().map(|p| &p.name).collect::<Vec<_>>(),
+            m.properties.iter().map(|p| &p.name).collect::<Vec<_>>()
+        );
+        assert_eq!(n.if_not_exists, m.if_not_exists);
+        assert!(neo.as_create_fulltext_index().is_some());
+    }
+
+    #[test]
+    fn create_fulltext_index_neo4j_form_roundtrips_via_display() {
+        // Display renders the canonical native spelling; re-parsing it must
+        // yield the same two-property clause the ON EACH list produced.
+        let neo = ok(
+            "CREATE FULLTEXT INDEX body_ix IF NOT EXISTS \
+             FOR (d:Doc) ON EACH [d.title, d.body]",
+        );
+        let c = match &neo.head.clauses[0] {
+            Clause::CreateFulltextIndex(c) => c,
+            other => panic!("expected CreateFulltextIndex, got {other:?}"),
+        };
+        assert_eq!(
+            c.to_string(),
+            "CREATE FULLTEXT INDEX body_ix IF NOT EXISTS ON :Doc(title, body)"
+        );
+        let re = ok(&c.to_string());
+        match &re.head.clauses[0] {
+            Clause::CreateFulltextIndex(r) => {
+                assert_eq!(r.properties.len(), 2);
+                assert_eq!(r.properties[0].name, c.properties[0].name);
+                assert_eq!(r.properties[1].name, c.properties[1].name);
+                assert!(r.if_not_exists);
+            }
+            _ => panic!(),
+        }
     }
 
     #[test]

--- a/crates/namidb-query/src/parser/grammar.rs
+++ b/crates/namidb-query/src/parser/grammar.rs
@@ -3304,11 +3304,9 @@ mod tests {
         // The Neo4j 5 spelling maps onto the identical clause its native
         // twin produces — field by field (spans aside).
         let native = ok("CREATE VECTOR INDEX doc_emb ON :Doc(emb) METRIC cosine DIMENSION 16");
-        let neo = ok(
-            "CREATE VECTOR INDEX doc_emb FOR (d:Doc) ON d.emb \
+        let neo = ok("CREATE VECTOR INDEX doc_emb FOR (d:Doc) ON d.emb \
              OPTIONS {indexConfig: {`vector.dimensions`: 16, \
-             `vector.similarity_function`: 'cosine'}}",
-        );
+             `vector.similarity_function`: 'cosine'}}");
         let (n, m) = match (&native.head.clauses[0], &neo.head.clauses[0]) {
             (Clause::CreateVectorIndex(n), Clause::CreateVectorIndex(m)) => (n, m),
             other => panic!("expected two CreateVectorIndex clauses, got {other:?}"),
@@ -3373,7 +3371,11 @@ mod tests {
             let errs = parse(src).expect_err("incomplete vector DDL must not parse");
             assert_eq!(errs[0].code, ErrorCode::UnexpectedToken, "{src}");
             assert!(
-                errs[0].help.as_deref().unwrap_or("").contains("vector.dimensions"),
+                errs[0]
+                    .help
+                    .as_deref()
+                    .unwrap_or("")
+                    .contains("vector.dimensions"),
                 "help must list the required options, got: {:?}",
                 errs[0].help
             );
@@ -3404,10 +3406,8 @@ mod tests {
     fn create_fulltext_index_neo4j_form_roundtrips_via_display() {
         // Display renders the canonical native spelling; re-parsing it must
         // yield the same two-property clause the ON EACH list produced.
-        let neo = ok(
-            "CREATE FULLTEXT INDEX body_ix IF NOT EXISTS \
-             FOR (d:Doc) ON EACH [d.title, d.body]",
-        );
+        let neo = ok("CREATE FULLTEXT INDEX body_ix IF NOT EXISTS \
+             FOR (d:Doc) ON EACH [d.title, d.body]");
         let c = match &neo.head.clauses[0] {
             Clause::CreateFulltextIndex(c) => c,
             other => panic!("expected CreateFulltextIndex, got {other:?}"),

--- a/crates/namidb-query/src/plan/lower.rs
+++ b/crates/namidb-query/src/plan/lower.rs
@@ -245,38 +245,66 @@ fn lower_clause_seq(
             }
             // `CREATE VECTOR INDEX` is schema DDL, not a query operator: the
             // server intercepts a standalone one before lowering (see
-            // `Query::as_create_vector_index`). Reaching this arm means the
-            // DDL was combined with other clauses or lowered directly via the
-            // library API — reject it rather than silently dropping it.
+            // `Query::as_create_vector_index`). With the feature compiled in,
+            // reaching this arm means the DDL was combined with other clauses
+            // or lowered directly via the library API — reject it rather than
+            // silently dropping it. With the feature compiled OUT the server
+            // hook does not exist, so even a sole statement lands here: name
+            // the missing build feature instead of implying a mis-combined
+            // query (the official images/binaries ship with both features).
             Clause::CreateVectorIndex(_) => {
                 return Err(LowerError::new(
                     LowerErrorKind::UnsupportedFeature,
-                    "CREATE VECTOR INDEX is a schema command and must be the \
-                     sole statement; it cannot be lowered to a query plan",
+                    if cfg!(feature = "vector-index") {
+                        "CREATE VECTOR INDEX is a schema command and must be the \
+                         sole statement; it cannot be lowered to a query plan"
+                    } else {
+                        "this server was built without the vector-index feature; \
+                         the official Docker image and release binaries include \
+                         it — rebuild with --features vector-index"
+                    },
                     clause.span(),
                 ));
             }
             Clause::CreateFulltextIndex(_) => {
                 return Err(LowerError::new(
                     LowerErrorKind::UnsupportedFeature,
-                    "CREATE FULLTEXT INDEX is a schema command and must be the \
-                     sole statement; it cannot be lowered to a query plan",
+                    if cfg!(feature = "text-index") {
+                        "CREATE FULLTEXT INDEX is a schema command and must be the \
+                         sole statement; it cannot be lowered to a query plan"
+                    } else {
+                        "this server was built without the text-index feature; \
+                         the official Docker image and release binaries include \
+                         it — rebuild with --features text-index"
+                    },
                     clause.span(),
                 ));
             }
             Clause::DropVectorIndex(_) => {
                 return Err(LowerError::new(
                     LowerErrorKind::UnsupportedFeature,
-                    "DROP VECTOR INDEX is a schema command and must be the \
-                     sole statement; it cannot be lowered to a query plan",
+                    if cfg!(feature = "vector-index") {
+                        "DROP VECTOR INDEX is a schema command and must be the \
+                         sole statement; it cannot be lowered to a query plan"
+                    } else {
+                        "this server was built without the vector-index feature; \
+                         the official Docker image and release binaries include \
+                         it — rebuild with --features vector-index"
+                    },
                     clause.span(),
                 ));
             }
             Clause::DropFulltextIndex(_) => {
                 return Err(LowerError::new(
                     LowerErrorKind::UnsupportedFeature,
-                    "DROP INDEX is a schema command and must be the sole \
-                     statement; it cannot be lowered to a query plan",
+                    if cfg!(feature = "text-index") {
+                        "DROP INDEX is a schema command and must be the sole \
+                         statement; it cannot be lowered to a query plan"
+                    } else {
+                        "this server was built without the text-index feature; \
+                         the official Docker image and release binaries include \
+                         it — rebuild with --features text-index"
+                    },
                     clause.span(),
                 ));
             }

--- a/crates/namidb-server/src/bolt.rs
+++ b/crates/namidb-server/src/bolt.rs
@@ -2174,7 +2174,39 @@ async fn serve_tenancy(
             }
         });
     }
+    // Sessions accepted before the stop run on detached tasks; without a
+    // barrier here the process could exit mid-transaction the moment HTTP
+    // finished draining (fourth field report, item 61).
+    drain_sessions(&conn_limit, max_conns).await;
     Ok(())
+}
+
+/// Upper bound on waiting for in-flight Bolt sessions after the listener
+/// stops accepting. Long enough for a normal statement to finish under the
+/// default timeouts; short enough that one wedged session cannot pin process
+/// shutdown past a supervisor's grace period.
+const SESSION_DRAIN_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(25);
+
+/// Wait until every session task has released its connection permit, bounded
+/// by [`SESSION_DRAIN_TIMEOUT`]. Reacquiring the full permit count is the
+/// proof that all detached session tasks have exited, since each holds its
+/// permit for the whole connection lifetime.
+async fn drain_sessions(conn_limit: &Arc<tokio::sync::Semaphore>, max_conns: usize) {
+    let all_permits = u32::try_from(max_conns).unwrap_or(u32::MAX);
+    match tokio::time::timeout(SESSION_DRAIN_TIMEOUT, conn_limit.acquire_many(all_permits)).await {
+        Ok(Ok(_reacquired)) => info!("bolt sessions drained"),
+        // The connection semaphore is never closed; do not block shutdown on
+        // a would-be logic error here.
+        Ok(Err(_)) => {}
+        Err(_) => {
+            let abandoned = max_conns.saturating_sub(conn_limit.available_permits());
+            warn!(
+                abandoned_sessions = abandoned,
+                timeout_secs = SESSION_DRAIN_TIMEOUT.as_secs(),
+                "bolt session drain timed out; abandoning in-flight sessions"
+            );
+        }
+    }
 }
 
 /// Build and run one Bolt session over any byte stream — a plain `TcpStream`
@@ -2291,6 +2323,52 @@ mod tests {
             Some(std::time::Duration::from_millis(750))
         );
         assert!(bolt_partial_message_timeout(Some("later")).is_err());
+    }
+
+    /// The shutdown barrier that `serve_tenancy` runs after its accept loop
+    /// breaks: it must not return while a session task still holds its
+    /// connection permit. Paused time keeps the release deterministic.
+    #[tokio::test(start_paused = true)]
+    async fn shutdown_drain_waits_until_sessions_release_their_permits() {
+        let max_conns = 4;
+        let conn_limit = Arc::new(tokio::sync::Semaphore::new(max_conns));
+        let held = conn_limit.clone().try_acquire_owned().unwrap();
+        let released = Arc::new(AtomicBool::new(false));
+        {
+            let released = Arc::clone(&released);
+            tokio::spawn(async move {
+                // Well inside the drain bound: the barrier must wait for this
+                // release rather than race past the held permit.
+                tokio::time::sleep(std::time::Duration::from_secs(1)).await;
+                released.store(true, Ordering::SeqCst);
+                drop(held);
+            });
+        }
+        drain_sessions(&conn_limit, max_conns).await;
+        assert!(
+            released.load(Ordering::SeqCst),
+            "drain returned while a session still held its permit"
+        );
+        assert_eq!(
+            conn_limit.available_permits(),
+            max_conns,
+            "the barrier must give the reacquired permits back"
+        );
+    }
+
+    #[tokio::test(start_paused = true)]
+    async fn shutdown_drain_is_bounded_when_a_session_never_exits() {
+        let max_conns = 2;
+        let conn_limit = Arc::new(tokio::sync::Semaphore::new(max_conns));
+        let _held = conn_limit.clone().try_acquire_owned().unwrap();
+        // Paused time: the 25s bound elapses deterministically instead of
+        // stalling the test for real.
+        drain_sessions(&conn_limit, max_conns).await;
+        assert_eq!(
+            conn_limit.available_permits(),
+            max_conns - 1,
+            "a timed-out drain must return the permits it did reacquire"
+        );
     }
 
     /// Blocks exactly one cold SST read so a cancellation test can stop a

--- a/crates/namidb-server/src/bolt.rs
+++ b/crates/namidb-server/src/bolt.rs
@@ -975,7 +975,23 @@ impl ServerBackend {
             // Read path: borrow a short-lived `Snapshot` from the owned
             // snapshot; the Arc keeps the underlying memtable alive for
             // the duration of the query, no writer lock needed.
-            let _scan_permit = crate::acquire_scan_permit(&plan).await;
+            let admission = tokio::select! {
+                admission = crate::acquire_read_admission(&plan) => admission,
+                _ = cancellation.cancelled() => {
+                    return disconnected_observation(started, Some(QueryKind::Read));
+                }
+            };
+            let Some(_admission) = admission else {
+                return RunObservation {
+                    kind: Some(QueryKind::Read),
+                    elapsed: started.elapsed(),
+                    result: Err(BackendError::Storage(
+                        "too many concurrent queries; the read admission queue is full — \
+                         retry (raise NAMIDB_MAX_CONCURRENT_QUERIES to widen the gate)"
+                            .into(),
+                    )),
+                };
+            };
             let snap = owned.borrow();
             let read = execute_with_limits(
                 &plan,
@@ -1207,7 +1223,23 @@ impl ServerBackend {
                     };
                 }
             };
-            let _scan_permit = crate::acquire_scan_permit(&plan).await;
+            let admission = tokio::select! {
+                admission = crate::acquire_read_admission(&plan) => admission,
+                _ = cancellation.cancelled() => {
+                    return disconnected_observation(started, Some(QueryKind::Read));
+                }
+            };
+            let Some(_admission) = admission else {
+                return RunObservation {
+                    kind: Some(QueryKind::Read),
+                    elapsed: started.elapsed(),
+                    result: Err(BackendError::Storage(
+                        "too many concurrent queries; the read admission queue is full — \
+                         retry (raise NAMIDB_MAX_CONCURRENT_QUERIES to widen the gate)"
+                            .into(),
+                    )),
+                };
+            };
             let snap = tx.writer.overlay_snapshot();
             let read = execute_with_limits(
                 &plan,

--- a/crates/namidb-server/src/lib.rs
+++ b/crates/namidb-server/src/lib.rs
@@ -994,6 +994,16 @@ pub async fn run_with_memory_max_bytes(
                  lower NAMIDB_CACHE_MAX_BYTES"
             );
         }
+    } else if let Some(limit) = memory::finite_cgroup_memory_limit_bytes() {
+        // The container has a hard memory ceiling but the admission rail is
+        // off, so the kernel OOM killer — not a 503 — is what happens at that
+        // limit. Say so at boot, while an operator is still watching.
+        warn!(
+            cgroup_memory_limit_bytes = limit,
+            "memory governor disabled under a finite cgroup memory limit; set \
+             NAMIDB_MEMORY_MAX_BYTES=auto to reject queries at 90% of the \
+             limit instead of risking an OOM kill"
+        );
     }
 
     // One shutdown signal is shared by HTTP, optional Bolt, and the resident
@@ -1001,10 +1011,23 @@ pub async fn run_with_memory_max_bytes(
     // watchdog before namespace recovery lets it reclaim reconstructible
     // state even when opening a large writer moves RSS without any request.
     let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
-    tokio::spawn(async move {
-        wait_for_shutdown_signal().await;
-        let _ = shutdown_tx.send(true);
-    });
+    {
+        // Attribute the shutdown in one greppable WARN with the memory gauges
+        // alongside: a SIGTERM from an operator otherwise looks identical to
+        // a supervisor killing a pressured pod (fourth field report, item 61).
+        let memory = Arc::clone(&memory);
+        tokio::spawn(async move {
+            let cause = wait_for_shutdown_signal().await;
+            warn!(
+                signal = cause.as_str(),
+                resident_bytes = memory.sample().unwrap_or_else(|| memory.resident_bytes()),
+                memory_max_bytes = memory.max_bytes(),
+                rejected_queries = memory.rejected_queries(),
+                "shutdown signal received, draining…"
+            );
+            let _ = shutdown_tx.send(true);
+        });
+    }
     if memory_max_bytes > 0 {
         // Dropping a Tokio JoinHandle deliberately detaches the task; the
         // shared shutdown receiver still terminates it cleanly.
@@ -1085,7 +1108,7 @@ pub async fn run_with_memory_max_bytes(
         // named by the Bolt `db` field (driver `session(database=...)`).
         // Before this, the flag combination silently never opened the Bolt
         // port and 2.2.x refused it at boot.
-        if let Some(bolt_addr) = config.bolt_listen {
+        let bolt_task = config.bolt_listen.map(|bolt_addr| {
             let bolt_shared = shared.clone();
             let bolt_auth = shared.auth.clone();
             let tx_timeout = config.bolt_tx_timeout;
@@ -1106,11 +1129,14 @@ pub async fn run_with_memory_max_bytes(
                 {
                     error!(error = %e, "multi-tenant bolt listener exited");
                 }
-            });
-        }
+            })
+        });
 
         info!(multi_tenant = true, "starting multi-tenant server");
-        return serve_http(app, config, tls_config, shutdown_rx).await;
+        let bolt_drain_rx = shutdown_rx.clone();
+        let served = serve_http(app, config, tls_config, shutdown_rx).await;
+        await_bolt_drain(bolt_task, &bolt_drain_rx).await;
+        return served;
     }
 
     let (store, paths) = namidb_storage::parse_uri(&config.store_uri)
@@ -1367,7 +1393,7 @@ pub async fn run_with_memory_max_bytes(
         _ => anyhow::bail!("set both --tls-cert and --tls-key to enable TLS, or neither"),
     };
 
-    if let Some(bolt_addr) = config.bolt_listen {
+    let bolt_task = config.bolt_listen.map(|bolt_addr| {
         let bolt_state = state.clone();
         let bolt_auth = state.auth();
         let tx_timeout = config.bolt_tx_timeout;
@@ -1388,14 +1414,23 @@ pub async fn run_with_memory_max_bytes(
             {
                 error!(error = %e, "bolt listener exited");
             }
-        });
-    }
+        })
+    });
 
     let app = build_router(state);
-    serve_http(app, config, tls_config, shutdown_rx).await
+    let bolt_drain_rx = shutdown_rx.clone();
+    let served = serve_http(app, config, tls_config, shutdown_rx).await;
+    await_bolt_drain(bolt_task, &bolt_drain_rx).await;
+    served
 }
 
 /// Serve an HTTP router with TLS and graceful shutdown.
+///
+/// Only a drain that a real signal started keeps exit code 0. `wait_for` on
+/// the shutdown watch also resolves when the sender is dropped without ever
+/// signalling — the signal task died — and that used to be indistinguishable
+/// from a clean SIGTERM: the server stopped, `main` returned `Ok(())`, and
+/// the process exited 0 with nothing in the log to explain the death.
 async fn serve_http(
     app: Router,
     config: Config,
@@ -1403,13 +1438,17 @@ async fn serve_http(
     shutdown_rx: tokio::sync::watch::Receiver<bool>,
 ) -> anyhow::Result<()> {
     let mut http_shutdown = shutdown_rx;
+    let signalled = Arc::new(std::sync::atomic::AtomicBool::new(false));
 
     match tls_config {
         Some(server_config) => {
             let handle = axum_server::Handle::new();
             let drain = handle.clone();
+            let drain_signalled = Arc::clone(&signalled);
             tokio::spawn(async move {
-                let _ = http_shutdown.wait_for(|stop| *stop).await;
+                if http_shutdown.wait_for(|stop| *stop).await.is_ok() {
+                    drain_signalled.store(true, std::sync::atomic::Ordering::Release);
+                }
                 info!("shutdown signalled, draining HTTPS requests…");
                 drain.graceful_shutdown(Some(Duration::from_secs(10)));
             });
@@ -1423,24 +1462,78 @@ async fn serve_http(
         None => {
             let listener = TcpListener::bind(config.listen).await?;
             info!(addr = %config.listen, "namidb-server listening");
+            let drain_signalled = Arc::clone(&signalled);
             axum::serve(listener, app)
                 .with_graceful_shutdown(async move {
-                    let _ = http_shutdown.wait_for(|stop| *stop).await;
+                    if http_shutdown.wait_for(|stop| *stop).await.is_ok() {
+                        drain_signalled.store(true, std::sync::atomic::Ordering::Release);
+                    }
                     info!("shutdown signalled, draining HTTP requests…");
                 })
                 .await?;
         }
     }
+    if !signalled.load(std::sync::atomic::Ordering::Acquire) {
+        error!("shutdown channel closed without a signal — treating as failure");
+        anyhow::bail!("HTTP server stopped without a shutdown signal");
+    }
     Ok(())
+}
+
+/// After HTTP stops, hold the boot path open until the Bolt listener has run
+/// its bounded session drain (see `bolt::serve_tenancy`): sessions run on
+/// detached tasks, and returning from [`run`] while they are mid-transaction
+/// abandons them at process exit. The extra 5s over Bolt's 25s barrier covers
+/// listener teardown itself. A serve error with nothing signalled means the
+/// listener was never told to stop — waiting on it would only delay the
+/// failure exit.
+async fn await_bolt_drain(
+    task: Option<tokio::task::JoinHandle<()>>,
+    shutdown: &tokio::sync::watch::Receiver<bool>,
+) {
+    let Some(task) = task else { return };
+    if !*shutdown.borrow() && shutdown.has_changed().is_ok() {
+        return;
+    }
+    match tokio::time::timeout(Duration::from_secs(30), task).await {
+        Ok(Ok(())) => {}
+        Ok(Err(error)) => error!(%error, "bolt listener task failed during shutdown"),
+        Err(_) => warn!("bolt listener did not stop within 30s of HTTP shutdown; exiting anyway"),
+    }
+}
+
+/// Why the process is shutting down. Exit code 0 is only reachable through a
+/// graceful drain, and a drain is only legitimate after one of these signals;
+/// naming the cause keeps a "who stopped the server" investigation greppable.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ShutdownCause {
+    Sigint,
+    Sigterm,
+}
+
+impl ShutdownCause {
+    fn as_str(self) -> &'static str {
+        match self {
+            ShutdownCause::Sigint => "SIGINT",
+            ShutdownCause::Sigterm => "SIGTERM",
+        }
+    }
 }
 
 /// Resolve when the process is asked to stop: Ctrl-C (SIGINT) on every
 /// platform, plus SIGTERM on Unix — what `docker stop`, systemd and
 /// Kubernetes send. Without the SIGTERM arm the server ignored the orderly
 /// stop signal and was hard-killed once the grace period elapsed.
-async fn wait_for_shutdown_signal() {
+///
+/// A failed handler registration must never read as a received signal: that
+/// would turn an environment quirk at boot into a silent exit-0 shutdown.
+/// Each arm logs its failure once and pends, leaving the other source armed.
+async fn wait_for_shutdown_signal() -> ShutdownCause {
     let ctrl_c = async {
-        let _ = tokio::signal::ctrl_c().await;
+        if let Err(error) = tokio::signal::ctrl_c().await {
+            error!(%error, "SIGINT handler unavailable; Ctrl-C will not be observed");
+            std::future::pending::<()>().await;
+        }
     };
     #[cfg(unix)]
     let terminate = async {
@@ -1448,14 +1541,17 @@ async fn wait_for_shutdown_signal() {
             Ok(mut sig) => {
                 sig.recv().await;
             }
-            Err(_) => std::future::pending::<()>().await,
+            Err(error) => {
+                error!(%error, "SIGTERM handler unavailable; SIGTERM will not be observed");
+                std::future::pending::<()>().await;
+            }
         }
     };
     #[cfg(not(unix))]
     let terminate = std::future::pending::<()>();
     tokio::select! {
-        _ = ctrl_c => info!("SIGINT received, draining…"),
-        _ = terminate => info!("SIGTERM received, draining…"),
+        _ = ctrl_c => ShutdownCause::Sigint,
+        _ = terminate => ShutdownCause::Sigterm,
     }
 }
 
@@ -5051,6 +5147,87 @@ mod tests {
         let status = response.status();
         let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
         (status, String::from_utf8_lossy(&body).into_owned())
+    }
+
+    #[test]
+    fn shutdown_cause_maps_each_signal_to_its_greppable_name() {
+        assert_eq!(ShutdownCause::Sigint.as_str(), "SIGINT");
+        assert_eq!(ShutdownCause::Sigterm.as_str(), "SIGTERM");
+    }
+
+    fn shutdown_test_config(ns: &str) -> Config {
+        Config {
+            store_uri: format!("memory://{ns}"),
+            listen: "127.0.0.1:0".parse().unwrap(),
+            auth_token: None,
+            auth_tokens_file: None,
+            auth_tokens_reload_interval: Duration::ZERO,
+            no_auth: true,
+            backup_target_uri: None,
+            group_commit_window: Duration::ZERO,
+            #[cfg(feature = "jwt")]
+            jwt: None,
+            #[cfg(feature = "pdp")]
+            pdp_url: None,
+            flush_interval: Duration::ZERO,
+            compaction_interval: Duration::ZERO,
+            sweep_min_age: Duration::ZERO,
+            sweep_delete: false,
+            bolt_listen: None,
+            bolt_max_message_bytes: 64 << 20,
+            bolt_tx_timeout: Duration::ZERO,
+            query_timeout: Duration::from_secs(30),
+            write_timeout: Duration::from_secs(30),
+            query_row_cap: 0,
+            compaction_l0_trigger: 0,
+            write_stall_l0: 0,
+            write_stall_delay: Duration::ZERO,
+            memtable_flush_bytes: 0,
+            memtable_stall_bytes: 0,
+            writer_lock_timeout: Duration::from_secs(5),
+            tls_cert: None,
+            tls_key: None,
+            slow_query_threshold: Duration::ZERO,
+            multi_tenant: false,
+            default_namespace: ns.to_string(),
+            max_namespaces: 100,
+            namespace_idle_timeout: Duration::from_secs(3600),
+        }
+    }
+
+    /// The shutdown watch closing without ever signalling means the signal
+    /// task died. The server still stops — but exit code 0 would misreport
+    /// that as a clean drain, so `serve_http` must surface it as an error.
+    #[tokio::test]
+    async fn serve_http_fails_when_the_shutdown_channel_closes_without_a_signal() {
+        let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+        drop(shutdown_tx);
+        let err = serve_http(
+            Router::new(),
+            shutdown_test_config("serve-http-closed-channel"),
+            None,
+            shutdown_rx,
+        )
+        .await
+        .expect_err("a channel closure is not a graceful shutdown");
+        assert!(
+            err.to_string().contains("without a shutdown signal"),
+            "unexpected error: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn serve_http_keeps_the_clean_exit_path_for_a_signalled_drain() {
+        let (shutdown_tx, shutdown_rx) = tokio::sync::watch::channel(false);
+        shutdown_tx.send(true).unwrap();
+        serve_http(
+            Router::new(),
+            shutdown_test_config("serve-http-signalled"),
+            None,
+            shutdown_rx,
+        )
+        .await
+        .expect("a signal-driven drain must keep exit code 0");
     }
 
     /// Item 56 end-to-end: a runaway write is listed with its statement and

--- a/crates/namidb-server/src/lib.rs
+++ b/crates/namidb-server/src/lib.rs
@@ -1868,6 +1868,90 @@ pub(crate) fn plan_contains_node_scan(plan: &namidb_query::LogicalPlan) -> bool 
         || plan.children().into_iter().any(plan_contains_node_scan)
 }
 
+/// Process-wide bound on CONCURRENT READ EXECUTION (fourth field report,
+/// item 64): nine parallel large aggregations exhausted a container that
+/// handled them fine serialized, and nothing bounded them — the memory
+/// governor defaults off, the scan gate meters only plans containing a
+/// `NodeScan` (lookup+expand aggregations pass free), and the row cap
+/// bounds rows, not concurrency. Every read acquires a permit here (the
+/// scan gate stays nested inside for its own O(label) reasons); waiting
+/// longer than the bounded window returns the retryable 503 so clients
+/// get server-side admission instead of each implementing a queue.
+///
+/// `NAMIDB_MAX_CONCURRENT_QUERIES` overrides the default of
+/// `max(4, available cores)`; `0` disables the gate.
+fn read_admission_gate() -> Option<&'static tokio::sync::Semaphore> {
+    static GATE: std::sync::OnceLock<Option<tokio::sync::Semaphore>> = std::sync::OnceLock::new();
+    GATE.get_or_init(|| {
+        let default = std::thread::available_parallelism()
+            .map(|n| n.get().max(4))
+            .unwrap_or(4);
+        let permits = std::env::var("NAMIDB_MAX_CONCURRENT_QUERIES")
+            .ok()
+            .and_then(|raw| raw.parse::<usize>().ok())
+            .unwrap_or(default);
+        (permits > 0).then(|| tokio::sync::Semaphore::new(permits))
+    })
+    .as_ref()
+}
+
+/// How long a read may queue for admission before the retryable 503
+/// (`NAMIDB_QUERY_ADMISSION_WAIT_MS`, default 5000). Bounded chiefly for
+/// Bolt, which has no outer request-timeout layer.
+fn read_admission_wait() -> Duration {
+    Duration::from_millis(
+        std::env::var("NAMIDB_QUERY_ADMISSION_WAIT_MS")
+            .ok()
+            .and_then(|raw| raw.parse::<u64>().ok())
+            .unwrap_or(5_000),
+    )
+}
+
+/// Guards a read holds for its whole execution: the admission permit and,
+/// when the plan scans, the nested scan permit.
+#[doc(hidden)]
+pub struct ReadAdmission {
+    _admission: Option<tokio::sync::SemaphorePermit<'static>>,
+    _scan: Option<tokio::sync::SemaphorePermit<'static>>,
+}
+
+/// Admit one read: bounded wait on the concurrency gate, then the scan
+/// gate when the plan needs it. `None` = the admission window elapsed —
+/// the caller returns the retryable too-many-queries rejection.
+#[doc(hidden)]
+pub async fn acquire_read_admission(plan: &namidb_query::LogicalPlan) -> Option<ReadAdmission> {
+    let admission = match read_admission_gate() {
+        None => None,
+        Some(gate) => match tokio::time::timeout(read_admission_wait(), gate.acquire()).await {
+            Ok(permit) => Some(permit.expect("read admission gate is never closed")),
+            Err(_) => return None,
+        },
+    };
+    let scan = acquire_scan_permit(plan).await;
+    Some(ReadAdmission {
+        _admission: admission,
+        _scan: scan,
+    })
+}
+
+/// Retryable 503 for a read that could not be admitted within the window.
+pub(crate) fn admission_exhausted_observation(started: std::time::Instant) -> ObservedQuery {
+    ObservedQuery {
+        kind: Some(QueryKind::Read),
+        ok: false,
+        elapsed: started.elapsed(),
+        response: (
+            StatusCode::SERVICE_UNAVAILABLE,
+            Json(ErrorBody {
+                error: "too many concurrent queries; the read admission queue is full — retry \
+                        (raise NAMIDB_MAX_CONCURRENT_QUERIES to widen the gate)"
+                    .into(),
+            }),
+        )
+            .into_response(),
+    }
+}
+
 /// Acquire a scan permit when the plan needs one. Holding the returned
 /// guard for the duration of execution is the whole contract.
 pub(crate) async fn acquire_scan_permit(
@@ -3669,7 +3753,9 @@ async fn run_cypher(state: &AppState, req: &CypherRequest, principal: &Principal
         // Read path: no writer lock. Borrow a short-lived `Snapshot`
         // from the owned one; the `OwnedSnapshot` Arc keeps the
         // underlying memtable alive for the duration of the query.
-        let _scan_permit = acquire_scan_permit(&plan).await;
+        let Some(_admission) = acquire_read_admission(&plan).await else {
+            return admission_exhausted_observation(started);
+        };
         let snap = owned.borrow();
         let result = execute_with_limits(
             &plan,
@@ -4769,7 +4855,9 @@ async fn run_cypher_multi(
         }
     } else {
         // Read path.
-        let _scan_permit = acquire_scan_permit(&plan).await;
+        let Some(_admission) = acquire_read_admission(&plan).await else {
+            return admission_exhausted_observation(started);
+        };
         let snap = owned.borrow();
         let result = execute_with_limits(
             &plan,

--- a/crates/namidb-server/src/lib.rs
+++ b/crates/namidb-server/src/lib.rs
@@ -186,7 +186,7 @@ pub struct Config {
     /// transaction. A runaway MERGE/DELETE is aborted cooperatively rather
     /// than pinning the single writer, and its pending batch is discarded so
     /// nothing partial is committed. `Duration::ZERO` disables it; the CLI
-    /// defaults it to `query_timeout`.
+    /// defaults it to 60s, independent of `query_timeout`.
     pub write_timeout: Duration,
     /// Maximum rows a single read-query operator may materialise. A query
     /// whose operator output would exceed this aborts with a row-cap error

--- a/crates/namidb-server/src/main.rs
+++ b/crates/namidb-server/src/main.rs
@@ -563,7 +563,10 @@ mod tests {
         // An explicit flag overrides, and `0s` still means unbounded.
         let cli = parse(&["--write-timeout", "5m"]);
         assert_eq!(cli.write_timeout, Duration::from_secs(300));
-        assert_eq!(parse(&["--write-timeout", "0s"]).write_timeout, Duration::ZERO);
+        assert_eq!(
+            parse(&["--write-timeout", "0s"]).write_timeout,
+            Duration::ZERO
+        );
         // The env-var form overrides the default too.
         std::env::set_var("NAMIDB_WRITE_TIMEOUT", "2m");
         assert_eq!(parse(&[]).write_timeout, Duration::from_secs(120));

--- a/crates/namidb-server/src/main.rs
+++ b/crates/namidb-server/src/main.rs
@@ -234,14 +234,17 @@ struct Cli {
     /// Wall-clock budget for a single write query: an HTTP / Bolt auto-commit
     /// statement, or each statement of a Bolt explicit transaction. A runaway
     /// MERGE/DELETE is aborted instead of pinning the single writer, and its
-    /// pending batch is discarded so nothing partial commits. Defaults to
-    /// `--query-timeout`; set to `0s` to allow writes to run unbounded.
+    /// pending batch is discarded so nothing partial commits. Writes get a
+    /// larger default than `--query-timeout` because a legitimate bulk-load
+    /// statement outlives any sane read; set to `0s` to allow writes to run
+    /// unbounded (recommended for one-off bulk loads, or chunk the writes).
     #[arg(
         long,
         env = "NAMIDB_WRITE_TIMEOUT",
+        default_value = "60s",
         value_parser = humantime::parse_duration,
     )]
-    write_timeout: Option<Duration>,
+    write_timeout: Duration,
 
     /// Maximum rows a single read-query operator may materialise. A query
     /// whose operator output would exceed this aborts with a row-cap error
@@ -422,8 +425,7 @@ fn main() -> anyhow::Result<()> {
         bolt_max_message_bytes: cli.bolt_max_message_bytes,
         bolt_tx_timeout: cli.bolt_tx_timeout,
         query_timeout: cli.query_timeout,
-        // Writes inherit the read budget unless given their own; `0s` opts out.
-        write_timeout: cli.write_timeout.unwrap_or(cli.query_timeout),
+        write_timeout: cli.write_timeout,
         query_row_cap: cli.query_row_cap,
         compaction_l0_trigger: cli.compaction_l0_trigger,
         write_stall_l0: cli.write_stall_l0,
@@ -536,5 +538,35 @@ mod tests {
         std::env::set_var("NAMIDB_SWEEP_DELETE", "0");
         assert!(!Cli::try_parse_from(base).unwrap().sweep_delete);
         std::env::remove_var("NAMIDB_SWEEP_DELETE");
+    }
+
+    /// `--write-timeout` carries its own 60s default (fourth field report,
+    /// item 67b): it no longer inherits `--query-timeout`, so a bulk-load
+    /// write is not silently held to the 30s read budget. Serialized: clap
+    /// reads NAMIDB_WRITE_TIMEOUT on every try_parse_from.
+    #[test]
+    fn write_timeout_default_is_independent_of_query_timeout() {
+        let _guard = ENV_LOCK.lock().unwrap();
+        let base = ["namidb-server", "--store", "memory://t"];
+        let parse = |extra: &[&str]| {
+            let mut argv: Vec<&str> = base.to_vec();
+            argv.extend_from_slice(extra);
+            Cli::try_parse_from(argv).unwrap()
+        };
+
+        let cli = parse(&[]);
+        assert_eq!(cli.query_timeout, Duration::from_secs(30));
+        assert_eq!(cli.write_timeout, Duration::from_secs(60));
+        // Raising the read budget no longer drags the write budget along.
+        let cli = parse(&["--query-timeout", "90s"]);
+        assert_eq!(cli.write_timeout, Duration::from_secs(60));
+        // An explicit flag overrides, and `0s` still means unbounded.
+        let cli = parse(&["--write-timeout", "5m"]);
+        assert_eq!(cli.write_timeout, Duration::from_secs(300));
+        assert_eq!(parse(&["--write-timeout", "0s"]).write_timeout, Duration::ZERO);
+        // The env-var form overrides the default too.
+        std::env::set_var("NAMIDB_WRITE_TIMEOUT", "2m");
+        assert_eq!(parse(&[]).write_timeout, Duration::from_secs(120));
+        std::env::remove_var("NAMIDB_WRITE_TIMEOUT");
     }
 }

--- a/crates/namidb-server/src/memory.rs
+++ b/crates/namidb-server/src/memory.rs
@@ -181,6 +181,13 @@ pub struct MemoryGovernor {
     reclaim_state: Mutex<ReclaimState>,
     reclaim_events: AtomicU64,
     rejected_queries: AtomicU64,
+    /// Monotonic base for [`Self::last_rejection_warn_secs`].
+    created_at: Instant,
+    /// Whole seconds since `created_at`, offset by one so zero means "never",
+    /// of the last rejection WARN. Rate-limits pressure logging to one line
+    /// per second: enough to make sustained pressure greppable without
+    /// letting a retry storm own the log.
+    last_rejection_warn_secs: AtomicU64,
     /// Working-set headroom promised to authenticated Bolt requests that have
     /// passed RSS admission but have not finished decode/execution yet.
     reserved_headroom_bytes: AtomicUsize,
@@ -223,6 +230,8 @@ impl MemoryGovernor {
             reclaim_state: Mutex::new(ReclaimState::default()),
             reclaim_events: AtomicU64::new(0),
             rejected_queries: AtomicU64::new(0),
+            created_at: Instant::now(),
+            last_rejection_warn_secs: AtomicU64::new(0),
             reserved_headroom_bytes: AtomicUsize::new(0),
             admin_flush_gate: Arc::new(tokio::sync::Semaphore::new(1)),
         }
@@ -252,10 +261,39 @@ impl MemoryGovernor {
         let resident = self.reclaim_off_worker(initial).await;
 
         if let Some(pressure) = Self::projected_pressure(resident, 0, self.max_bytes) {
-            self.rejected_queries.fetch_add(1, Ordering::Relaxed);
+            self.note_rejection(&pressure);
             return Err(pressure);
         }
         Ok(())
+    }
+
+    /// Count one refused admission and say so at WARN, at most once per
+    /// second. The governor's 503s carry no server-side log line of their
+    /// own, so a shutdown taken under sustained pressure used to be invisible
+    /// in default logs.
+    fn note_rejection(&self, pressure: &MemoryPressure) {
+        self.rejected_queries.fetch_add(1, Ordering::Relaxed);
+        if self.should_log_rejection() {
+            tracing::warn!(
+                resident_bytes = pressure.resident_bytes,
+                requested_headroom_bytes = pressure.requested_headroom_bytes,
+                max_bytes = pressure.max_bytes,
+                rejected_queries = self.rejected_queries.load(Ordering::Relaxed),
+                "memory pressure: rejecting new query admissions"
+            );
+        }
+    }
+
+    fn should_log_rejection(&self) -> bool {
+        // Offset by one so the very first rejection (elapsed < 1s) still
+        // logs; the compare-exchange elects one logger per one-second window.
+        let now_secs = self.created_at.elapsed().as_secs().saturating_add(1);
+        let last = self.last_rejection_warn_secs.load(Ordering::Relaxed);
+        now_secs > last
+            && self
+                .last_rejection_warn_secs
+                .compare_exchange(last, now_secs, Ordering::Relaxed, Ordering::Relaxed)
+                .is_ok()
     }
 
     /// Atomically reserve projected decode/runtime headroom after normal RSS
@@ -295,16 +333,17 @@ impl MemoryGovernor {
             if let Some(pressure) =
                 Self::projected_pressure(resident_bytes, projected_headroom, self.max_bytes)
             {
-                self.rejected_queries.fetch_add(1, Ordering::Relaxed);
+                self.note_rejection(&pressure);
                 return Err(pressure);
             }
             let next = reserved.checked_add(additional_bytes).ok_or_else(|| {
-                self.rejected_queries.fetch_add(1, Ordering::Relaxed);
-                MemoryPressure {
+                let pressure = MemoryPressure {
                     resident_bytes,
                     requested_headroom_bytes: usize::MAX,
                     max_bytes: self.max_bytes,
-                }
+                };
+                self.note_rejection(&pressure);
+                pressure
             })?;
             match self.reserved_headroom_bytes.compare_exchange_weak(
                 reserved,
@@ -878,6 +917,25 @@ mod tests {
         let governor = MemoryGovernor::new(1);
         let _ = governor.reclaim_if_needed();
         assert_eq!(governor.rejected_queries(), 0);
+    }
+
+    #[test]
+    fn rejection_warn_rate_limiter_logs_first_then_holds_within_a_window() {
+        let governor = MemoryGovernor::new(1);
+        assert!(
+            governor.should_log_rejection(),
+            "the first rejection must always log"
+        );
+        // A later window is only elected when now advances past the recorded
+        // second; force "recorded in the far future" to model the same-window
+        // case without depending on wall-clock granularity.
+        governor
+            .last_rejection_warn_secs
+            .store(u64::MAX, Ordering::Relaxed);
+        assert!(
+            !governor.should_log_rejection(),
+            "a rejection inside an already-logged window must stay quiet"
+        );
     }
 
     #[tokio::test]

--- a/crates/namidb-server/tests/read_admission.rs
+++ b/crates/namidb-server/tests/read_admission.rs
@@ -1,0 +1,75 @@
+//! Fourth field report, item 64: a server-side read admission queue.
+//! Single-test binary (the gate is a process-wide OnceLock configured from
+//! env, so this test must own the process — the project convention for
+//! env-mutating tests).
+
+use std::time::Duration;
+
+use axum::body::{to_bytes, Body};
+use axum::http::{Request, StatusCode};
+use tower::ServiceExt;
+
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn read_admission_bounds_concurrency_and_rejects_retryably() {
+    // MUST run before anything touches the gate: one permit, 100ms window.
+    std::env::set_var("NAMIDB_MAX_CONCURRENT_QUERIES", "1");
+    std::env::set_var("NAMIDB_QUERY_ADMISSION_WAIT_MS", "100");
+
+    let (store, paths) = namidb_storage::parse_uri("memory://admission").unwrap();
+    let writer = namidb_storage::WriterSession::open(store, paths)
+        .await
+        .unwrap();
+    let state = namidb_server::AppState::new(writer, None, "admission".into());
+    let app = namidb_server::build_router(state);
+
+    let post = |app: axum::Router, query: &'static str| async move {
+        let body = serde_json::to_vec(&serde_json::json!({ "query": query })).unwrap();
+        let response = app
+            .oneshot(
+                Request::builder()
+                    .method("POST")
+                    .uri("/v0/cypher")
+                    .header("content-type", "application/json")
+                    .header("content-length", body.len().to_string())
+                    .body(Body::from(body))
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        let status = response.status();
+        let bytes = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        (status, String::from_utf8_lossy(&bytes).into_owned())
+    };
+
+    // Deterministic occupancy: hold the single permit directly.
+    let plan = {
+        let q = namidb_query::parse("MATCH (n:X) RETURN count(n) AS n").unwrap();
+        namidb_query::plan(&q, &namidb_query::StatsCatalog::empty()).unwrap()
+    };
+    let held = namidb_server::acquire_read_admission(&plan)
+        .await
+        .expect("first admission must succeed");
+
+    // A read while the gate is full: retryable 503 naming the knob.
+    let (status, body) = post(app.clone(), "RETURN 1 AS one").await;
+    assert_eq!(status, StatusCode::SERVICE_UNAVAILABLE, "{body}");
+    assert!(
+        body.contains("too many concurrent queries")
+            && body.contains("NAMIDB_MAX_CONCURRENT_QUERIES"),
+        "rejection must be actionable: {body}"
+    );
+
+    // Writes are NOT gated here (they serialize on the writer lock).
+    let (status, body) = post(app.clone(), "CREATE (:W {ok: true})").await;
+    assert_eq!(
+        status,
+        StatusCode::OK,
+        "writes must pass the read gate: {body}"
+    );
+
+    // Releasing the permit re-admits reads within the wait window.
+    drop(held);
+    tokio::time::sleep(Duration::from_millis(10)).await;
+    let (status, body) = post(app.clone(), "RETURN 1 AS one").await;
+    assert_eq!(status, StatusCode::OK, "{body}");
+}

--- a/crates/namidb-storage/src/lib.rs
+++ b/crates/namidb-storage/src/lib.rs
@@ -90,9 +90,9 @@ pub use parquet_loader::{
 pub use paths::NamespacePaths;
 pub use pin::{PinLease, RetentionPin, DEFAULT_PIN_TTL};
 pub use range_cache::{
-    shared_range_cache, ImmutableRangeCache, ImmutableRangeKey, PinnedObjectGeneration,
-    PinnedObjectRangeSource, RangeCacheConfig, RangeCacheError, RangeCacheStats,
-    DEFAULT_NVME_CACHE_BLOCK_BYTES, DEFAULT_NVME_CACHE_WRITE_BUFFER_BYTES,
+    mark_store_paths_immutable, shared_range_cache, ImmutableRangeCache, ImmutableRangeKey,
+    PinnedObjectGeneration, PinnedObjectRangeSource, RangeCacheConfig, RangeCacheError,
+    RangeCacheStats, DEFAULT_NVME_CACHE_BLOCK_BYTES, DEFAULT_NVME_CACHE_WRITE_BUFFER_BYTES,
     DEFAULT_RAM_PAGE_CACHE_MAX_BYTES, DEFAULT_RANGE_CACHE_MAX_ENTRY_BYTES,
     DEFAULT_RANGE_CACHE_PAGE_BYTES,
 };

--- a/crates/namidb-storage/src/range_cache.rs
+++ b/crates/namidb-storage/src/range_cache.rs
@@ -2415,12 +2415,12 @@ mod tests {
             &PinnedObjectGeneration::ETag("etag-at-head".into())
         );
         let error = source.read_range(0..16).await.unwrap_err();
+        // With the shared range cache enabled (on by default), the store's
+        // Precondition error surfaces wrapped in the fetch pipeline's
+        // Generic error — assert the CAUSE, not the outermost variant.
         assert!(
-            matches!(
-                error,
-                crate::error::Error::ObjectStore(object_store::Error::Precondition { .. })
-            ),
-            "expected a Precondition failure, got {error:?}"
+            format!("{error:?}").contains("precondition"),
+            "expected a Precondition failure in the chain, got {error:?}"
         );
         let seen = spy.seen_if_match.lock().unwrap().clone();
         assert_eq!(seen, vec![Some("etag-at-head".to_string())]);

--- a/crates/namidb-storage/src/range_cache.rs
+++ b/crates/namidb-storage/src/range_cache.rs
@@ -1556,10 +1556,22 @@ impl PinnedObjectRangeSource {
     /// Open a NamiDB create-only UUID object, preferring a backend generation
     /// token and falling back to the explicit immutable-path invariant only
     /// when metadata exposes neither version nor ETag.
+    ///
+    /// A store registered through [`mark_store_paths_immutable`] asserts the
+    /// path-level invariant for every object it holds, so the backend token
+    /// adds no safety there — and a stat-derived local ETag actively fails
+    /// healthy reads on FUSE-backed bind mounts, whose synthetic inode churns
+    /// under an unmodified file. Marked stores therefore open with
+    /// [`Self::from_immutable_meta`] semantics (shared cache on, no remote
+    /// precondition) unless `NAMIDB_LOCAL_ETAG_PIN=1|true` restores the
+    /// generation pin.
     pub async fn from_create_only_meta(
         store: Arc<dyn ObjectStore>,
         meta: ObjectMeta,
     ) -> crate::error::Result<Self> {
+        if store_paths_marked_immutable(&store) && !local_etag_pin_forced() {
+            return Self::from_immutable_meta(store, meta).await;
+        }
         match PinnedObjectGeneration::from_meta(&meta) {
             Ok(generation) => {
                 let range_cache = resolved_shared_range_cache(&meta).await?;
@@ -1837,6 +1849,54 @@ fn store_instance_token(store: &Arc<dyn ObjectStore>) -> u64 {
     let id = NEXT.fetch_add(1, Ordering::Relaxed);
     map.insert(pointer, (id, Arc::downgrade(store)));
     id
+}
+
+/// Store instances (by [`store_instance_token`]) whose object paths are all
+/// create-only. Tokens are process-unique and never reused, so an entry that
+/// outlives its store can never match a later instance; the set grows by one
+/// `u64` per marked store and needs no reclamation.
+static IMMUTABLE_PATH_STORE_TOKENS: std::sync::OnceLock<
+    std::sync::Mutex<std::collections::HashSet<u64>>,
+> = std::sync::OnceLock::new();
+
+/// Declare that every object path in `store` is create-only: written once
+/// under a fresh name (tmp + atomic rename, PUT-if-absent) and never modified
+/// in place. [`PinnedObjectRangeSource::from_create_only_meta`] then pins
+/// reads on the immutable path instead of the backend generation token. That
+/// keeps reads working where the token is a stat: `LocalFileSystem` ETags are
+/// `{inode:x}-{mtime:x}-{size:x}`, and FUSE-backed bind mounts (macOS Docker
+/// Desktop gRPC-FUSE) churn the synthetic inode under an unmodified file, so
+/// an `If-Match` pin fails healthy reads. The shared range cache stays on for
+/// marked stores — its keys are already scoped per store instance.
+pub fn mark_store_paths_immutable(store: &Arc<dyn ObjectStore>) {
+    let token = store_instance_token(store);
+    IMMUTABLE_PATH_STORE_TOKENS
+        .get_or_init(|| std::sync::Mutex::new(std::collections::HashSet::new()))
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .insert(token);
+}
+
+fn store_paths_marked_immutable(store: &Arc<dyn ObjectStore>) -> bool {
+    let Some(tokens) = IMMUTABLE_PATH_STORE_TOKENS.get() else {
+        return false;
+    };
+    let token = store_instance_token(store);
+    tokens
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner)
+        .contains(&token)
+}
+
+/// `NAMIDB_LOCAL_ETAG_PIN=1|true` makes marked stores keep pinning the
+/// backend generation token (`If-Match` on the stat-derived local ETag), the
+/// behavior before stores could be marked create-only. Escape hatch only;
+/// sampled at every source open so no restart is needed to flip it.
+fn local_etag_pin_forced() -> bool {
+    std::env::var("NAMIDB_LOCAL_ETAG_PIN").is_ok_and(|value| {
+        let value = value.trim();
+        value == "1" || value.eq_ignore_ascii_case("true")
+    })
 }
 
 static SHARED_RANGE_CACHE: tokio::sync::OnceCell<Option<ImmutableRangeCache>> =
@@ -2218,6 +2278,178 @@ mod tests {
             .await
             .unwrap();
         assert_eq!(source.read_range(0..16).await.unwrap(), second);
+    }
+
+    /// Simulates a FUSE-backed local filesystem whose stat-derived ETag has
+    /// churned between HEAD and GET for an unmodified file: `head` reports
+    /// one tag, data reads enforce another and reject any other `If-Match`
+    /// with `Precondition`, exactly as `LocalFileSystem` does. Every data
+    /// read's `If-Match` option is recorded.
+    #[derive(Debug)]
+    struct ChurnedEtagStore {
+        inner: Arc<dyn ObjectStore>,
+        head_etag: &'static str,
+        current_etag: &'static str,
+        seen_if_match: std::sync::Mutex<Vec<Option<String>>>,
+    }
+
+    impl ChurnedEtagStore {
+        fn new() -> Arc<Self> {
+            Arc::new(Self {
+                inner: Arc::new(InMemory::new()),
+                head_etag: "etag-at-head",
+                current_etag: "etag-after-fuse-churn",
+                seen_if_match: std::sync::Mutex::new(Vec::new()),
+            })
+        }
+    }
+
+    impl fmt::Display for ChurnedEtagStore {
+        fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+            write!(f, "ChurnedEtagStore({})", self.inner)
+        }
+    }
+
+    #[async_trait::async_trait]
+    impl ObjectStore for ChurnedEtagStore {
+        async fn put_opts(
+            &self,
+            location: &ObjectPath,
+            payload: PutPayload,
+            opts: object_store::PutOptions,
+        ) -> object_store::Result<object_store::PutResult> {
+            self.inner.put_opts(location, payload, opts).await
+        }
+
+        async fn put_multipart_opts(
+            &self,
+            location: &ObjectPath,
+            opts: object_store::PutMultipartOptions,
+        ) -> object_store::Result<Box<dyn object_store::MultipartUpload>> {
+            self.inner.put_multipart_opts(location, opts).await
+        }
+
+        async fn get_opts(
+            &self,
+            location: &ObjectPath,
+            options: GetOptions,
+        ) -> object_store::Result<object_store::GetResult> {
+            if options.head {
+                let mut result = self.inner.get_opts(location, options).await?;
+                result.meta.e_tag = Some(self.head_etag.to_string());
+                return Ok(result);
+            }
+            self.seen_if_match
+                .lock()
+                .unwrap()
+                .push(options.if_match.clone());
+            if let Some(condition) = options.if_match.as_deref() {
+                if condition != self.current_etag {
+                    return Err(object_store::Error::Precondition {
+                        path: location.to_string(),
+                        source: format!("{} does not match {condition}", self.current_etag).into(),
+                    });
+                }
+            }
+            // The inner InMemory etag matches neither synthetic tag; strip
+            // the condition so it serves the (unchanged) bytes.
+            let mut passthrough = options;
+            passthrough.if_match = None;
+            let mut result = self.inner.get_opts(location, passthrough).await?;
+            result.meta.e_tag = Some(self.current_etag.to_string());
+            Ok(result)
+        }
+
+        fn list(
+            &self,
+            prefix: Option<&ObjectPath>,
+        ) -> futures::stream::BoxStream<'static, object_store::Result<ObjectMeta>> {
+            self.inner.list(prefix)
+        }
+
+        async fn list_with_delimiter(
+            &self,
+            prefix: Option<&ObjectPath>,
+        ) -> object_store::Result<object_store::ListResult> {
+            self.inner.list_with_delimiter(prefix).await
+        }
+
+        async fn copy_opts(
+            &self,
+            from: &ObjectPath,
+            to: &ObjectPath,
+            options: object_store::CopyOptions,
+        ) -> object_store::Result<()> {
+            self.inner.copy_opts(from, to, options).await
+        }
+
+        fn delete_stream(
+            &self,
+            locations: futures::stream::BoxStream<'static, object_store::Result<ObjectPath>>,
+        ) -> futures::stream::BoxStream<'static, object_store::Result<ObjectPath>> {
+            self.inner.delete_stream(locations)
+        }
+    }
+
+    /// Baseline contract for an UNMARKED store: the ETag from HEAD is pinned
+    /// and a data read whose stat-derived ETag has since churned fails with
+    /// `Precondition` — the failure mode marked stores exist to avoid.
+    #[tokio::test]
+    async fn unmarked_store_etag_pin_fails_when_the_stat_etag_churns() {
+        let spy = ChurnedEtagStore::new();
+        let store: Arc<dyn ObjectStore> = spy.clone();
+        let location = ObjectPath::from(format!("immutable/{}/unmarked", uuid::Uuid::now_v7()));
+        let body = Bytes::from_static(b"0123456789abcdef");
+        store
+            .put(&location, PutPayload::from_bytes(body.clone()))
+            .await
+            .unwrap();
+        let meta = store.head(&location).await.unwrap();
+        assert_eq!(meta.e_tag.as_deref(), Some("etag-at-head"));
+
+        let source = PinnedObjectRangeSource::from_create_only_meta(store, meta)
+            .await
+            .unwrap();
+        assert_eq!(
+            source.generation(),
+            &PinnedObjectGeneration::ETag("etag-at-head".into())
+        );
+        let error = source.read_range(0..16).await.unwrap_err();
+        assert!(
+            matches!(
+                error,
+                crate::error::Error::ObjectStore(object_store::Error::Precondition { .. })
+            ),
+            "expected a Precondition failure, got {error:?}"
+        );
+        let seen = spy.seen_if_match.lock().unwrap().clone();
+        assert_eq!(seen, vec![Some("etag-at-head".to_string())]);
+    }
+
+    /// The same churned store, registered create-only: the pin degrades to
+    /// the immutable path, no `If-Match` reaches the store, and the read
+    /// succeeds despite the churned ETag.
+    #[tokio::test]
+    async fn marked_store_reads_without_if_match_despite_churned_etag() {
+        let spy = ChurnedEtagStore::new();
+        let store: Arc<dyn ObjectStore> = spy.clone();
+        mark_store_paths_immutable(&store);
+        let location = ObjectPath::from(format!("immutable/{}/marked", uuid::Uuid::now_v7()));
+        let body = Bytes::from_static(b"0123456789abcdef");
+        store
+            .put(&location, PutPayload::from_bytes(body.clone()))
+            .await
+            .unwrap();
+        let meta = store.head(&location).await.unwrap();
+        assert_eq!(meta.e_tag.as_deref(), Some("etag-at-head"));
+
+        let source = PinnedObjectRangeSource::from_create_only_meta(store, meta)
+            .await
+            .unwrap();
+        assert_eq!(source.generation(), &PinnedObjectGeneration::ImmutablePath);
+        assert_eq!(source.read_range(0..16).await.unwrap(), body);
+        let seen = spy.seen_if_match.lock().unwrap().clone();
+        assert_eq!(seen, vec![None::<String>]);
     }
 
     #[tokio::test]

--- a/crates/namidb-storage/src/uri.rs
+++ b/crates/namidb-storage/src/uri.rs
@@ -120,6 +120,10 @@ fn parse_memory(uri: &str) -> Result<(Arc<dyn ObjectStore>, NamespacePaths), Uri
         name: rest.to_string(),
         reason: e.to_string(),
     })?;
+    // Deliberately NOT marked create-only for pinned reads (unlike file://):
+    // InMemory ETags are stable per-instance counters with no churn to
+    // tolerate, and overwriting a path is legal against this store, so the
+    // `If-Match` pin still carries weight here.
     Ok((
         Arc::new(InMemory::new()),
         NamespacePaths::new("", namespace),
@@ -168,10 +172,16 @@ fn parse_file(uri: &str) -> Result<(Arc<dyn ObjectStore>, NamespacePaths), UriEr
         uri: uri.to_string(),
         source: anyhow::anyhow!("{e}"),
     })?;
-    Ok((
-        Arc::new(store) as Arc<dyn ObjectStore>,
-        NamespacePaths::new("", namespace),
-    ))
+    let store: Arc<dyn ObjectStore> = Arc::new(store);
+    // NamiDB writes every local object exactly once under a fresh UUID name
+    // (tmp + atomic rename; `O_CREAT|O_EXCL` for pointers), so pinned reads
+    // may key by the immutable path. The alternative — `If-Match` on
+    // `LocalFileSystem`'s `{inode:x}-{mtime:x}-{size:x}` ETag — fails healthy
+    // reads on FUSE-backed bind mounts (macOS Docker Desktop gRPC-FUSE),
+    // which churn the synthetic inode under an unmodified file.
+    // `NAMIDB_LOCAL_ETAG_PIN=1` restores the ETag pin.
+    crate::range_cache::mark_store_paths_immutable(&store);
+    Ok((store, NamespacePaths::new("", namespace)))
 }
 
 /// Optional client tuning for the HTTP-backed stores (S3/GCS/Azure), from
@@ -471,6 +481,45 @@ mod tests {
         let uri = format!("file://{}?ns=acme", dir.path().display());
         let (_store, paths) = parse_uri(&uri).unwrap();
         assert_eq!(paths.namespace().as_str(), "acme");
+    }
+
+    /// A `file://` store is registered create-only at parse time, so pinned
+    /// reads use the immutable-path generation instead of `If-Match` on
+    /// `LocalFileSystem`'s `{inode,mtime,size}` ETag — which FUSE-backed
+    /// bind mounts churn for unmodified files.
+    #[tokio::test]
+    async fn file_store_pins_reads_by_immutable_path() {
+        use object_store::ObjectStoreExt as _;
+
+        let dir = tempfile::tempdir().unwrap();
+        let uri = format!("file://{}?ns=acme", dir.path().display());
+        let (store, _paths) = parse_uri(&uri).unwrap();
+        let location = object_store::path::Path::from(format!("sst/{}.sst", uuid::Uuid::now_v7()));
+        store
+            .put(
+                &location,
+                object_store::PutPayload::from_static(b"immutable-bytes"),
+            )
+            .await
+            .unwrap();
+        let meta = store.head(&location).await.unwrap();
+        assert!(
+            meta.e_tag.is_some(),
+            "LocalFileSystem reports a stat-derived ETag; the pin must still ignore it"
+        );
+
+        let source =
+            crate::range_cache::PinnedObjectRangeSource::from_create_only_meta(store, meta)
+                .await
+                .unwrap();
+        assert_eq!(
+            source.generation(),
+            &crate::range_cache::PinnedObjectGeneration::ImmutablePath
+        );
+        assert_eq!(
+            source.read_range(0..15).await.unwrap(),
+            bytes::Bytes::from_static(b"immutable-bytes")
+        );
     }
 
     #[test]

--- a/docs/testing/25tb-readiness.md
+++ b/docs/testing/25tb-readiness.md
@@ -909,7 +909,7 @@ unreproduced: HTTP single-tenant listing verified live at 3M/5M).
 Recon-before-fix once more; verdicts: three CORRECTED on mechanism, the
 rest confirmed. Fix cycle targets 2.6.0.
 
-### 61. [CORRECTED — fix in progress] Process dies silently: exit 0, no log, restarts cluster in write bursts
+### 61. [CORRECTED — shipped in 2.6.0] Process dies silently: exit 0, no log, restarts cluster in write bursts
 
 The binary has NO self-exit path and NO exit-under-memory-pressure path
 (panic=abort → 134; kernel OOM → 137/OOMKilled). Exit 0 is reachable ONLY
@@ -928,7 +928,7 @@ permits) + awaiting the listener handle; rate-limited warns on pressure
 rejections; boot WARN when the governor is disabled under a finite
 cgroup limit.
 
-### 62. [CORRECTED — fix in progress] adjacency_cache_bytes=0; 53k-degree reverse expand doesn't finish in 300s
+### 62. [CORRECTED — shipped in 2.6.0] adjacency_cache_bytes=0; 53k-degree reverse expand doesn't finish in 300s
 
 The 0 is deliberate: adjacency is the only OPT-IN cache tier
 (NAMIDB_ADJACENCY, requests 0 bytes unless enabled) by object-native
@@ -942,7 +942,7 @@ log names the disabled tier + env var; per-operator-invocation partner
 memo in both expand paths; topology-mode skips property hydration in
 edge_lookup_via_sst.
 
-### 63. [CONFIRMED — fix in progress] CREATE INDEX point lookup 70x slower than unique constraint; 4.8GB vs 574MB store
+### 63. [CONFIRMED — shipped in 2.6.0] CREATE INDEX point lookup 70x slower than unique constraint; 4.8GB vs 574MB store
 
 The unique arm batches an entire statement into ONE storage call
 (claimant pass + one multi-value paged probe + one batch confirm); the
@@ -957,7 +957,7 @@ snapshot (kills the per-call HEAD); default-on 64MiB RAM range cache;
 batch the multi arm like the unique arm. Legacy-body default flip
 deferred (2.0.4 rollback contract); flush.rs doc contradiction fixed.
 
-### 64. [CONFIRMED — fix in progress] Nine parallel read aggregations kill the server; no admission queue
+### 64. [CONFIRMED — shipped in 2.6.0] Nine parallel read aggregations kill the server; no admission queue
 
 No bound on concurrent query execution exists in the default config: the
 memory governor defaults OFF, the scan gate (4) meters only plans
@@ -967,7 +967,7 @@ per-operator rows not bytes. Fix: --max-concurrent-queries semaphore
 bounded wait then retryable 503 (HTTP) / transient Bolt error; scan-gate
 waits raced against client cancellation while there.
 
-### 65. [CORRECTED — fix in progress] file:// on macOS bind mounts: Precondition failures
+### 65. [CORRECTED — shipped in 2.6.0] file:// on macOS bind mounts: Precondition failures
 
 Real, but the unstable field is the INODE, not the size (etag format is
 {inode:x}-{mtime:x}-{size:x}; the failing pair differs in field one —
@@ -987,7 +987,7 @@ Now dispatched in the ENGINE (one chokepoint serves every surface) from
 manifest-cheap observed_* snapshot data, with stable virtual node ids;
 propertyKeys unions the memtable delta.
 
-### 67. [minor gaps — fixes staged] Docker features, write-timeout, SHOW INDEXES
+### 67. [minor gaps — shipped in 2.6.0] Docker features, write-timeout, SHOW INDEXES
 
 (a) REFUTED as packaging: every 2.x tag's Dockerfile bakes
 vector-index,text-index (verified per tag), and CALL even lists


### PR DESCRIPTION
Four fix bundles integrated (three authored in isolated worktrees against recon specs, one direct), each with tests:

- **Item 61**: shutdown is attributed (SIGINT/SIGTERM at WARN with memory telemetry); a shutdown-channel closure without a signal exits nonzero at ERROR; in-flight Bolt sessions drain behind a bounded permit barrier before the process may return; memory-pressure rejections log (rate-limited); boot warns when the governor is disabled under a finite cgroup limit.
- **Item 65**: file:// reads stop pinning If-Match on the stat-derived etag (gRPC-FUSE churns the inode field); create-only local stores use immutable-path pins, escape hatch `NAMIDB_LOCAL_ETAG_PIN=1`.
- **Item 67a**: Neo4j spellings of `CREATE VECTOR INDEX ... FOR (n:L) ON n.p OPTIONS {...}` / `CREATE FULLTEXT INDEX ... ON EACH [...]` accepted alongside the native dialect; feature-off builds report the missing build feature instead of a misleading message.
- **Item 67b**: `--write-timeout` gains its own 60s default (was inheriting the 30s query timeout).
- **Item 64**: process-wide read admission queue — `NAMIDB_MAX_CONCURRENT_QUERIES` (default max(4, cores)) with a bounded wait then retryable 503; Bolt waits raced against disconnect.

Gate (stepped): storage 25, query 36, server 13, bolt/cli/mcp/bench/namidb/py 11 suites green; clippy; fmt. One cherry-picked test assertion relaxed to the error cause chain (shared range cache wraps the Precondition).