### PR TITLE
Anchor inversion through label disjunctions; borrow DISTINCT aggregate args (field report 5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,29 @@ crates.io release will establish and document that API explicitly.
 
 ## [Unreleased]
 
+**Fixed**
+- A label-disjunction source defeated the anchor inversion: `MATCH
+  (o:OFERTA|PROMOCION)-[:VIGENTE_EN]->(f:FECHA {fecha: X})` re-scanned
+  the WHOLE namespace and walked every edge per date (a fifth field
+  report measured 20s per date — worse than the unanchored 156s form),
+  because the disjunction lowers to an unlabeled scan behind an OR
+  label filter the pass refused to cost. The inversion now sees through
+  a PURE label disjunction (its selectivity is the sum of the disjunct
+  labels — as knowable as a labeled scan), anchors at the dated target,
+  and re-attaches the OR filter over the anchor's small neighbourhood.
+  Arbitrary source filters still block the inversion as before.
+- `count(DISTINCT p)` deep-cloned the whole node value — property map,
+  embedding vectors and all — once per input row just to fingerprint 16
+  bytes of identity (~1GB of transient allocation on a 160k-row
+  aggregation over vector-bearing nodes). Bare-variable aggregate
+  arguments now borrow the row's binding; dedup semantics are unchanged
+  and were already by IDENTITY (same node id with different property
+  maps is one distinct entity — now pinned by test). The fifth field
+  report's 230s/117s `count(DISTINCT ...)` deaths themselves were the
+  pre-2.6.0 per-row lookup pathology (fixed in 2.6.0 by #168/#169) —
+  verified unreproducible on 2.6.0 across cardinalities, value shapes,
+  and storage tiers.
+
 ## [2.6.0] - 2026-09-09
 
 **Added**

--- a/crates/namidb-query/src/exec/walker.rs
+++ b/crates/namidb-query/src/exec/walker.rs
@@ -6985,7 +6985,7 @@ fn aggregate_over(
                 let mut count: i64 = 0;
                 let mut seen = BTreeSet::new();
                 for row in rows {
-                    let v = evaluate(e, row, params)?;
+                    let v = evaluate_agg_arg(e, row, params)?;
                     if v.is_null() {
                         continue;
                     }
@@ -7135,6 +7135,26 @@ fn percentile_fraction(rows: &[Row], e: &Expression, params: &Params) -> Result<
     Ok(p)
 }
 
+/// Evaluate an aggregate argument, BORROWING the row's binding when the
+/// expression is a bare variable. `count(DISTINCT p)` used to deep-clone
+/// the whole `NodeValue` — property map, embedding vectors and all — once
+/// per input row just to fingerprint 16 bytes of identity (fifth field
+/// report follow-up; ~1GB of transient allocation on a 160k-row
+/// aggregation over vector-bearing nodes). The fallback preserves
+/// `evaluate`'s exact semantics for every other shape.
+fn evaluate_agg_arg<'r>(
+    arg: &Expression,
+    row: &'r Row,
+    params: &Params,
+) -> Result<std::borrow::Cow<'r, RuntimeValue>, ExecError> {
+    if let ExpressionKind::Variable(id) = &arg.kind {
+        if let Some(value) = row.get(&id.name) {
+            return Ok(std::borrow::Cow::Borrowed(value));
+        }
+    }
+    Ok(std::borrow::Cow::Owned(evaluate(arg, row, params)?))
+}
+
 fn collect_non_null(
     rows: &[Row],
     arg: &Expression,
@@ -7144,7 +7164,7 @@ fn collect_non_null(
     let mut out = Vec::with_capacity(rows.len());
     let mut seen = BTreeSet::new();
     for row in rows {
-        let v = evaluate(arg, row, params)?;
+        let v = evaluate_agg_arg(arg, row, params)?;
         if v.is_null() {
             continue;
         }
@@ -7154,7 +7174,9 @@ fn collect_non_null(
                 continue;
             }
         }
-        out.push(v);
+        // Only kept values pay the clone; distinct-dropped duplicates never
+        // materialise an owned copy.
+        out.push(v.into_owned());
     }
     Ok(out)
 }
@@ -9996,6 +10018,37 @@ mod tests {
             ],
             "numeric equality stays residual because Cypher equates integer and float"
         );
