### PR TITLE
Field report 6: alias pushdown anchors WITH-renamed predicates; flatten the expansion cliff; unify request deadlines (items 70-72)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,39 @@ crates.io release will establish and document that API explicitly.
 
 ## [Unreleased]
 
+**Fixed**
+- A predicate on a WITH-renamed property stranded the index anchor and
+  forced a full-label scan: `MATCH (v:VENTA)-[:R]->(p:PRODUCTO) WITH v,
+  p.cod_item AS c WHERE c = '…'` planned a scan of every VENTA, while the
+  identical query written with the equality inside the pattern anchored
+  at PRODUCTO and finished instantly (sixth field report: the scan form
+  ran 120s+ and took the process with it). Predicate pushdown now
+  substitutes a projection alias back to the expression it binds and
+  pushes the rewritten conjunct below the projection, so the existing
+  anchor machinery sees it on the next fixpoint round. Computed aliases
+  and DISTINCT projections are deliberately not substituted.
+- Reverse expansion into a very high-degree node failed as a CLIFF, not a
+  slowdown (instant at degree ~3.9k, fatal at ~53k) — and enabling
+  `NAMIDB_ADJACENCY` made it arrive EARLIER. The hop prewarmed all
+  distinct endpoints into the shared node cache and then re-read each one
+  through it; once the endpoint set outgrew that cache the FIFO eviction
+  discarded the prewarm's own earliest entries before the per-edge loop
+  reached them, collapsing the hit rate to ~0% and leaving tens of
+  thousands of sequential cold point reads. Three changes: a single-hop
+  labelled expansion now consumes its own materialisation directly
+  (bounded by `NAMIDB_EXPAND_TARGET_VIEW_BUDGET`, default 250k
+  endpoints), `batch_lookup_nodes` resolves in chunks
+  (`NAMIDB_BATCH_LOOKUP_CHUNK`, default 8192) so peak memory no longer
+  scales with fan-out, and a single-hop expansion stops deep-cloning
+  every matched row into a frontier that is never read.
+- Two request deadlines overlapped silently: the outer HTTP ceiling
+  (120s, env-only) could sit BELOW `--query-timeout`, so a query
+  configured for 300s still died at 120s with a 408 instead of its own
+  504. The ceiling is now a documented flag (`--http-request-timeout`,
+  `0s` disables), its default is derived so it can never truncate the
+  configured query/write budgets, and setting it at or below them warns
+  at boot.
+
 ## [2.6.1] - 2026-09-09
 
 **Fixed**

