### PR TITLE
Unlabelled expand targets no longer read one node per edge (2.6.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,25 @@ crates.io release will establish and document that API explicitly.
 
 ## [Unreleased]
 
+## [2.6.4] - 2026-09-10
+
+### Fixed
+
+- **An expand whose target carries no label no longer reads one node per
+  edge.** The 2.6.2 fan-out fix let a single hop consume its own prewarmed
+  batch instead of re-reading each endpoint through the shared node cache,
+  but it was gated on the target being labelled — so `(a)-[:R]->(x)` and
+  `(a)-[:R]->()`, among the most common patterns in Cypher, kept the old
+  per-edge path. On a 197k-degree hub the unlabelled and anonymous forms
+  timed out at 300s where the labelled form took 3.5s; all three now cost
+  about 2.8s and return the same rows. `batch_lookup_nodes` resolves ids
+  across every node descriptor and uses its label argument only to
+  namespace cache keys, so an empty label is a complete id-primary batch.
+- A batch miss during expansion now falls back to the authoritative point
+  reader instead of skipping the edge, so a batch that under-reports can
+  no longer drop rows silently.
+
+
 ## [2.6.3] - 2026-09-09
 
 ### Added
@@ -3173,7 +3192,8 @@ Change License: Apache License 2.0).
 - LDBC-shaped synthetic benchmark harness with a paired Kùzu runner
   under [`bench/`](./bench/).
 
-[Unreleased]: https://github.com/namidb/namidb/compare/v2.6.3...HEAD
+[Unreleased]: https://github.com/namidb/namidb/compare/v2.6.4...HEAD
+[2.6.4]: https://github.com/namidb/namidb/compare/v2.6.3...v2.6.4
 [2.6.3]: https://github.com/namidb/namidb/compare/v2.6.2...v2.6.3
 [2.6.2]: https://github.com/namidb/namidb/compare/v2.6.1...v2.6.2
 [2.6.1]: https://github.com/namidb/namidb/compare/v2.6.0...v2.6.1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2199,7 +2199,7 @@ dependencies = [
 
 [[package]]
 name = "namidb"