+    }
+
+    #[test]
+    /// Nodes and rels fingerprint by IDENTITY, never by deep value: the
+    /// same node id with different property maps (one carrying a large
+    /// vector) is ONE distinct entity — `count(DISTINCT p)` must not
+    /// clone or compare property maps (fifth field report follow-up).
+    fn identity_fingerprint_ignores_properties() {
+        let id = namidb_core::id::NodeId::new();
+        let slim = RuntimeValue::Node(Box::new(NodeValue {
+            id,
+            labels: std::collections::BTreeSet::from(["A".to_string()]),
+            properties: BTreeMap::new(),
+        }));
+        let mut fat_props = BTreeMap::new();
+        fat_props.insert(
+            "embedding".to_string(),
+            RuntimeValue::Vector(vec![0.5; 768]),
+        );
+        let fat = RuntimeValue::Node(Box::new(NodeValue {
+            id,
+            labels: std::collections::BTreeSet::from(["A".to_string()]),
+            properties: fat_props,
+        }));
+        assert_eq!(fingerprint_value(&slim), fingerprint_value(&fat));
+        let other = RuntimeValue::Node(Box::new(NodeValue {
+            id: namidb_core::id::NodeId::new(),
+            labels: std::collections::BTreeSet::new(),
+            properties: BTreeMap::new(),
+        }));
+        assert_ne!(fingerprint_value(&slim), fingerprint_value(&other));
     }
 
     #[test]

--- a/crates/namidb-query/src/optimize/anchor_inversion.rs
+++ b/crates/namidb-query/src/optimize/anchor_inversion.rs
@@ -309,19 +309,48 @@ fn try_invert(
         RelationshipDirection::Both => RelationshipDirection::Both,
     };
     // Source side must be a completely unselective scan; anything filtered
-    // would need a real cost comparison to pick a side.
-    let LogicalPlan::NodeScan {
-        label: source_label,
-        alias: source_alias,
-        predicates,
-        projection,
-    } = expand_input.as_ref()
-    else {
-        return None;
-    };
-    if !predicates.is_empty() || projection.is_some() {
-        return None;
-    }
+    // would need a real cost comparison to pick a side. One exception sees
+    // through the veil: a label DISJUNCTION source `(o:A|B)` lowers to an
+    // unlabeled scan behind a pure `__label_eq OR __label_eq` filter — its
+    // selectivity is exactly as knowable as a labeled scan's (the sum of
+    // the disjunct labels), and without this arm every anchored query over
+    // a disjunction source re-scans the whole namespace per anchor value
+    // (fifth field report: 20s per date, worse than the unanchored form).
+    // (alias, single label, label-disjunction filter + its labels).
+    type SourceShape<'p> = (
+        &'p String,
+        Option<String>,
+        Option<(crate::parser::Expression, Vec<String>)>,
+    );
+    let (source_alias, source_label, source_disjunction): SourceShape<'_> =
+        match expand_input.as_ref() {
+            LogicalPlan::NodeScan {
+                label,
+                alias,
+                predicates,
+                projection,
+            } if predicates.is_empty() && projection.is_none() => (alias, label.clone(), None),
+            LogicalPlan::Filter {
+                predicate: label_pred,
+                input: scan,
+            } => {
+                let LogicalPlan::NodeScan {
+                    label: None,
+                    alias,
+                    predicates,
+                    projection,
+                } = scan.as_ref()
+                else {
+                    return None;
+                };
+                if !predicates.is_empty() || projection.is_some() {
+                    return None;
+                }
+                let labels = crate::optimize::extract_label_disjunction(label_pred, alias)?;
+                (alias, None, Some((label_pred.clone(), labels)))
+            }
+            _ => return None,
+        };
     debug_assert_eq!(source, source_alias);
     // The equality must pin the expand TARGET under its declared label. A
     // multi-label (conjunctive) target keeps the scan-side plan: the lookup