--- a/crates/namidb-query/src/exec/walker.rs
+++ b/crates/namidb-query/src/exec/walker.rs
@@ -1810,6 +1810,7 @@ pub(crate) async fn execute_expand(
                 target_labels,
                 &unique_targets,
                 skip_target_materialize,
+                max == 1 && !target_labels.is_empty(),
             )
             .await?;
             for (step, neighbours) in step_neighbours {
@@ -1882,15 +1883,25 @@ pub(crate) async fn execute_expand(
                     let target_view_opt = if back_reference {
                         None
                     } else if skip_target_materialize {
-                        if !target_membership
-                            .as_ref()
-                            .and_then(|membership| membership.get(&target_id))
-                            .copied()
-                            .unwrap_or(false)
-                        {
+                        if !match &target_membership {
+                            ExpandTargets::Membership(membership) => {
+                                membership.get(&target_id).copied().unwrap_or(false)
+                            }
+                            _ => false,
+                        } {
                             continue;
                         }
                         None
+                    } else if let ExpandTargets::Views(views) = &target_membership {
+                        // Single-hop labelled expansion: the hop's own
+                        // materialisation answers directly, so a large
+                        // fan-out no longer depends on cache retention.
+                        match views.get(&target_id) {
+                            Some(v) if target_labels.iter().all(|l| v.labels.contains(l)) => {
+                                Some(v.clone())
+                            }
+                            _ => continue,
+                        }
                     } else if let Some(label) = target_labels.first() {
                         if max > 1 {
                             // Multi-hop: traverse through any existing node; the
@@ -1999,13 +2010,20 @@ pub(crate) async fn execute_expand(
                     if let Some(k) = &edge_key {
                         new_rels.push(k.clone());
                     }
-                    next_frontier.push(Step {
-                        tail: target_id,
-                        row: new_row.clone(),
-                        trail: new_trail.clone(),
-                        rels: new_rels,
-                        rel_values: new_rel_values.clone(),
-                    });
+                    // A single-hop expansion never runs another round, so the
+                    // frontier entry is dead on arrival — and it costs a DEEP
+                    // clone of the row (every binding, whole node values
+                    // included) per matched edge. At a 53k-degree hub that was
+                    // hundreds of MB of pure waste (sixth field report).
+                    if max > 1 {
+                        next_frontier.push(Step {
+                            tail: target_id,
+                            row: new_row.clone(),
+                            trail: new_trail.clone(),
+                            rels: new_rels,
+                            rel_values: new_rel_values.clone(),
+                        });
+                    }
                     if hop >= min.max(1) {
                         let keeps = bound_target_matches_labels
                             && target_is_result
@@ -6429,14 +6447,48 @@ fn partner_id(edge: &EdgeView, direction: RelationshipDirection, source: NodeId)
 /// exact dangling-node/label semantics. For value-consuming targets this
 /// merely prewarms the point cache, including typeless expansions that
 /// previously repeated one cold lookup per relationship.
+/// What [`prepare_expand_targets`] resolved for one hop.
+pub(crate) enum ExpandTargets {
+    /// Identity-only route: membership per distinct endpoint.
+    Membership(HashMap<NodeId, bool>),
+    /// Value-consuming route: the hop's endpoint views, materialised ONCE
+    /// and consumed directly. Previously this batch was thrown away and
+    /// every edge re-read its endpoint through the shared node cache —
+    /// which collapsed once a hop's distinct targets outgrew that cache,
+    /// because eviction is FIFO and the prewarm evicted its own earliest
+    /// entries before the per-edge loop reached them (sixth field report:
+    /// instant at degree 3.8k, fatal at 53k — a step function at a capacity
+    /// boundary, arriving EARLIER when the CSR cache is enabled because
+    /// that shrinks the node cache's share of the budget).
+    Views(HashMap<NodeId, namidb_storage::NodeView>),
+    /// Nothing prepared: each edge resolves its own endpoint.
+    Cold,
+}
+
+/// Upper bound on endpoint views held for one hop. Beyond it the batch is
+/// skipped entirely rather than materialised and thrown away: a set that
+/// large cannot be retained by any cache either, so the per-edge path is
+/// the honest route and the churn is pure loss.
+fn expand_target_view_budget() -> usize {
+    std::env::var("NAMIDB_EXPAND_TARGET_VIEW_BUDGET")
+        .ok()
+        .and_then(|raw| raw.parse::<usize>().ok())
+        .unwrap_or(250_000)
+}
+
 async fn prepare_expand_targets(
     snapshot: &Snapshot<'_>,
     target_labels: &[String],
     unique_targets: &[NodeId],
     skip_target_materialize: bool,
-) -> Result<Option<HashMap<NodeId, bool>>, ExecError> {
+    views_usable: bool,
+) -> Result<ExpandTargets, ExecError> {
     if unique_targets.is_empty() {
-        return Ok(skip_target_materialize.then(HashMap::new));
+        return Ok(if skip_target_materialize {
+            ExpandTargets::Membership(HashMap::new())
+        } else {
+            ExpandTargets::Cold
+        });
     }
     if skip_target_materialize {
         let matches = match snapshot
@@ -6465,12 +6517,28 @@ async fn prepare_expand_targets(
                 "batched endpoint membership returned a misaligned result".into(),
             ));
         }
-        return Ok(Some(unique_targets.iter().copied().zip(matches).collect()));
+        return Ok(ExpandTargets::Membership(
+            unique_targets.iter().copied().zip(matches).collect(),
+        ));
     }
 
     let label = target_labels.first().map_or("", String::as_str);
-    let _ = snapshot.batch_lookup_nodes(label, unique_targets).await?;
-    Ok(None)
+    // Only a SINGLE-HOP labelled expansion may consume the batch directly:
+    // the batch is label-scoped, while a variable-length traversal must be
+    // able to walk THROUGH nodes carrying other labels.
+    if !views_usable || unique_targets.len() > expand_target_view_budget() {
+        let _ = snapshot.batch_lookup_nodes(label, unique_targets).await?;
+        return Ok(ExpandTargets::Cold);
+    }
+    let views = snapshot.batch_lookup_nodes(label, unique_targets).await?;
+    Ok(ExpandTargets::Views(
+        unique_targets
+            .iter()
+            .copied()
+            .zip(views)
+            .filter_map(|(id, view)| view.map(|view| (id, view)))
+            .collect(),
+    ))
 }
 
 /// Decide whether an Expand target may be represented by an id-only stub.
@@ -8618,6 +8686,7 @@ async fn execute_expand_factor(
                 target_labels,
                 &unique_targets,
                 skip_target_materialize,
+                max == 1 && !target_labels.is_empty(),
             )
             .await?;
             for ((cur_parent, tail, rels), neighbours) in step_neighbours {
@@ -8652,15 +8721,25 @@ async fn execute_expand_factor(
                     let target_view_opt = if back_reference {
                         None
                     } else if skip_target_materialize {
-                        if !target_membership
-                            .as_ref()
-                            .and_then(|membership| membership.get(&target_id))
-                            .copied()
-                            .unwrap_or(false)
-                        {
+                        if !match &target_membership {
+                            ExpandTargets::Membership(membership) => {
+                                membership.get(&target_id).copied().unwrap_or(false)
+                            }
+                            _ => false,
+                        } {
                             continue;
                         }
                         None
+                    } else if let ExpandTargets::Views(views) = &target_membership {
+                        // Single-hop labelled expansion: the hop's own
+                        // materialisation answers directly, so a large
+                        // fan-out no longer depends on cache retention.
+                        match views.get(&target_id) {
+                            Some(v) if target_labels.iter().all(|l| v.labels.contains(l)) => {
+                                Some(v.clone())
+                            }
+                            _ => continue,
+                        }
                     } else if let Some(label) = target_labels.first() {
                         if max > 1 {
                             match scan_node_for_id(snapshot, target_id).await? {

--- a/crates/namidb-query/src/optimize/pushdown.rs
+++ b/crates/namidb-query/src/optimize/pushdown.rs
@@ -8,7 +8,7 @@
 //! Distinct/TopN/write operators are barriers — pending predicates are
 //! materialised as a `Filter` above them rather than crossed.
 
-use std::collections::BTreeSet;
+use std::collections::{BTreeMap, BTreeSet};
 
 use super::parquet_pushdown::classify_pending_for_scan;
 use super::{and_chain, apply_filters, expression_aliases, produced_aliases, split_and_terms};
@@ -294,7 +294,18 @@ fn pushdown_at(plan: LogicalPlan, pending: Vec<Expression>) -> LogicalPlan {
             discard_input_bindings,
         } => {
             let preserved = identity_projection_aliases(&items);
-            let (pushable, stay) = partition_by_alias_subset(pending, &preserved);
+            let (mut pushable, stay) = partition_by_alias_subset(pending, &preserved);
+            // A WITH that RENAMES a property (`WITH v, p.cod_item AS c
+            // WHERE c = '…'`) used to strand the predicate above this
+            // Project, so the index anchor on `p` was never visible to
+            // unique_lookup / anchor_inversion and the plan degenerated to
+            // scanning the whole source label (fifth field report: a 160k
+            // scan where the in-pattern spelling of the SAME query anchors
+            // and finishes instantly). Substitute the alias back to its
+            // bound expression and push the rewritten conjunct down; the
+            // fixpoint loop then re-plans it as an anchored lookup.
+            let (substituted, stay) = partition_substitutable(stay, &items, distinct);
+            pushable.extend(substituted);
             let new_input = pushdown_at(*input, pushable);
             apply_filters(
                 LogicalPlan::Project {
@@ -595,6 +606,80 @@ fn partition_by_alias_subset(
     (pushable, stay)
 }
 
+/// Split predicates that can be pushed BELOW an aliasing projection by
+/// substituting each referenced alias with the expression the projection
+/// binds it to. Returns `(rewritten_pushable, stay)`.
+///
+/// Only pure property/variable bindings substitute: a computed alias could
+/// hide a function call whose evaluation count would change, and an
+/// aggregate cannot be evaluated below its own projection. A conjunct is
+/// pushed only when EVERY alias it references resolves, and no substituted
+/// expression mentions a name this projection rebinds (`WITH p.x AS p`
+/// means `p` below is a different value).
+fn partition_substitutable(
+    pending: Vec<Expression>,
+    items: &[crate::plan::logical::ProjectionItem],
+    distinct: bool,
+) -> (Vec<Expression>, Vec<Expression>) {
+    // A DISTINCT projection dedups before the filter; pushing a predicate
+    // below it would change how often a non-deterministic term is
+    // evaluated, so leave those alone.
+    if distinct {
+        return (Vec::new(), pending);
+    }
+    let mut substitutions: BTreeMap<String, Expression> = BTreeMap::new();
+    let mut rebound: BTreeSet<String> = BTreeSet::new();
+    for item in items {
+        let identity = matches!(
+            &item.expression.kind,
+            ExpressionKind::Variable(id) if id.name == item.alias
+        );
+        if !identity {
+            // This name means something different above than below.
+            rebound.insert(item.alias.clone());
+        }
+        if is_substitutable_projection(&item.expression) && !identity {
+            substitutions.insert(item.alias.clone(), item.expression.clone());
+        }
+    }
+    let preserved = identity_projection_aliases(items);
+    let keep_as_var = BTreeSet::new();
+    let mut pushable = Vec::new();
+    let mut stay = Vec::new();
+    for term in pending {
+        let refs = expression_aliases(&term);
+        let resolvable = refs
+            .iter()
+            .all(|alias| preserved.contains(alias) || substitutions.contains_key(alias));
+        if !resolvable {
+            stay.push(term);
+            continue;
+        }
+        let rewritten = crate::plan::lower::substitute_aliases(&term, &substitutions, &keep_as_var);
+        // The rewritten predicate must only mention names whose meaning is
+        // the same below this projection.
+        if expression_aliases(&rewritten)
+            .iter()
+            .any(|alias| rebound.contains(alias))
+        {
+            stay.push(term);
+            continue;
+        }
+        pushable.push(rewritten);
+    }
+    (pushable, stay)
+}
+
+/// A projection expression safe to evaluate below its own projection: a
+/// bare variable or a property access chain rooted at one.
+fn is_substitutable_projection(expr: &Expression) -> bool {
+    match &expr.kind {
+        ExpressionKind::Variable(_) => true,
+        ExpressionKind::Property(access) => is_substitutable_projection(&access.target),
+        _ => false,
+    }
+}
+
 fn identity_projection_aliases(items: &[crate::plan::logical::ProjectionItem]) -> BTreeSet<String> {
     let mut out = BTreeSet::new();
     for it in items {
@@ -892,8 +977,11 @@ mod tests {
     }
 
     #[test]
-    fn keeps_filter_above_project_when_alias_renamed() {
-        // Filter(x.age > 30) over Project [x=a] — `x` doesn't exist below.
+    fn pushes_filter_through_a_renaming_projection() {
+        // Filter(x.age > 30) over Project [x=a]: `WITH a AS x WHERE …` is
+        // the same query as filtering `a.age` below, so the predicate now
+        // substitutes the alias and sinks into the scan. Leaving it above
+        // stranded index anchors behind a WITH (sixth field report).
         let pred = binop(BinaryOp::Gt, prop("x", "age"), int(30));
         let plan = LogicalPlan::Filter {
             input: Box::new(LogicalPlan::Project {
@@ -908,8 +996,62 @@ mod tests {
             predicate: pred,
         };
         let optimized = predicate_pushdown(plan);
-        // Filter must remain on top because `x` is the projected name.
+        // The Project is now the root and the rewritten predicate lives
+        // below it (absorbed by the scan or as a Filter under the Project).
+        let LogicalPlan::Project { input, .. } = &optimized else {
+            panic!("expected Project at root, got {optimized:?}");
+        };
+        let rendered = format!("{input:?}");
+        assert!(
+            rendered.contains("\"a\"") && rendered.contains("age"),
+            "the alias must be substituted back to a.age below the Project: {rendered}"
+        );
+    }
+
+    #[test]
+    fn keeps_filter_above_project_for_a_computed_alias() {
+        // Filter(x > 30) over Project [x = a.age * 2]: a computed binding is
+        // deliberately NOT substituted — only pure variable/property
+        // bindings are, so the pass never duplicates arbitrary evaluation
+        // below its own projection.
+        let pred = binop(BinaryOp::Gt, var("x"), int(30));
+        let plan = LogicalPlan::Filter {
+            input: Box::new(LogicalPlan::Project {
+                input: Box::new(scan("Person", "a")),
+                items: vec![ProjectionItem {
+                    expression: binop(BinaryOp::Mul, prop("a", "age"), int(2)),
+                    alias: "x".into(),
+                }],
+                distinct: false,
+                discard_input_bindings: true,
+            }),
+            predicate: pred,
+        };
+        let optimized = predicate_pushdown(plan);
         assert!(matches!(optimized, LogicalPlan::Filter { .. }));
+    }
+
+    #[test]
+    fn keeps_filter_above_a_distinct_projection() {
+        // DISTINCT dedups before the filter; pushing below would change how
+        // often a non-deterministic term is evaluated, so the pass declines.
+        let pred = binop(BinaryOp::Gt, prop("x", "age"), int(30));
+        let plan = LogicalPlan::Filter {
+            input: Box::new(LogicalPlan::Project {
+                input: Box::new(scan("Person", "a")),
+                items: vec![ProjectionItem {
+                    expression: var("a"),
+                    alias: "x".into(),
+                }],
+                distinct: true,
+                discard_input_bindings: true,
+            }),
+            predicate: pred,
+        };
+        assert!(matches!(
+            predicate_pushdown(plan),
+            LogicalPlan::Filter { .. }
+        ));
     }
 
     #[test]

--- a/crates/namidb-query/src/plan/lower.rs
+++ b/crates/namidb-query/src/plan/lower.rs
@@ -1758,7 +1758,7 @@ fn lower_projection(
 /// rewritten) item expression. `keep_as_var` lists alias names that
 /// must be left as plain variables — typically because they are
 /// already materialised on the row (e.g. group keys after Aggregate).
-fn substitute_aliases(
+pub(crate) fn substitute_aliases(
     expr: &Expression,
     alias_map: &BTreeMap<String, Expression>,
     keep_as_var: &BTreeSet<String>,

--- a/crates/namidb-query/tests/exec_anchor_inversion.rs
+++ b/crates/namidb-query/tests/exec_anchor_inversion.rs
@@ -360,3 +360,139 @@ async fn disjunction_source_anchors_at_the_dated_target() {
         "{rows:?}"
     );
 }
+
+/// Fifth/sixth field report: `WITH v, p.cod_item AS c WHERE c = '…'` is the
+/// same query as the in-pattern spelling, but the alias hid the equality
+/// above a Project, so the anchor was never visible and the plan scanned
+/// the whole source label (the reporter's 160k-row scan that killed the
+/// process, while the in-pattern form finished instantly). The predicate
+/// must now substitute back through the projection, anchor, and return
+/// identical rows.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn with_alias_predicate_still_anchors_at_the_indexed_target() {
+    let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    let paths = NamespacePaths::new("tenants", NamespaceId::new("alias-anchor").unwrap());
+    let mut writer = WriterSession::open(store, paths).await.unwrap();
+
+    // 20 products; 200 sales spread over them and over 5 dates.
+    let mut productos = Vec::new();
+    for i in 0..20 {
+        let id = NodeId::new();
+        productos.push(id);
+        let mut props: BTreeMap<String, CoreValue> = BTreeMap::new();
+        props.insert("cod_item".into(), CoreValue::Str(format!("cod-{i}")));
+        writer
+            .upsert_node(
+                "PRODUCTO",
+                id,
+                &NodeWriteRecord {
+                    properties: props,
+                    schema_version: 1,
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+    }
+    let mut fechas = Vec::new();
+    for d in 0..5 {
+        let id = NodeId::new();
+        fechas.push(id);
+        let mut props: BTreeMap<String, CoreValue> = BTreeMap::new();
+        props.insert("fecha".into(), CoreValue::Str(format!("f{d}")));
+        writer
+            .upsert_node(
+                "FECHA",
+                id,
+                &NodeWriteRecord {
+                    properties: props,
+                    schema_version: 1,
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+    }
+    let edge = EdgeWriteRecord {
+        properties: BTreeMap::new(),
+        schema_version: 1,
+    };
+    for i in 0..200usize {
+        let v = NodeId::new();
+        let mut props: BTreeMap<String, CoreValue> = BTreeMap::new();
+        props.insert("venta_neta".into(), CoreValue::I64((i % 7) as i64 + 1));
+        writer
+            .upsert_node(
+                "VENTA",
+                v,
+                &NodeWriteRecord {
+                    properties: props,
+                    schema_version: 1,
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        writer
+            .upsert_edge("VENTA_DE_PRODUCTO", v, productos[i % 20], &edge)
+            .unwrap();
+        writer
+            .upsert_edge("VENTA_EN_FECHA", v, fechas[i % 5], &edge)
+            .unwrap();
+    }
+    writer.commit_batch().await.unwrap();
+    writer
+        .create_unique_constraint("PRODUCTO", "cod_item")
+        .await
+        .unwrap();
+    let schema = writer.snapshot().manifest().manifest.schema.clone();
+    writer.flush(schema).await.unwrap();
+
+    let snapshot = writer.snapshot();
+    let catalog = StatsCatalog::from_manifest(&snapshot.manifest().manifest);
+    let with_alias = "MATCH (v:VENTA)-[:VENTA_DE_PRODUCTO]->(p:PRODUCTO) \
+                      WITH v, p.cod_item AS c WHERE c = 'cod-3' \
+                      MATCH (v)-[:VENTA_EN_FECHA]->(f:FECHA) \
+                      RETURN f.fecha AS fecha, sum(v.venta_neta) AS total \
+                      ORDER BY fecha";
+    let in_pattern = "MATCH (v:VENTA)-[:VENTA_DE_PRODUCTO]->(p:PRODUCTO {cod_item: 'cod-3'}) \
+                      MATCH (v)-[:VENTA_EN_FECHA]->(f:FECHA) \
+                      RETURN f.fecha AS fecha, sum(v.venta_neta) AS total \
+                      ORDER BY fecha";
+
+    fn anchors_at_producto(plan: &LogicalPlan) -> bool {
+        matches!(
+            plan,
+            LogicalPlan::NodeByPropertyValue { label, .. } if label == "PRODUCTO"
+        ) || plan.children().into_iter().any(anchors_at_producto)
+    }
+    fn scans_ventas(plan: &LogicalPlan) -> bool {
+        matches!(
+            plan,
+            LogicalPlan::NodeScan { label: Some(l), .. } if l == "VENTA"
+        ) || plan.children().into_iter().any(scans_ventas)
+    }
+
+    let aliased_plan = optimize(lower(&parse(with_alias).unwrap()).unwrap(), &catalog);
+    assert!(
+        anchors_at_producto(&aliased_plan),
+        "the WITH-aliased predicate must anchor at PRODUCTO: {aliased_plan:?}"
+    );
+    assert!(
+        !scans_ventas(&aliased_plan),
+        "the whole-VENTA scan must be gone: {aliased_plan:?}"
+    );
+
+    // Same rows as the in-pattern spelling, which already anchored.
+    let rows_aliased = execute(&aliased_plan, &snapshot, &Params::new())
+        .await
+        .unwrap();
+    let pattern_plan = optimize(lower(&parse(in_pattern).unwrap()).unwrap(), &catalog);
+    let rows_pattern = execute(&pattern_plan, &snapshot, &Params::new())
+        .await
+        .unwrap();
+    let fmt = |rows: &[namidb_query::Row]| {
+        rows.iter()
+            .map(|r| format!("{:?}|{:?}", r.get("fecha"), r.get("total")))
+            .collect::<Vec<_>>()
+    };
+    assert_eq!(fmt(&rows_aliased), fmt(&rows_pattern));
+    assert!(!rows_aliased.is_empty());
+}

--- a/crates/namidb-server/src/lib.rs
+++ b/crates/namidb-server/src/lib.rs
@@ -222,6 +222,12 @@ pub struct Config {
     /// flush/compaction/recovery always wait as long as it takes.
     /// `Duration::ZERO` disables the bound.
     pub writer_lock_timeout: Duration,
+    /// Ceiling on a whole HTTP request (body read + handler). `None` derives
+    /// a default that can never truncate the configured query/write budgets;
+    /// `ZERO` disables the layer. An explicit value BELOW `query_timeout` or
+    /// `write_timeout` silently converts those 504/timeout outcomes into a
+    /// 408 at this ceiling, so boot warns about it.
+    pub http_request_timeout: Option<Duration>,
     /// PEM certificate-chain file enabling TLS on the HTTP and Bolt
     /// listeners. Must be set together with `tls_key`; when both are `None`
     /// the server serves plaintext.
@@ -705,11 +711,71 @@ pub fn build_router(state: AppState) -> Router {
 /// may run so a slow/stuck client cannot pin a task indefinitely; the
 /// concurrency limit caps total in-flight requests so slow connections cannot
 /// accumulate without bound and starve the server. Overridable via env.
+static HTTP_REQUEST_TIMEOUT: std::sync::OnceLock<Duration> = std::sync::OnceLock::new();
+
+/// Headroom the derived default leaves above the largest query budget, so a
+/// statement that legitimately runs to its own deadline reports ITS outcome
+/// (504 timeout / 200) instead of being cut by this outer ceiling (408).
+const HTTP_TIMEOUT_HEADROOM: Duration = Duration::from_secs(30);
+
+/// Baseline ceiling when nothing else is configured.
+const DEFAULT_HTTP_REQUEST_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// Resolve the HTTP request ceiling ONCE at boot, from the explicit setting
+/// when given, else derived so it never truncates the configured query and
+/// write budgets. Two overlapping deadlines returning different status codes
+/// (504 from ours, 408 from the outer layer) was a real field-report
+/// confusion: `--query-timeout 300s` still failed at 120s with a 408.
+pub(crate) fn resolve_http_request_timeout(config: &Config) -> Duration {
+    let explicit = config.http_request_timeout.or_else(|| {
+        std::env::var("NAMIDB_HTTP_REQUEST_TIMEOUT")
+            .ok()
+            .and_then(|s| humantime::parse_duration(&s).ok())
+    });
+    let resolved = match explicit {
+        Some(explicit) => {
+            for (name, budget) in [
+                ("--query-timeout", config.query_timeout),
+                ("--write-timeout", config.write_timeout),
+            ] {
+                if !explicit.is_zero() && budget > Duration::ZERO && explicit <= budget {
+                    warn!(
+                        http_request_timeout = ?explicit,
+                        budget_flag = name,
+                        budget = ?budget,
+                        "the HTTP request ceiling is at or below a query budget; \
+                         statements will be cut with 408 before their own timeout \
+                         reports 504 — raise --http-request-timeout"
+                    );
+                }
+            }
+            explicit
+        }
+        None => {
+            let largest = config.query_timeout.max(config.write_timeout);
+            if largest.is_zero() {
+                // Budgets disabled: keep the historical ceiling rather than
+                // deriving an unbounded one.
+                DEFAULT_HTTP_REQUEST_TIMEOUT
+            } else {
+                DEFAULT_HTTP_REQUEST_TIMEOUT.max(largest.saturating_add(HTTP_TIMEOUT_HEADROOM))
+            }
+        }
+    };
+    let _ = HTTP_REQUEST_TIMEOUT.set(resolved);
+    resolved
+}
+
 fn http_request_timeout() -> Duration {
+    if let Some(resolved) = HTTP_REQUEST_TIMEOUT.get() {
+        return *resolved;
+    }
+    // Router built outside `serve` (tests, embedded harnesses): keep the
+    // historical env-or-default behaviour.
     std::env::var("NAMIDB_HTTP_REQUEST_TIMEOUT")
         .ok()
         .and_then(|s| humantime::parse_duration(&s).ok())
-        .unwrap_or_else(|| Duration::from_secs(120))
+        .unwrap_or(DEFAULT_HTTP_REQUEST_TIMEOUT)
 }
 
 fn http_max_concurrency() -> usize {
@@ -729,9 +795,15 @@ fn timeout_router<S>(router: Router<S>) -> Router<S>
 where
     S: Clone + Send + Sync + 'static,
 {
+    let timeout = http_request_timeout();
+    if timeout.is_zero() {
+        // Explicitly disabled: the per-query and per-write deadlines remain
+        // the only bounds, and they report their own status codes.
+        return router;
+    }
     router.layer(tower_http::timeout::TimeoutLayer::with_status_code(
         axum::http::StatusCode::REQUEST_TIMEOUT,
-        http_request_timeout(),
+        timeout,
     ))
 }
 
@@ -890,6 +962,15 @@ pub async fn run_with_memory_max_bytes(
     if config.bolt_max_message_bytes == 0 {
         anyhow::bail!("NAMIDB_BOLT_MAX_MESSAGE_BYTES must be greater than zero");
     }
+    // Resolve the outer HTTP ceiling before any router is built, so it can be
+    // derived from (and never silently truncate) the query/write budgets.
+    let http_timeout = resolve_http_request_timeout(&config);
+    info!(
+        http_request_timeout = ?http_timeout,
+        query_timeout = ?config.query_timeout,
+        write_timeout = ?config.write_timeout,
+        "resolved request deadlines"
+    );
     // Resolve the auth configuration: a tokens file (with roles) wins, else a
     // single read-write `--auth-token`, else open.
     let auth = match (&config.auth_tokens_file, &config.auth_token) {
@@ -5247,6 +5328,7 @@ mod tests {
         Config {
             store_uri: format!("memory://{ns}"),
             listen: "127.0.0.1:0".parse().unwrap(),
+            http_request_timeout: None,
             auth_token: None,
             auth_tokens_file: None,
             auth_tokens_reload_interval: Duration::ZERO,
@@ -5625,6 +5707,61 @@ mod tests {
         )
         .await;
         assert_eq!(status, StatusCode::OK, "{body}");
+    }
+
+    /// Sixth field report: two deadlines used to overlap silently — a
+    /// `--query-timeout 300s` still died at 120s with a 408 from the outer
+    /// HTTP layer instead of its own 504. The derived default must always
+    /// clear the configured budgets, and an explicit value is honoured
+    /// (with a boot warning when it would truncate them).
+    #[test]
+    fn http_request_timeout_never_silently_truncates_query_budgets() {
+        let base = |query: Duration, write: Duration, explicit: Option<Duration>| {
+            let mut config = shutdown_test_config("http-timeout");
+            config.query_timeout = query;
+            config.write_timeout = write;
+            config.http_request_timeout = explicit;
+            config
+        };
+        // Derived: comfortably above the largest budget.
+        let derived = resolve_http_request_timeout(&base(
+            Duration::from_secs(300),
+            Duration::from_secs(60),
+            None,
+        ));
+        assert!(
+            derived > Duration::from_secs(300),
+            "a 300s query budget must not be cut by the outer layer, got {derived:?}"
+        );
+        // Small budgets keep the historical 120s floor.
+        assert_eq!(
+            resolve_http_request_timeout(&base(
+                Duration::from_secs(30),
+                Duration::from_secs(60),
+                None
+            )),
+            Duration::from_secs(120)
+        );
+        // Disabled budgets keep the floor too (not an unbounded ceiling).
+        assert_eq!(
+            resolve_http_request_timeout(&base(Duration::ZERO, Duration::ZERO, None)),
+            Duration::from_secs(120)
+        );
+        // Explicit wins, including the disable sentinel.
+        assert_eq!(
+            resolve_http_request_timeout(&base(
+                Duration::from_secs(30),
+                Duration::from_secs(60),
+                Some(Duration::from_secs(5))
+            )),
+            Duration::from_secs(5)
+        );
+        assert!(resolve_http_request_timeout(&base(
+            Duration::from_secs(30),
+            Duration::from_secs(60),
+            Some(Duration::ZERO)
+        ))
+        .is_zero());
     }
 
     /// Item 59: the group-commit waiter is bounded by the write deadline —

--- a/crates/namidb-server/src/main.rs
+++ b/crates/namidb-server/src/main.rs
@@ -323,6 +323,19 @@ struct Cli {
     )]
     writer_lock_timeout: Duration,
 
+    /// Ceiling on a whole HTTP request (body read + handler), returning 408.
+    /// Unset derives a value that can never truncate `--query-timeout` /
+    /// `--write-timeout` (their own deadlines report 504 instead); `0s`
+    /// disables this outer layer entirely. Setting it AT OR BELOW either
+    /// budget is accepted but warns at boot: statements would be cut here
+    /// with 408 before their own timeout could report 504.
+    #[arg(
+        long,
+        env = "NAMIDB_HTTP_REQUEST_TIMEOUT",
+        value_parser = humantime::parse_duration,
+    )]
+    http_request_timeout: Option<Duration>,
+
     /// PEM certificate-chain file. Set together with `--tls-key` to serve the
     /// HTTP and Bolt listeners over TLS; omit both to serve plaintext.
     #[arg(long, env = "NAMIDB_TLS_CERT")]
@@ -433,6 +446,7 @@ fn main() -> anyhow::Result<()> {
         memtable_flush_bytes: cli.memtable_flush_bytes,
         memtable_stall_bytes: cli.memtable_stall_bytes,
         writer_lock_timeout: cli.writer_lock_timeout,
+        http_request_timeout: cli.http_request_timeout,
         tls_cert: cli.tls_cert,
         tls_key: cli.tls_key,
         slow_query_threshold: cli.slow_query_threshold,

--- a/crates/namidb-server/tests/bolt_integration.rs
+++ b/crates/namidb-server/tests/bolt_integration.rs
@@ -193,6 +193,7 @@ async fn boot_bolt_grouped(ns: &str) -> (std::net::SocketAddr, tokio::task::Join
         default_namespace: ns.to_string(),
         max_namespaces: 100,
         namespace_idle_timeout: Duration::from_secs(3600),
+        http_request_timeout: None,
     };
     let task = tokio::spawn(async move {
         if let Err(e) = namidb_server::run(config).await {
@@ -306,6 +307,7 @@ async fn boot_bolt_multi(
         max_namespaces: 100,
         namespace_idle_timeout: Duration::from_secs(3600),
         auth_tokens_reload_interval: std::time::Duration::ZERO,
+        http_request_timeout: None,
     };
     let task = tokio::spawn(async move {
         if let Err(e) = namidb_server::run(config).await {
@@ -671,6 +673,7 @@ async fn boot_bolt_config(
         default_namespace: ns.to_string(),
         max_namespaces: 100,
         namespace_idle_timeout: Duration::from_secs(3600),
+        http_request_timeout: None,
     };
     let task = tokio::spawn(async move {
         if let Err(e) = namidb_server::run(config).await {
@@ -738,6 +741,7 @@ async fn boot_bolt_tokens(
         max_namespaces: 100,
         namespace_idle_timeout: Duration::from_secs(3600),
         auth_tokens_reload_interval: std::time::Duration::ZERO,
+        http_request_timeout: None,
     };
     let task = tokio::spawn(async move {
         if let Err(e) = namidb_server::run(config).await {
@@ -994,6 +998,7 @@ async fn bolt_create_then_match_roundtrip() {
         default_namespace: "bolt-test".to_string(),
         max_namespaces: 100,
         namespace_idle_timeout: Duration::from_secs(3600),
+        http_request_timeout: None,
     };
 
     let server_task = tokio::spawn(async move {
@@ -1088,6 +1093,7 @@ async fn bolt_bad_token_yields_failure() {
         default_namespace: "bolt-bad-auth".to_string(),
         max_namespaces: 100,
         namespace_idle_timeout: Duration::from_secs(3600),
+        http_request_timeout: None,
     };
 
     let server_task = tokio::spawn(async move {
@@ -1260,6 +1266,7 @@ async fn bolt_memgraph_introspection_populates_schema() {
         default_namespace: "bolt-introspect".to_string(),
         max_namespaces: 100,
         namespace_idle_timeout: Duration::from_secs(3600),
+        http_request_timeout: None,
     };
     let server_task = tokio::spawn(async move {
         let _ = namidb_server::run(config).await;

--- a/crates/namidb-server/tests/ddl_index_backfill.rs
+++ b/crates/namidb-server/tests/ddl_index_backfill.rs
@@ -59,6 +59,7 @@ async fn boot(store_uri: String) -> String {
         default_namespace: NS.to_string(),
         max_namespaces: 100,
         namespace_idle_timeout: Duration::from_secs(3600),
+        http_request_timeout: None,
     };
     tokio::spawn(async move {
         if let Err(e) = namidb_server::run(config).await {

--- a/crates/namidb-server/tests/disk_full_degraded.rs
+++ b/crates/namidb-server/tests/disk_full_degraded.rs
@@ -62,6 +62,7 @@ async fn boot() -> String {
         default_namespace: NS.to_string(),
         max_namespaces: 100,
         namespace_idle_timeout: Duration::from_secs(3600),
+        http_request_timeout: None,
     };
     tokio::spawn(async move {
         if let Err(e) = namidb_server::run(config).await {

--- a/crates/namidb-server/tests/explain_surface.rs
+++ b/crates/namidb-server/tests/explain_surface.rs
@@ -51,6 +51,7 @@ async fn boot() -> String {
         default_namespace: NS.to_string(),
         max_namespaces: 100,
         namespace_idle_timeout: Duration::from_secs(3600),
+        http_request_timeout: None,
     };
     tokio::spawn(async move {
         if let Err(e) = namidb_server::run(config).await {

--- a/crates/namidb-server/tests/scan_gate.rs
+++ b/crates/namidb-server/tests/scan_gate.rs
@@ -53,6 +53,7 @@ async fn boot() -> String {
         default_namespace: NS.to_string(),
         max_namespaces: 100,
         namespace_idle_timeout: Duration::from_secs(3600),
+        http_request_timeout: None,
     };
     tokio::spawn(async move {
         if let Err(e) = namidb_server::run(config).await {

--- a/crates/namidb-server/tests/startup_validation.rs
+++ b/crates/namidb-server/tests/startup_validation.rs
@@ -43,6 +43,7 @@ fn base_config(ns: &str) -> namidb_server::Config {
         default_namespace: ns.to_string(),
         max_namespaces: 100,
         namespace_idle_timeout: Duration::from_secs(3600),
+        http_request_timeout: None,
     }
 }
 

--- a/crates/namidb-server/tests/tls_integration.rs
+++ b/crates/namidb-server/tests/tls_integration.rs
@@ -94,6 +94,7 @@ async fn serves_https_and_bolt_over_tls() {
         default_namespace: "tls-it".to_string(),
         max_namespaces: 100,
         namespace_idle_timeout: Duration::from_secs(3600),
+        http_request_timeout: None,
     };
     let task = tokio::spawn(async move {
         let _ = namidb_server::run(config).await;

--- a/crates/namidb-storage/src/read.rs
+++ b/crates/namidb-storage/src/read.rs
@@ -3797,12 +3797,40 @@ impl<'mt> Snapshot<'mt> {
     /// attached) so already-resolved ids skip the SST scan entirely.
     /// Fresh resolutions populate L1 and L2 on the way out.
     #[instrument(skip(self, ids), fields(label = label, ids_len = ids.len()))]
+    /// Batched point lookups, CHUNKED so peak memory is proportional to the
+    /// chunk rather than the whole id list. Every intermediate inside the
+    /// inner pass (per-id output map, pending sets, decoded winners, and the
+    /// three live copies each view briefly has on its way to the caches) is
+    /// sized to the batch, so one hop over a 53k-degree endpoint set used to
+    /// allocate hundreds of megabytes at once — a step change in RSS that a
+    /// memory-capped container did not survive (sixth field report). Results
+    /// keep the caller's order: chunks are contiguous slices concatenated in
+    /// order.
     pub async fn batch_lookup_nodes(
         &self,
         label: &str,
         ids: &[NodeId],
     ) -> Result<Vec<Option<NodeView>>> {
         namidb_core::profile_scope!("Snapshot::batch_lookup_nodes");
+        if ids.is_empty() {
+            return Ok(Vec::new());
+        }
+        let chunk = batch_lookup_chunk_size();
+        if ids.len() > chunk {
+            let mut out = Vec::with_capacity(ids.len());
+            for slice in ids.chunks(chunk) {
+                out.extend(self.batch_lookup_nodes_chunk(label, slice).await?);
+            }
+            return Ok(out);
+        }
+        self.batch_lookup_nodes_chunk(label, ids).await
+    }
+
+    async fn batch_lookup_nodes_chunk(
+        &self,
+        label: &str,
+        ids: &[NodeId],
+    ) -> Result<Vec<Option<NodeView>>> {
         if ids.is_empty() {
             return Ok(Vec::new());
         }
@@ -9484,6 +9512,17 @@ fn equality_sidecar_key(
             _ => None,
         },
     }
+}
+
+/// Ids resolved per inner batch pass. Large enough that the batched
+/// row-group and locator reads keep their vectorised advantage, small
+/// enough that peak transient memory stays bounded regardless of fan-out.
+fn batch_lookup_chunk_size() -> usize {
+    std::env::var("NAMIDB_BATCH_LOOKUP_CHUNK")
+        .ok()
+        .and_then(|raw| raw.parse::<usize>().ok())
+        .filter(|&n| n > 0)
+        .unwrap_or(8192)
 }
 
 /// Conservative overlap test for descriptor key ranges. Invalid/reversed

--- a/crates/namidb-storage/tests/batch_multi_and_topology.rs
+++ b/crates/namidb-storage/tests/batch_multi_and_topology.rs
@@ -262,3 +262,62 @@ async fn topology_fallback_matches_property_route_partners_without_hydration() {
     expected.sort();
     assert_eq!(slim_partners, expected, "tombstone dropped, delta included");
 }
+
+/// Sixth field report: `batch_lookup_nodes` sized every intermediate to the
+/// WHOLE id list, so one hop over a 53k-degree endpoint set allocated
+/// hundreds of megabytes at once. It now resolves in chunks — with the
+/// caller's order, duplicates, and misses preserved exactly.
+#[tokio::test]
+async fn batch_lookup_nodes_chunks_without_changing_results() {
+    std::env::set_var("NAMIDB_BATCH_LOOKUP_CHUNK", "7");
+    let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    let paths = NamespacePaths::new("tenants", NamespaceId::new("chunked").unwrap());
+    let mut w = WriterSession::open(store, paths).await.unwrap();
+
+    let mut ids = Vec::new();
+    for seq in 0..40i64 {
+        let id = NodeId::new();
+        ids.push(id);
+        w.upsert_node("Person", id, &person("team", seq)).unwrap();
+    }
+    w.commit_batch().await.unwrap();
+    let schema = w.snapshot().manifest().manifest.schema.clone();
+    w.flush(schema).await.unwrap();
+    let missing = NodeId::new();
+
+    // Interleave duplicates and a miss across several chunk boundaries.
+    let mut probe: Vec<NodeId> = Vec::new();
+    for (i, id) in ids.iter().enumerate() {
+        probe.push(*id);
+        if i % 5 == 0 {
+            probe.push(*id);
+        }
+        if i % 11 == 0 {
+            probe.push(missing);
+        }
+    }
+    let snap = w.snapshot();
+    let views = snap.batch_lookup_nodes("Person", &probe).await.unwrap();
+    assert_eq!(views.len(), probe.len(), "one slot per requested id");
+    for (requested, view) in probe.iter().zip(&views) {
+        if *requested == missing {
+            assert!(view.is_none(), "a missing id stays None in its own slot");
+        } else {
+            assert_eq!(
+                view.as_ref().map(|v| v.id),
+                Some(*requested),
+                "each slot must hold ITS id"
+            );
+        }
+    }
+    // The chunked result equals the single-pass result.
+    std::env::set_var("NAMIDB_BATCH_LOOKUP_CHUNK", "100000");
+    let single = snap.batch_lookup_nodes("Person", &probe).await.unwrap();
+    let ids_of = |vs: &[Option<namidb_storage::NodeView>]| {
+        vs.iter()
+            .map(|v| v.as_ref().map(|v| v.id))
+            .collect::<Vec<_>>()
+    };
+    assert_eq!(ids_of(&views), ids_of(&single));
+    std::env::remove_var("NAMIDB_BATCH_LOOKUP_CHUNK");
+}

--- a/docs/testing/25tb-readiness.md
+++ b/docs/testing/25tb-readiness.md
@@ -1062,3 +1062,51 @@ that expansion — the one pathology behind all four sightings (items
 node prewarm, batched non-unique lookups; item 61/64's fixes for the
 death mode). Their 52s ≈ 53k x ~1ms is the pre-#168 arithmetic once
 more.
+
+## Sixth field report (2026-09-09, second batch) — items 70-72
+
+### 70. [CONFIRMED — fixed in 2.6.2] WITH-renamed predicate strands the index anchor
+
+Reported as "the planner chooses badly in this concrete shape", and that
+is exactly right. Reproduced with EXPLAIN on the published 2.6.1 image:
+`... WITH v, p.cod_item AS c WHERE c = '…' ...` plans
+`Aggregate <- Expand(v->f) <- Filter(c=…) <- Project[c=p.cod_item] <-
+Expand(v->p) <- NodeScan(VENTA)` — a full scan of the 160k-row label —
+while the identical query with the equality inside the pattern plans
+`NodeByPropertyValue(PRODUCTO) -> reverse Expand`. Nothing substituted
+the alias back, so neither unique_lookup nor anchor_inversion ever saw
+an anchorable equality. Fixed in predicate pushdown: aliases bound to
+pure variable/property expressions are substituted and the rewritten
+conjunct pushed below the projection (computed aliases and DISTINCT
+projections excluded); the optimizer's fixpoint loop then re-plans it as
+an anchored lookup.
+
+### 71. [CORRECTED — fixed in 2.6.2] The reverse-expansion cliff is a node-cache capacity boundary, not a CSR budget
+
+Reported: degree 3,871 instant, degree ~53,000 fatal, "not gradual",
+even with adjacency enabled. The CSR theory is refuted — the CSR is per
+(edge_type, direction) for the WHOLE type, so it is either retained for
+both probes or neither. The real step function: the hop prewarms every
+distinct endpoint via one `batch_lookup_nodes` and then re-reads each
+endpoint through the shared NodeViewCache, whose eviction is FIFO; once
+the endpoint set outgrows that cache the prewarm evicts its own earliest
+entries before the consumer reaches them, so the hit rate collapses from
+~100% to ~0% and the fallback is N sequential cold point reads. Verified
+in the field: enabling NAMIDB_ADJACENCY adds a 512 MiB request to the
+proportional split and SHRANK the node cache from 86 MiB to 73.8 MiB at
+the same cap — the cliff arrives earlier with the CSR on, exactly as
+reported. Fixes: single-hop labelled expands consume their own
+materialisation (no cache dependency; budgeted), batch_lookup_nodes is
+chunked (peak memory no longer scales with fan-out), and the dead
+frontier clone on single-hop expands is gone. Recorded, deferred: the
+row cap still counts rows, not bytes (item 64), and multi-hop traversals
+keep the per-edge path because the batch is label-scoped.
+
+### 72. [CONFIRMED — fixed in 2.6.2] Two overlapping request deadlines with different status codes
+
+`--query-timeout 60s` failed at 62s with 504 (ours, correct);
+`--query-timeout 300s` failed at 120s with 408 — the outer HTTP
+TimeoutLayer, whose only knob was an undocumented env var. Now a real
+flag (`--http-request-timeout`, `0s` disables) whose default is derived
+to clear the largest configured query/write budget, with a boot warning
+when an explicit value would truncate them.


### PR DESCRIPTION
Three findings, each reproduced against the published 2.6.1 image before fixing.

**Item 70 — the planner did choose badly for one shape (confirmed).** `EXPLAIN` of the reporter's query shows a full scan of the 160k-row label: the equality sits above a `Project` that renames the property (`WITH v, p.cod_item AS c WHERE c = '…'`), so no anchor is visible; the identical query with the equality inside the pattern anchors at PRODUCTO. Predicate pushdown now substitutes aliases bound to pure variable/property expressions and pushes the rewritten conjunct below the projection — the fixpoint loop then plans the anchored lookup. Computed aliases and DISTINCT projections stay above by design.

**Item 71 — the cliff, mechanism corrected.** Not the CSR budget (that cache is per edge type — it cannot be retained for a 3.9k probe and refused for a 53k one). The hop prewarmed every endpoint and re-read each through the shared node cache, whose eviction is **FIFO**: once the endpoint set outgrew the cache the prewarm evicted its own earliest entries before the consumer reached them → hit rate ~0% → tens of thousands of sequential cold reads. Confirmed in the field that enabling `NAMIDB_ADJACENCY` shrinks the node cache (86 MiB → 73.8 MiB at the same cap), so the cliff arrives *earlier* with the CSR on. Fixes: single-hop labelled expands consume their own materialisation (budgeted); `batch_lookup_nodes` is chunked so peak memory stops scaling with fan-out; the dead frontier clone on single-hop expands is gone.

**Item 72 — overlapping deadlines.** The outer HTTP ceiling had no flag and could sit below `--query-timeout` (300s configured → 408 at 120s instead of 504). Now `--http-request-timeout` (`0s` disables) with a derived default that clears the largest configured budget, and a boot warning when an explicit value would truncate it.

Gate: query 36, storage 25, server/cli/mcp 17, remaining crates 15 suites green; clippy; fmt.