-version = "2.6.3"
+version = "2.6.4"
 dependencies = [
  "namidb-core",
  "namidb-graph",
@@ -2209,7 +2209,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-ann"
-version = "2.6.3"
+version = "2.6.4"
 dependencies = [
  "namidb-core",
  "rand 0.8.6",
@@ -2222,7 +2222,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-bench"
-version = "2.6.3"
+version = "2.6.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2246,7 +2246,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-bolt"
-version = "2.6.3"
+version = "2.6.4"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2266,7 +2266,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-cli"
-version = "2.6.3"
+version = "2.6.4"
 dependencies = [
  "anyhow",
  "clap",
@@ -2286,7 +2286,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-core"
-version = "2.6.3"
+version = "2.6.4"
 dependencies = [
  "arrow-array",
  "arrow-schema",
@@ -2302,7 +2302,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-graph"
-version = "2.6.3"
+version = "2.6.4"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -2324,7 +2324,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-markdown"
-version = "2.6.3"
+version = "2.6.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2347,7 +2347,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-mcp"
-version = "2.6.3"
+version = "2.6.4"
 dependencies = [
  "anyhow",
  "clap",
@@ -2367,7 +2367,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-py"
-version = "2.6.3"
+version = "2.6.4"
 dependencies = [
  "bytes",
  "chrono",
@@ -2385,7 +2385,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-query"
-version = "2.6.3"
+version = "2.6.4"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2409,7 +2409,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-server"
-version = "2.6.3"
+version = "2.6.4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2449,7 +2449,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-storage"
-version = "2.6.3"
+version = "2.6.4"
 dependencies = [
  "anyhow",
  "arrow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2.6.3"
+version = "2.6.4"
 edition = "2021"
 rust-version = "1.85"
 license = "BUSL-1.1"
@@ -123,13 +123,13 @@ tower = { version = "0.5", features = ["limit"] }
 tower-http = { version = "0.6", features = ["trace", "cors", "timeout"] }
 
 # Local workspace crates
-namidb-core = { path = "crates/namidb-core", version = "2.6.3" }
-namidb-storage = { path = "crates/namidb-storage", version = "2.6.3" }
-namidb-markdown = { path = "crates/namidb-markdown", version = "2.6.3" }
-namidb-graph = { path = "crates/namidb-graph", version = "2.6.3" }
-namidb-ann = { path = "crates/namidb-ann", version = "2.6.3" }
-namidb-query = { path = "crates/namidb-query", version = "2.6.3" }
-namidb-bolt = { path = "crates/namidb-bolt", version = "2.6.3" }
+namidb-core = { path = "crates/namidb-core", version = "2.6.4" }
+namidb-storage = { path = "crates/namidb-storage", version = "2.6.4" }
+namidb-markdown = { path = "crates/namidb-markdown", version = "2.6.4" }
+namidb-graph = { path = "crates/namidb-graph", version = "2.6.4" }
+namidb-ann = { path = "crates/namidb-ann", version = "2.6.4" }
+namidb-query = { path = "crates/namidb-query", version = "2.6.4" }
+namidb-bolt = { path = "crates/namidb-bolt", version = "2.6.4" }
 
 [profile.release]
 opt-level = 3

--- a/crates/namidb-py/pyproject.toml
+++ b/crates/namidb-py/pyproject.toml
@@ -7,7 +7,7 @@ name = "namidb"
 # Keep in sync with the workspace `version` in /Cargo.toml.
 # `python-wheels.yml` publishes a wheel whose filename uses THIS
 # version; the release tag `py-vX.Y.Z` must match X.Y.Z exactly.
-version = "2.6.3"
+version = "2.6.4"
 description = "Cloud-native graph database on object storage (Python bindings)"
 readme = "README.md"
 license = "BUSL-1.1"

--- a/crates/namidb-query/src/exec/walker.rs
+++ b/crates/namidb-query/src/exec/walker.rs
@@ -1810,7 +1810,7 @@ pub(crate) async fn execute_expand(
                 target_labels,
                 &unique_targets,
                 skip_target_materialize,
-                max == 1 && !target_labels.is_empty(),
+                max == 1,
             )
             .await?;
             for (step, neighbours) in step_neighbours {
@@ -1893,14 +1893,27 @@ pub(crate) async fn execute_expand(
                         }
                         None
                     } else if let ExpandTargets::Views(views) = &target_membership {
-                        // Single-hop labelled expansion: the hop's own
-                        // materialisation answers directly, so a large
+                        // Single-hop expansion, labelled or not: the hop's
+                        // own materialisation answers directly, so a large
                         // fan-out no longer depends on cache retention.
                         match views.get(&target_id) {
-                            Some(v) if target_labels.iter().all(|l| v.labels.contains(l)) => {
-                                Some(v.clone())
+                            Some(v) => {
+                                if target_labels.iter().all(|l| v.labels.contains(l)) {
+                                    Some(v.clone())
+                                } else {
+                                    continue;
+                                }
                             }
-                            _ => continue,
+                            // Absent from the batch is NOT absent from the
+                            // graph: fall back to the authoritative point
+                            // reader so a batch that under-reports can never
+                            // drop a real row.
+                            None => match scan_node_for_id(snapshot, target_id).await? {
+                                Some(v) if target_labels.iter().all(|l| v.labels.contains(l)) => {
+                                    Some(v)
+                                }
+                                _ => continue,
+                            },
                         }
                     } else if let Some(label) = target_labels.first() {
                         if max > 1 {
@@ -6522,10 +6535,12 @@ async fn prepare_expand_targets(
         ));
     }
 
+    // `batch_lookup_nodes` resolves by id across every node descriptor; the
+    // label only namespaces its cache keys, so an EMPTY label is a complete
+    // id-primary batch, not a miss. Only a SINGLE-HOP expansion may consume
+    // it directly: a variable-length traversal must be able to walk THROUGH
+    // nodes this batch does not describe.
     let label = target_labels.first().map_or("", String::as_str);
-    // Only a SINGLE-HOP labelled expansion may consume the batch directly:
-    // the batch is label-scoped, while a variable-length traversal must be
-    // able to walk THROUGH nodes carrying other labels.
     if !views_usable || unique_targets.len() > expand_target_view_budget() {
         let _ = snapshot.batch_lookup_nodes(label, unique_targets).await?;
         return Ok(ExpandTargets::Cold);
@@ -8686,7 +8701,7 @@ async fn execute_expand_factor(
                 target_labels,
                 &unique_targets,
                 skip_target_materialize,
-                max == 1 && !target_labels.is_empty(),
+                max == 1,
             )
             .await?;
             for ((cur_parent, tail, rels), neighbours) in step_neighbours {
@@ -8731,14 +8746,27 @@ async fn execute_expand_factor(
                         }
                         None
                     } else if let ExpandTargets::Views(views) = &target_membership {
-                        // Single-hop labelled expansion: the hop's own
-                        // materialisation answers directly, so a large
+                        // Single-hop expansion, labelled or not: the hop's
+                        // own materialisation answers directly, so a large
                         // fan-out no longer depends on cache retention.
                         match views.get(&target_id) {
-                            Some(v) if target_labels.iter().all(|l| v.labels.contains(l)) => {
-                                Some(v.clone())
+                            Some(v) => {
+                                if target_labels.iter().all(|l| v.labels.contains(l)) {
+                                    Some(v.clone())
+                                } else {
+                                    continue;
+                                }
                             }
-                            _ => continue,
+                            // Absent from the batch is NOT absent from the
+                            // graph: fall back to the authoritative point
+                            // reader so a batch that under-reports can never
+                            // drop a real row.
+                            None => match scan_node_for_id(snapshot, target_id).await? {
+                                Some(v) if target_labels.iter().all(|l| v.labels.contains(l)) => {
+                                    Some(v)
+                                }
+                                _ => continue,
+                            },
                         }
                     } else if let Some(label) = target_labels.first() {
                         if max > 1 {

--- a/crates/namidb-query/tests/exec_supernode.rs
+++ b/crates/namidb-query/tests/exec_supernode.rs
@@ -190,10 +190,9 @@ async fn unlabelled_and_anonymous_hub_targets_match_the_labelled_form() {
     // The unlabelled binding must still carry real property values, so the
     // batch cannot be answering with id-only stubs.
     let snapshot = writer.snapshot();
-    let parsed = parse(
-        "MATCH (h:Person {name: 'hub'})-[:KNOWS]->(x) RETURN x.name AS n ORDER BY n LIMIT 3",
-    )
-    .unwrap();
+    let parsed =
+        parse("MATCH (h:Person {name: 'hub'})-[:KNOWS]->(x) RETURN x.name AS n ORDER BY n LIMIT 3")
+            .unwrap();
     let plan = lower(&parsed).unwrap();
     let rows = namidb_query::execute(&plan, &snapshot, &Params::new())
         .await
@@ -208,4 +207,3 @@ async fn unlabelled_and_anonymous_hub_targets_match_the_labelled_form() {
         }
     }
 }
-

--- a/crates/namidb-query/tests/exec_supernode.rs
+++ b/crates/namidb-query/tests/exec_supernode.rs
@@ -131,3 +131,81 @@ async fn traversals_cross_a_flushed_supernode_exactly() {
     .await;
     assert_eq!(total, (FANOUT + FANIN + 1) as i64);
 }
+
+/// A hub expansion whose target carries NO label must cost the same as a
+/// labelled one and return the same rows.
+///
+/// The 2.6.2 fan-out fix let a single hop consume its own prewarmed batch
+/// instead of re-reading each endpoint through the shared FIFO node cache,
+/// but it was gated on the target being labelled. An unlabelled or anonymous
+/// target — `(a)-[:R]->()`, one of the most common patterns in Cypher — fell
+/// back to one authoritative point read PER EDGE. Measured on a 197k-degree
+/// hub: 3.5s labelled versus a 300s timeout unlabelled, for the same answer.
+/// The batch resolves by id across every node descriptor, so an empty label
+/// is a complete id-primary batch rather than a miss.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn unlabelled_and_anonymous_hub_targets_match_the_labelled_form() {
+    let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    let paths = NamespacePaths::new("tenants", NamespaceId::new("exec-unlabelled").unwrap());
+    let mut writer = WriterSession::open(store, paths).await.unwrap();
+
+    let hub = NodeId::new();
+    writer.upsert_node("Person", hub, &person("hub")).unwrap();
+    for ordinal in 0..FANOUT {
+        let spoke = NodeId::new();
+        writer
+            .upsert_node("Person", spoke, &person(&format!("out-{ordinal}")))
+            .unwrap();
+        writer.upsert_edge("KNOWS", hub, spoke, &edge()).unwrap();
+    }
+    writer.commit_batch().await.unwrap();
+    writer.flush(schema()).await.unwrap();
+
+    // All three spellings describe the same set of edges.
+    let labelled = count_value(
+        &writer,
+        "MATCH (h:Person {name: 'hub'})-[:KNOWS]->(x:Person) RETURN count(*) AS c",
+    )
+    .await;
+    let unlabelled = count_value(
+        &writer,
+        "MATCH (h:Person {name: 'hub'})-[:KNOWS]->(x) RETURN count(*) AS c",
+    )
+    .await;
+    let anonymous = count_value(
+        &writer,
+        "MATCH (h:Person {name: 'hub'})-[:KNOWS]->() RETURN count(*) AS c",
+    )
+    .await;
+    assert_eq!(labelled, FANOUT as i64);
+    assert_eq!(
+        unlabelled, labelled,
+        "an unlabelled target must not change the result"
+    );
+    assert_eq!(
+        anonymous, labelled,
+        "an anonymous target must not change the result"
+    );
+
+    // The unlabelled binding must still carry real property values, so the
+    // batch cannot be answering with id-only stubs.
+    let snapshot = writer.snapshot();
+    let parsed = parse(
+        "MATCH (h:Person {name: 'hub'})-[:KNOWS]->(x) RETURN x.name AS n ORDER BY n LIMIT 3",
+    )
+    .unwrap();
+    let plan = lower(&parsed).unwrap();
+    let rows = namidb_query::execute(&plan, &snapshot, &Params::new())
+        .await
+        .unwrap();
+    assert_eq!(rows.len(), 3);
+    for row in &rows {
+        match row.bindings.get("n") {
+            Some(RuntimeValue::String(name)) => {
+                assert!(name.starts_with("out-"), "unexpected spoke name {name}")
+            }
+            other => panic!("unlabelled target lost its properties: {other:?}"),
+        }
+    }
+}
+


### PR DESCRIPTION
## The bug

2.6.2 fixed the fan-out cliff by letting a single hop consume its own prewarmed batch instead of re-reading every endpoint through the shared FIFO node cache. That fix was gated on the target carrying a **label**.

So these kept the old path — one authoritative point read per edge:

```cypher
MATCH (a)-[:R]->(x)     -- bound, unlabelled
MATCH (a)-[:R]->()      -- anonymous
```

Measured on a 197k-degree hub with ~1 KB targets, all three spellings returning the same 197,000 rows:

| pattern | before | after |
|---|---|---|
| `-[:TIENE]->(t:FAT)` | 3.47 s | 3.09 s |
| `-[:TIENE]->(t)` | **timed out at 300 s** | **2.93 s** |
| `-[:TIENE]->()` | **timed out at 300 s** | **2.76 s** |

## Why the gate was wrong

`batch_lookup_nodes` iterates `manifest.index.node_descriptors()` — it resolves by **id across every node descriptor** and uses its `label` argument only to namespace cache keys. An empty label is a complete id-primary batch, not a miss.

The old code demonstrated this against itself: it called the batch with the empty label, threw the result away with `let _ = …`, and then did the per-edge point reads anyway.

Only `max == 1` still gates the batch, which is the real constraint: a variable-length traversal must be able to walk **through** nodes the batch does not describe. That half of the gate is what fixed the three var-length regressions in 2.6.2 and is unchanged.

## A second, quieter defect

The `Views` arm collapsed two different outcomes into one `continue`:

```rust
Some(v) if labels_ok => Some(v.clone()),
_ => continue,          // "absent from batch" AND "wrong label"
```

"Absent from the batch" is not "absent from the graph". A batch that under-reported for any reason would drop real rows with no error. The two cases are now distinct, and an absent id falls back to the authoritative point reader.

## Why it survived the release that fixed its twin

Nothing in the suite expanded a hub through an unlabelled target. The new test in `exec_supernode.rs` asserts all three spellings agree, and that the unlabelled binding still carries real property values rather than id-only stubs.

## Verification

- `namidb-query`: 558 lib tests, plus `exec_match_expand` (65), `exec_shortest_path` (10), `exec_supernode` (2), `exec_limit_pushdown` (10), `exec_limits` (8) — the suites that regressed when this code changed in 2.6.2.
- Numbers above measured against a release build of this branch, seeded and queried over HTTP, against the same fixture used for the published 2.6.2 image.