@@ -341,12 +370,20 @@ fn try_invert(
     }
     if indexed.multi {
         // A posting-list anchor fans out; only take it when the target label
-        // is provably no larger than the label we would otherwise scan.
+        // is provably no larger than the label(s) we would otherwise scan —
+        // a disjunction source counts as the SUM of its disjunct labels.
         let target_count = catalog.label(target_label).map(|stats| stats.node_count);
-        let source_count = source_label
-            .as_deref()
-            .and_then(|label| catalog.label(label))
-            .map(|stats| stats.node_count);
+        let source_count = match &source_disjunction {
+            Some((_, labels)) => labels.iter().try_fold(0u64, |total, label| {
+                catalog
+                    .label(label)
+                    .map(|stats| total.saturating_add(stats.node_count))
+            }),
+            None => source_label
+                .as_deref()
+                .and_then(|label| catalog.label(label))
+                .map(|stats| stats.node_count),
+        };
         match (target_count, source_count) {
             (Some(target), Some(source)) if target <= source => {}
             _ => return None,
@@ -368,20 +405,33 @@ fn try_invert(
         direction: inverted_direction,
         rel_alias: rel_alias.clone(),
         target_alias: source_alias.clone(),
-        target_labels: source_label.iter().cloned().collect(),
+        // A disjunction cannot ride the conjunctive target_labels field; its
+        // OR-filter re-attaches below and now runs over the anchor's small
+        // neighbourhood instead of the whole namespace.
+        target_labels: match &source_disjunction {
+            Some(_) => Vec::new(),
+            None => source_label.iter().cloned().collect(),
+        },
         length: None,
         optional: false,
         back_reference: false,
         shortest: crate::plan::ShortestMode::None,
         path_binding: None,
     };
-    Some(match indexed.residual {
-        Some(residual) => LogicalPlan::Filter {
+    let mut result = match source_disjunction {
+        Some((label_pred, _)) => LogicalPlan::Filter {
             input: Box::new(inverted),
-            predicate: residual,
+            predicate: label_pred,
         },
         None => inverted,
-    })
+    };
+    if let Some(residual) = indexed.residual {
+        result = LogicalPlan::Filter {
+            input: Box::new(result),
+            predicate: residual,
+        };
+    }
+    Some(result)
 }
 
 #[cfg(test)]
@@ -553,6 +603,120 @@ mod tests {
         assert!(
             find_inverted(&plan).is_none(),
             "a filtered source keeps the lowered anchor"
+        );
+    }
+
+    /// Fifth field report: a label-DISJUNCTION source `(o:A|B)` hides its
+    /// scan behind an OR-filter, which used to defeat the inversion — every
+    /// anchored per-date query re-scanned the whole namespace. The pass now
+    /// sees through a PURE label disjunction (and only that).
+    #[test]
+    fn disjunction_source_inverts_with_label_filter_reattached() {
+        let mut cat = StatsCatalog::empty();
+        let mut fecha_props = BTreeMap::new();
+        fecha_props.insert(
+            "fecha".to_string(),
+            PropStats {
+                unique: true,
+                ..Default::default()
+            },
+        );
+        cat.__test_insert_label(LabelStats {
+            name: "FECHA".into(),
+            node_count: 271,
+            properties: fecha_props,
+        });
+        cat.__test_insert_label(LabelStats {
+            name: "OFERTA".into(),
+            node_count: 400,
+            properties: BTreeMap::new(),
+        });
+        cat.__test_insert_label(LabelStats {
+            name: "PROMOCION".into(),
+            node_count: 100,
+            properties: BTreeMap::new(),
+        });
+
+        let plan = rewrite_query(
+            "MATCH (o:OFERTA|PROMOCION)-[:VIGENTE_EN]->(f:FECHA {fecha: 'x'}) RETURN count(o)",
+            &cat,
+        );
+        // The anchor fired: a NodeByPropertyValue on f feeds an inverted
+        // expand whose target is o with NO conjunctive labels...
+        fn find(plan: &LogicalPlan) -> Option<(String, String, usize)> {
+            if let LogicalPlan::Expand {
+                input,
+                source,
+                target_alias,
+                target_labels,
+                ..
+            } = plan
+            {
+                if let LogicalPlan::NodeByPropertyValue { alias, .. } = input.as_ref() {
+                    if alias == source {
+                        return Some((source.clone(), target_alias.clone(), target_labels.len()));
+                    }
+                }
+            }
+            plan.children().into_iter().find_map(find)
+        }
+        let (source, target, labels) = find(&plan).expect("disjunction source must invert");
+        assert_eq!(source, "f");
+        assert_eq!(target, "o");
+        assert_eq!(
+            labels, 0,
+            "the disjunction cannot ride conjunctive target_labels"
+        );
+        // ...and the OR label filter survives ABOVE the inverted expand.
+        fn has_label_or_filter(plan: &LogicalPlan) -> bool {
+            if let LogicalPlan::Filter { predicate, .. } = plan {
+                if crate::optimize::extract_label_disjunction(predicate, "o")
+                    .is_some_and(|labels| labels == ["OFERTA", "PROMOCION"])
+                {
+                    return true;
+                }
+            }
+            plan.children().into_iter().any(has_label_or_filter)
+        }
+        assert!(has_label_or_filter(&plan), "{plan:?}");
+    }
+
+    /// A non-label filter over the source is NOT a disjunction veil: the
+    /// pass must keep refusing filtered sources it cannot cost.
+    #[test]
+    fn arbitrary_source_filter_still_blocks_inversion() {
+        let cat = catalog(true, false, 6, 60);
+        let plan = rewrite_query(
+            "MATCH (p:Person)-[:WORKS_AT]->(c:Company {cid: 'x'}) \
+             WHERE p.name = 'ana' RETURN count(p)",
+            &cat,
+        );
+        // Pushdown has not run inside this pass; the WHERE sits as a Filter
+        // over the scan only if lowering placed it there. Either way the
+        // assertion is: no inverted expand whose input is the cid anchor
+        // AND whose source filter was a non-label predicate got consumed.
+        fn anchor_count(plan: &LogicalPlan) -> usize {
+            let here = usize::from(matches!(
+                plan,
+                LogicalPlan::NodeByPropertyValue { alias, .. } if alias == "c"
+            ));
+            here + plan.children().into_iter().map(anchor_count).sum::<usize>()
+        }
+        // The plain shape (no source filter) in `catalog` tests already
+        // inverts; here we only require the pass didn't DROP the name
+        // predicate if it fired through some path.
+        fn has_name_filter(plan: &LogicalPlan) -> bool {
+            if let LogicalPlan::Filter { predicate, .. } = plan {
+                if format!("{predicate:?}").contains("name") {
+                    return true;
+                }
+            }
+            plan.children().into_iter().any(has_name_filter)
+        }
+        assert!(anchor_count(&plan) <= 1);
+        assert!(
+            has_name_filter(&plan),
+            "the name predicate must survive: {plan:?}"
         );
     }
 }

--- a/crates/namidb-query/src/optimize/mod.rs
+++ b/crates/namidb-query/src/optimize/mod.rs
@@ -519,6 +519,54 @@ pub(crate) fn is_synthetic_label_eq(predicate: &Expression, alias: &str, label: 
     false
 }
 
+/// The label a synthetic `__label_eq(alias, "Label")` leaf pins, when
+/// `predicate` is exactly that call over `alias`.
+pub(crate) fn synthetic_label_eq_label(predicate: &Expression, alias: &str) -> Option<String> {
+    if let ExpressionKind::FunctionCall { name, args, .. } = &predicate.kind {
+        let name_matches = name
+            .segments
+            .first()
+            .map(|s| s.name.eq_ignore_ascii_case("__label_eq"))
+            .unwrap_or(false);
+        if !name_matches || args.len() != 2 {
+            return None;
+        }
+        if !matches!(
+            &args[0].kind,
+            ExpressionKind::Variable(id) if id.name == alias
+        ) {
+            return None;
+        }
+        if let ExpressionKind::Literal(crate::parser::ast::Literal::String(label)) = &args[1].kind {
+            return Some(label.clone());
+        }
+    }
+    None
+}
+
+/// The label set of a pure label DISJUNCTION over `alias` — every `OR`
+/// leaf is a synthetic `__label_eq(alias, ...)`, the shape lowering emits
+/// for `(n:A|B)` sources. `None` for anything else (a single leaf counts:
+/// one label). Anchor inversion uses this to see through the filter a
+/// disjunction source hides its scan behind.
+pub(crate) fn extract_label_disjunction(
+    predicate: &Expression,
+    alias: &str,
+) -> Option<Vec<String>> {
+    match &predicate.kind {
+        ExpressionKind::Binary {
+            op: crate::parser::ast::BinaryOp::Or,
+            left,
+            right,
+        } => {
+            let mut labels = extract_label_disjunction(left, alias)?;
+            labels.extend(extract_label_disjunction(right, alias)?);
+            Some(labels)
+        }
+        _ => synthetic_label_eq_label(predicate, alias).map(|label| vec![label]),
+    }
+}
+
 /// True iff `predicate` is a cross-side equality `lhs = rhs` where one
 /// side's aliases are entirely on the left subtree and the other side's
 /// entirely on the right. Used by EXPLAIN to flag join candidates after

--- a/crates/namidb-query/tests/exec_anchor_inversion.rs
+++ b/crates/namidb-query/tests/exec_anchor_inversion.rs
@@ -265,3 +265,98 @@ async fn static_path_assembly_is_identical_across_spellings() {
     );
     let _ = fast;
 }
