### PR TITLE
Anonymous intermediate nodes returned wrong rows (2.6.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,22 @@ crates.io release will establish and document that API explicitly.
 
 ## [Unreleased]
 
+## [2.6.5] - 2026-09-10
+
+### Fixed
+
+- **A pattern with an anonymous intermediate node returned wrong rows.**
+  `MATCH (a)-[:X]->()-[:Y]->(b)` re-anchored its second hop on the last
+  NAMED binding instead of the anonymous node, so it planned and executed
+  as `MATCH (a)-[:X]->() , (a)-[:Y]->(b)` — the one-hop neighbours crossed
+  with themselves. The answers looked plausible, which is what made this
+  dangerous: on a fixture where the correct result is `[Carol, Dave]` the
+  engine returned `[Bob, Bob, Carol, Carol]`, and when the two hops used
+  different relationship types it silently returned nothing at all. The
+  chain now advances on the alias the hop actually bound, anonymous or
+  not. This affects every release that supported multi-hop patterns.
+
+
 ## [2.6.4] - 2026-09-10
 
 ### Fixed
@@ -3192,7 +3208,8 @@ Change License: Apache License 2.0).
 - LDBC-shaped synthetic benchmark harness with a paired Kùzu runner
   under [`bench/`](./bench/).
 
-[Unreleased]: https://github.com/namidb/namidb/compare/v2.6.4...HEAD
+[Unreleased]: https://github.com/namidb/namidb/compare/v2.6.5...HEAD
+[2.6.5]: https://github.com/namidb/namidb/compare/v2.6.4...v2.6.5
 [2.6.4]: https://github.com/namidb/namidb/compare/v2.6.3...v2.6.4
 [2.6.3]: https://github.com/namidb/namidb/compare/v2.6.2...v2.6.3
 [2.6.2]: https://github.com/namidb/namidb/compare/v2.6.1...v2.6.2

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2199,7 +2199,7 @@ dependencies = [
 
 [[package]]
 name = "namidb"
-version = "2.6.4"
+version = "2.6.5"
 dependencies = [
  "namidb-core",
  "namidb-graph",
@@ -2209,7 +2209,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-ann"
-version = "2.6.4"
+version = "2.6.5"
 dependencies = [
  "namidb-core",
  "rand 0.8.6",
@@ -2222,7 +2222,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-bench"
-version = "2.6.4"
+version = "2.6.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2246,7 +2246,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-bolt"
-version = "2.6.4"
+version = "2.6.5"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2266,7 +2266,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-cli"
-version = "2.6.4"
+version = "2.6.5"
 dependencies = [
  "anyhow",
  "clap",
@@ -2286,7 +2286,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-core"
-version = "2.6.4"
+version = "2.6.5"
 dependencies = [
  "arrow-array",
  "arrow-schema",
@@ -2302,7 +2302,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-graph"
-version = "2.6.4"
+version = "2.6.5"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -2324,7 +2324,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-markdown"
-version = "2.6.4"
+version = "2.6.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2347,7 +2347,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-mcp"
-version = "2.6.4"
+version = "2.6.5"
 dependencies = [
  "anyhow",
  "clap",
@@ -2367,7 +2367,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-py"
-version = "2.6.4"
+version = "2.6.5"
 dependencies = [
  "bytes",
  "chrono",
@@ -2385,7 +2385,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-query"
-version = "2.6.4"
+version = "2.6.5"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2409,7 +2409,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-server"
-version = "2.6.4"
+version = "2.6.5"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2449,7 +2449,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-storage"
-version = "2.6.4"
+version = "2.6.5"
 dependencies = [
  "anyhow",
  "arrow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2.6.4"
+version = "2.6.5"
 edition = "2021"
 rust-version = "1.85"
 license = "BUSL-1.1"
@@ -123,13 +123,13 @@ tower = { version = "0.5", features = ["limit"] }
 tower-http = { version = "0.6", features = ["trace", "cors", "timeout"] }
 
 # Local workspace crates
-namidb-core = { path = "crates/namidb-core", version = "2.6.4" }
-namidb-storage = { path = "crates/namidb-storage", version = "2.6.4" }
-namidb-markdown = { path = "crates/namidb-markdown", version = "2.6.4" }
-namidb-graph = { path = "crates/namidb-graph", version = "2.6.4" }
-namidb-ann = { path = "crates/namidb-ann", version = "2.6.4" }
-namidb-query = { path = "crates/namidb-query", version = "2.6.4" }
-namidb-bolt = { path = "crates/namidb-bolt", version = "2.6.4" }
+namidb-core = { path = "crates/namidb-core", version = "2.6.5" }
+namidb-storage = { path = "crates/namidb-storage", version = "2.6.5" }
+namidb-markdown = { path = "crates/namidb-markdown", version = "2.6.5" }
+namidb-graph = { path = "crates/namidb-graph", version = "2.6.5" }
+namidb-ann = { path = "crates/namidb-ann", version = "2.6.5" }
+namidb-query = { path = "crates/namidb-query", version = "2.6.5" }
+namidb-bolt = { path = "crates/namidb-bolt", version = "2.6.5" }
 
 [profile.release]
 opt-level = 3

--- a/crates/namidb-py/pyproject.toml
+++ b/crates/namidb-py/pyproject.toml
@@ -7,7 +7,7 @@ name = "namidb"
 # Keep in sync with the workspace `version` in /Cargo.toml.
 # `python-wheels.yml` publishes a wheel whose filename uses THIS
 # version; the release tag `py-vX.Y.Z` must match X.Y.Z exactly.
-version = "2.6.4"
+version = "2.6.5"
 description = "Cloud-native graph database on object storage (Python bindings)"
 readme = "README.md"
 license = "BUSL-1.1"

--- a/crates/namidb-query/src/plan/lower.rs
+++ b/crates/namidb-query/src/plan/lower.rs
@@ -1134,8 +1134,7 @@ fn lower_pattern_element(
     // shape and would otherwise reject those operators.
     let mut current_source = elem.head.binding.as_ref().map(|b| b.name.clone());
     for (rel, target) in &elem.chain {
-        let target_alias_for_next = target.binding.as_ref().map(|b| b.name.clone());
-        plan = lower_rel_node(
+        let (next_plan, bound_target) = lower_rel_node(
             plan,
             current_source.as_deref(),
             &elem.head,
@@ -1145,11 +1144,15 @@ fn lower_pattern_element(
             shortest,
             ctx,
         )?;
-        // After this rel, the target becomes the source for the next.
-        // Anonymous targets are named inside lower_rel_node; we don't
-        // need to track them here because variable-length chains
-        // terminate at named bindings in v0 LDBC queries.
-        current_source = target_alias_for_next.or(current_source);
+        plan = next_plan;
+        // After this rel the target becomes the source for the next hop —
+        // including when it is ANONYMOUS. `lower_rel_node` generates the
+        // binding for `()`, so only it knows the name; keeping the previous
+        // named binding here re-anchored the next hop on the wrong node and
+        // silently returned the wrong rows (`(a)-[:X]->()-[:Y]->(b)` became
+        // `(a)-[:Y]->(b)`). The old code assumed chains terminate at named
+        // bindings, which is not true of a very ordinary pattern.
+        current_source = Some(bound_target);
     }
     Ok(plan)
 }
@@ -1284,11 +1287,11 @@ fn lower_rel_node(
     optional: bool,
     shortest: ShortestMode,
     ctx: &mut LowerCtx,
-) -> Result<LogicalPlan, LowerError> {
+) -> Result<(LogicalPlan, String), LowerError> {
     // Prefer the explicit source (passed by `lower_pattern_element`,
     // which tracks the chain head + each target as the next source).
     // Fall back to inspecting the plan shape only if the chain didn't
-    // name a head — e.g. anonymous mid-chain nodes left as fallback.
+    // name a head.
     let source = match explicit_source {
         Some(name) if ctx.bindings.contains(name) => name.to_string(),
         _ => previous_source(&input)?,
@@ -1387,7 +1390,7 @@ fn lower_rel_node(
             };
         }
     }
-    Ok(plan)
+    Ok((plan, target_alias))
 }
 
 fn previous_source(plan: &LogicalPlan) -> Result<String, LowerError> {
@@ -2922,6 +2925,53 @@ mod tests {
             },
             _ => panic!(),
         }
+    }
+
+    /// `(a)-[:X]->()-[:Y]->(b)`: the SECOND hop must source from the
+    /// anonymous middle node, not from the last NAMED binding.
+    ///
+    /// The chain tracked `current_source` from explicit bindings only and
+    /// left it unchanged for an anonymous target, so the next hop
+    /// re-anchored on the previous named node: `(r)-[:A]->()-[:B]->(l)`
+    /// planned as `Expand(r -A-> __anon0)` then `Expand(r -B-> l)`, which
+    /// is the query `(r)-[:B]->(l)` — a silently WRONG answer (0 rows on a
+    /// graph with 15 matches), not a slow one.
+    #[test]
+    fn anonymous_middle_node_is_the_next_hops_source() {
+        let p = lp("MATCH (r:Root)-[:A]->()-[:B]->(l:Leaf) RETURN l");
+        // Walk down to the two Expands, skipping Filter/Project wrappers.
+        fn find_expands(plan: &LogicalPlan, out: &mut Vec<(String, String)>) {
+            if let LogicalPlan::Expand {
+                source,
+                target_alias,
+                input,
+                ..
+            } = plan
+            {
+                out.push((source.clone(), target_alias.clone()));
+                find_expands(input, out);
+                return;
+            }
+            for child in plan.children() {
+                find_expands(child, out);
+            }
+        }
+        let mut expands = Vec::new();
+        find_expands(&p, &mut expands);
+        assert_eq!(expands.len(), 2, "expected two hops, got {expands:?}");
+        // Outermost first: the (?, l) hop, then the (r, anon) hop.
+        let (outer_source, outer_target) = &expands[0];
+        let (inner_source, inner_target) = &expands[1];
+        assert_eq!(outer_target, "l");
+        assert_eq!(inner_source, "r");
+        assert_ne!(
+            outer_source, "r",
+            "the second hop must not re-anchor on the head; that is the bug"
+        );
+        assert_eq!(
+            outer_source, inner_target,
+            "the second hop must source from the anonymous node the first hop bound"
+        );
     }
 
     #[test]

--- a/crates/namidb-query/tests/exec_match_expand.rs
+++ b/crates/namidb-query/tests/exec_match_expand.rs
@@ -2834,3 +2834,77 @@ async fn var_length_alias_binds_the_relationship_list() {
         zero_rows[0].get("rs")
     );
 }
+
+/// `(a)-[:X]->()-[:Y]->(b)` must traverse THROUGH the anonymous middle node.
+///
+/// The chain tracked its next source from explicit bindings only, so an
+/// anonymous target left it pointing at the previous NAMED node and the
+/// following hop re-anchored there: `(a)-[:KNOWS]->()-[:KNOWS]->(c)` planned
+/// as `(a)-[:KNOWS]->(c)`. That is a silently WRONG answer, not a slow one —
+/// it returns the one-hop neighbours, or nothing at all when the two hops use
+/// different relationship types.
+///
+/// Runs through the full optimizer, as the server does.
+#[tokio::test]
+async fn anonymous_middle_node_traverses_two_hops() {
+    let mut writer = WriterSession::open(store(), paths("exec-anon-middle"))
+        .await
+        .unwrap();
+    let ids = build_friend_graph(&mut writer).await;
+    let snapshot = writer.snapshot();
+    let catalog = StatsCatalog::from_manifest(&snapshot.manifest().manifest);
+
+    // Alice -> {Bob, Carol}; Bob -> Carol; Carol -> Dave.
+    // So Alice's two-hop set through an anonymous middle is {Carol, Dave}.
+    let named = parse(
+        "MATCH (a:Person {name: 'Alice'})-[:KNOWS]->(m:Person)-[:KNOWS]->(c:Person) \
+         RETURN c.name AS name",
+    )
+    .unwrap();
+    let anon = parse(
+        "MATCH (a:Person {name: 'Alice'})-[:KNOWS]->()-[:KNOWS]->(c:Person) \
+         RETURN c.name AS name",
+    )
+    .unwrap();
+
+    let mut expected: Vec<String> = collect_names(
+        &execute(
+            &optimize(lower(&named).unwrap(), &catalog),
+            &snapshot,
+            &Params::new(),
+        )
+        .await
+        .unwrap(),
+    );
+    let mut got: Vec<String> = collect_names(
+        &execute(
+            &optimize(lower(&anon).unwrap(), &catalog),
+            &snapshot,
+            &Params::new(),
+        )
+        .await
+        .unwrap(),
+    );
+    expected.sort();
+    got.sort();
+
+    assert_eq!(
+        expected,
+        vec!["Carol".to_string(), "Dave".to_string()],
+        "fixture sanity: Alice's two-hop set"
+    );
+    assert_eq!(
+        got, expected,
+        "an anonymous middle node must not change which rows match"
+    );
+    let _ = ids;
+}
+
+fn collect_names(rows: &[namidb_query::Row]) -> Vec<String> {
+    rows.iter()
+        .filter_map(|r| match r.bindings.get("name") {
+            Some(RuntimeValue::String(s)) => Some(s.clone()),
+            _ => None,
+        })
+        .collect()
+}


### PR DESCRIPTION
## A correctness bug, not a performance one

```cypher
MATCH (a)-[:X]->()-[:Y]->(b) RETURN b
```

re-anchored its **second hop on the last named binding** instead of on the anonymous node the first hop bound. It planned — and executed — as `(a)-[:X]->()` crossed with `(a)-[:Y]->(b)`.

Plans, before and after, for `MATCH (r:ROOT)-[:A]->()-[:B]->(l:LEAF)`:

```
before:  Expand source=r  edge_type=B -> target=l        <-- wrong source
          Expand source=r edge_type=A -> target=__anon0

after:   Expand source=__anon0 edge_type=B -> target=l
          Expand source=r      edge_type=A -> target=__anon0
```

**The answers looked plausible, which is what makes this serious.** On a five-person fixture where Alice's two-hop set is `[Carol, Dave]`, the engine returned `[Bob, Bob, Carol, Carol]` — her *one-hop* neighbours, duplicated. When the two hops use different relationship types it returned nothing at all: on a 300×300 graph, `0` where the correct answer is `90000`.

This affects every release that supported multi-hop patterns. It is not a regression from 2.6.x.

## Cause

`lower_pattern_element` tracked the next hop's source from explicit bindings only:

```rust
current_source = target_alias_for_next.or(current_source);
```

`lower_rel_node` generates the binding for `()`, so only it knows the name. An anonymous target left `current_source` pointing at the previous named node. The comment directly above stated the assumption in the open: chains *"terminate at named bindings in v0 LDBC queries"*. That is not true of a very ordinary pattern.

`lower_rel_node` now returns the alias it actually bound, and the chain advances on that.

## Tests

Two, **both verified to fail without the fix** (I reverted the one-line change and confirmed each one goes red):

- `plan::lower::tests::anonymous_middle_node_is_the_next_hops_source` — asserts the second Expand sources from the alias the first Expand bound, and specifically that it is *not* the head.
- `exec_match_expand::anonymous_middle_node_traverses_two_hops` — runs the query through the **full optimizer**, as the server does, and compares rows against the explicitly-named spelling.

Without the fix the exec test reports `left: ["Bob", "Bob", "Carol", "Carol"]` against `right: ["Carol", "Dave"]`.

## How it was found

By sweeping query shapes that *should* cost the same and comparing them — the same method that found the unlabelled-target cliff in 2.6.4. This one showed up as a shape returning `0` where its labelled twin returned `90000`. I confirmed against the published 2.6.2 image that it predates the 2.6.4 work rather than being caused by it.

## Verification

`namidb-query`: 559 lib tests, `exec_match_expand` (66), plus `exec_shortest_path`, `exec_supernode`, `exec_limit_pushdown`, `exec_limits`, `exec_alternation`.