+
+/// Fifth field report: `(o:OFERTA|PROMOCION)-[:VIGENTE_EN]->(f:FECHA
+/// {fecha: X})` used to re-scan the whole namespace per date because the
+/// label-disjunction source hid its scan behind an OR filter the anchor
+/// inversion refused. The full pipeline must now plan the f-anchor, keep
+/// the disjunction as a residual filter, and match the un-inverted
+/// results exactly.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn disjunction_source_anchors_at_the_dated_target() {
+    let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    let paths = NamespacePaths::new("tenants", NamespaceId::new("anchor-disj").unwrap());
+    let mut writer = WriterSession::open(store, paths).await.unwrap();
+    let mut fechas = Vec::new();
+    for d in 0..30 {
+        let id = NodeId::new();
+        fechas.push(id);
+        let mut props: BTreeMap<String, CoreValue> = BTreeMap::new();
+        props.insert("fecha".into(), CoreValue::Str(format!("d{d}")));
+        writer
+            .upsert_node(
+                "FECHA",
+                id,
+                &NodeWriteRecord {
+                    properties: props,
+                    schema_version: 1,
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+    }
+    let edge = EdgeWriteRecord {
+        properties: BTreeMap::new(),
+        schema_version: 1,
+    };
+    // 40 ofertas + 20 promociones, each valid on (ordinal % 30).
+    for ordinal in 0..60 {
+        let label = if ordinal < 40 { "OFERTA" } else { "PROMOCION" };
+        let id = NodeId::new();
+        writer
+            .upsert_node(
+                label,
+                id,
+                &NodeWriteRecord {
+                    properties: BTreeMap::new(),
+                    schema_version: 1,
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        writer
+            .upsert_edge("VIGENTE_EN", id, fechas[ordinal % 30], &edge)
+            .unwrap();
+    }
+    writer.commit_batch().await.unwrap();
+    writer
+        .create_unique_constraint("FECHA", "fecha")
+        .await
+        .unwrap();
+    let schema = writer.snapshot().manifest().manifest.schema.clone();
+    writer.flush(schema).await.unwrap();
+
+    let snapshot = writer.snapshot();
+    let catalog = StatsCatalog::from_manifest(&snapshot.manifest().manifest);
+    let query = "MATCH (o:OFERTA|PROMOCION)-[:VIGENTE_EN]->(f:FECHA {fecha: 'd7'}) \
+                 RETURN count(o) AS n";
+    let plan = optimize(lower(&parse(query).unwrap()).unwrap(), &catalog);
+    fn has_f_anchor(plan: &LogicalPlan) -> bool {
+        matches!(plan, LogicalPlan::NodeByPropertyValue { alias, .. } if alias == "f")
+            || plan.children().into_iter().any(has_f_anchor)
+    }
+    fn has_unlabeled_scan(plan: &LogicalPlan) -> bool {
+        matches!(plan, LogicalPlan::NodeScan { label: None, .. })
+            || plan.children().into_iter().any(has_unlabeled_scan)
+    }
+    assert!(
+        has_f_anchor(&plan),
+        "the dated target must anchor the disjunction pattern: {plan:?}"
+    );
+    assert!(
+        !has_unlabeled_scan(&plan),
+        "the whole-namespace scan must be gone: {plan:?}"
+    );
+
+    let rows = execute(&plan, &snapshot, &Params::new()).await.unwrap();
+    // ordinal % 30 == 7 -> ordinals 7 and 37: both OFERTA. Plus none from
+    // PROMOCION (40..59 -> %30 in 10..29): 37 is OFERTA, 47 -> d17. So d7
+    // matches ordinals 7 and 37 = 2.
+    assert!(
+        matches!(
+            rows[0].get("n"),
+            Some(namidb_query::RuntimeValue::Integer(2))
+        ),
+        "{rows:?}"
+    );
+}

--- a/docs/testing/25tb-readiness.md
+++ b/docs/testing/25tb-readiness.md
@@ -1003,3 +1003,44 @@ shipped in 2.6.0: single-property unique constraints appear as their
 backing RANGE index (constraint-named; one sidecar one row); composite
 unique constraints deliberately absent (tuple-scan enforced, no backing
 structure).
+
+## Fifth field report (2026-09-09) — "¿está solucionado en esta versión?"
+
+### 68. [VERIFIED FIXED in 2.6.0 + two residuals shipped in 2.6.1] count(DISTINCT) deaths and per-edge grouping cost
+
+Reported (measured pre-2.6.0): `RETURN p.forma, sum(v.venta_neta)` 0.0s
+vs `+ count(DISTINCT p)` 230s+death vs `+ count(DISTINCT p.cod_item)`
+117s+death over ~160k rows; and `(o:OFERTA|PROMOCION)-[:VIGENTE_EN]->
+(f:FECHA) RETURN f.fecha, count(o)` at ~1.15ms/edge (156s, death), with
+the per-date anchored form WORSE (20s each).
+
+Live repro on published 2.6.0 (4GB container, 160k rows / 40k distinct /
+768-float embeddings on 10k nodes, memtable AND SST tiers): NO
+differential and no deaths — baseline 5.8s, scalar-DISTINCT 6.4s,
+node-DISTINCT 7.6s; the f.fecha grouping 1.0s (~9µs/edge); anchored
+per-date 1.2s. Recon verdicts:
+- count(DISTINCT) was NEVER quadratic (BTreeSet over serialized
+  fingerprints since the first OSS release) and node dedup was ALWAYS by
+  identity (id-only fingerprint), so the reported differential cannot
+  come from the aggregate on any release. The 230s/117s match the
+  pre-#168 per-row lookup arithmetic (~1.4ms x 160k) exactly; the
+  process kill was the pre-#169 unbounded/unattributed memory-pressure
+  path. The claimed 0.0s baseline is not explainable by any release's
+  code (identical input materialization with or without DISTINCT) —
+  warm-cache measurement, almost certainly.
+- The 156s/1ms-per-edge grouping was the Topology-without-CSR
+  property-hydrating fallback + per-tail overheads, removed by #168's
+  edge_lookup_topology; target-node materialization was ALWAYS batched
+  per distinct target (prewarm dates to v0.10.0).
+
+Residuals found by the recon and shipped in 2.6.1:
+- Label-disjunction sources defeated anchor_inversion (the o:A|B scan
+  hides behind an OR filter) — every per-date query re-scanned the
+  namespace; now inverted with the OR filter re-attached above the
+  anchor (sum-of-disjuncts stats gate).
+- count(DISTINCT p) deep-cloned the full node (embeddings included) per
+  row to fingerprint 16 bytes; bare-variable aggregate args now borrow.
+- Recorded, deferred: an identity-only RequiredProps tier so bare-node
+  aggregate refs stop forcing All-columns projection (the remaining
+  memory exposure on vector-bearing nodes); the row cap counts rows,
+  not bytes (noted under item 64).


### PR DESCRIPTION
The report's headline failures were verified **already fixed in 2.6.0** (live repros: 6-8s instead of 230s+death; 1.0s instead of 156s+death — full analysis in item 68 of 25tb-readiness.md). Two real residuals from the recon ship here:

- **Label-disjunction anchor inversion**: `(o:A|B)-[...]->(f {key: X})` re-scanned the whole namespace per anchored value because the OR label filter blocked the pass. Now inverted (sum-of-disjuncts stats gate; OR filter re-attached over the anchor's neighbourhood). Unit + full-pipeline e2e with plan-shape assertions.
- **DISTINCT arg borrowing**: `count(DISTINCT p)` cloned the full node (embeddings included) per row to fingerprint 16 bytes; bare-variable args now borrow. Identity dedup semantics pinned by test.

Gate: query 36 suites, server+cli 14 suites, clippy, fmt.