### PR TITLE
Batch endpoint reads for multi-hop traversals (2.6.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,28 @@ crates.io release will establish and document that API explicitly.
 
 ## [Unreleased]
 
+## [2.6.6] - 2026-09-10
+
+### Fixed
+
+- **Variable-length traversals of two hops or more no longer read one node
+  per edge.** The batched endpoint materialisation was restricted to single
+  hops, so every multi-hop traversal fell back to an authoritative point read
+  per edge. On a 300x300 fan-out (90,000 paths), `-[:A|B*2..2]->` and
+  `-[:A|B*1..2]->` both exceeded a 120s deadline; they now take 1.7s and
+  0.4s, matching the explicitly-spelled two-hop form. The batch resolves by
+  id across every node descriptor, so it describes nodes of any label — the
+  property that made the single-hop restriction unnecessary. The far-end
+  label still gates only whether a node is a RESULT, never whether it may be
+  traversed.
+- An expansion no longer builds a frontier on its final hop. The frontier
+  feeds the next round, so on the last hop every entry is discarded
+  immediately — after a deep clone of the row, its trail and its
+  relationship list, per matched edge. This was already avoided for
+  single-hop expansions; it is the same waste for the same reason at
+  `hop == max`.
+
+
 ## [2.6.5] - 2026-09-10
 
 ### Fixed
@@ -3208,7 +3230,8 @@ Change License: Apache License 2.0).
 - LDBC-shaped synthetic benchmark harness with a paired Kùzu runner
   under [`bench/`](./bench/).
 
-[Unreleased]: https://github.com/namidb/namidb/compare/v2.6.5...HEAD
+[Unreleased]: https://github.com/namidb/namidb/compare/v2.6.6...HEAD
+[2.6.6]: https://github.com/namidb/namidb/compare/v2.6.5...v2.6.6
 [2.6.5]: https://github.com/namidb/namidb/compare/v2.6.4...v2.6.5
 [2.6.4]: https://github.com/namidb/namidb/compare/v2.6.3...v2.6.4
 [2.6.3]: https://github.com/namidb/namidb/compare/v2.6.2...v2.6.3

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2199,7 +2199,7 @@ dependencies = [
 
 [[package]]
 name = "namidb"
-version = "2.6.5"
+version = "2.6.6"
 dependencies = [
  "namidb-core",
  "namidb-graph",
@@ -2209,7 +2209,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-ann"
-version = "2.6.5"
+version = "2.6.6"
 dependencies = [
  "namidb-core",
  "rand 0.8.6",
@@ -2222,7 +2222,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-bench"
-version = "2.6.5"
+version = "2.6.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2246,7 +2246,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-bolt"
-version = "2.6.5"
+version = "2.6.6"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2266,7 +2266,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-cli"
-version = "2.6.5"
+version = "2.6.6"
 dependencies = [
  "anyhow",
  "clap",
@@ -2286,7 +2286,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-core"
-version = "2.6.5"
+version = "2.6.6"
 dependencies = [
  "arrow-array",
  "arrow-schema",
@@ -2302,7 +2302,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-graph"
-version = "2.6.5"
+version = "2.6.6"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -2324,7 +2324,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-markdown"
-version = "2.6.5"
+version = "2.6.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2347,7 +2347,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-mcp"
-version = "2.6.5"
+version = "2.6.6"
 dependencies = [
  "anyhow",
  "clap",
@@ -2367,7 +2367,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-py"
-version = "2.6.5"
+version = "2.6.6"
 dependencies = [
  "bytes",
  "chrono",
@@ -2385,7 +2385,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-query"
-version = "2.6.5"
+version = "2.6.6"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2409,7 +2409,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-server"
-version = "2.6.5"
+version = "2.6.6"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2449,7 +2449,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-storage"
-version = "2.6.5"
+version = "2.6.6"
 dependencies = [
  "anyhow",
  "arrow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2.6.5"
+version = "2.6.6"
 edition = "2021"
 rust-version = "1.85"
 license = "BUSL-1.1"
@@ -123,13 +123,13 @@ tower = { version = "0.5", features = ["limit"] }
 tower-http = { version = "0.6", features = ["trace", "cors", "timeout"] }
 
 # Local workspace crates
-namidb-core = { path = "crates/namidb-core", version = "2.6.5" }
-namidb-storage = { path = "crates/namidb-storage", version = "2.6.5" }
-namidb-markdown = { path = "crates/namidb-markdown", version = "2.6.5" }
-namidb-graph = { path = "crates/namidb-graph", version = "2.6.5" }
-namidb-ann = { path = "crates/namidb-ann", version = "2.6.5" }
-namidb-query = { path = "crates/namidb-query", version = "2.6.5" }
-namidb-bolt = { path = "crates/namidb-bolt", version = "2.6.5" }
+namidb-core = { path = "crates/namidb-core", version = "2.6.6" }
+namidb-storage = { path = "crates/namidb-storage", version = "2.6.6" }
+namidb-markdown = { path = "crates/namidb-markdown", version = "2.6.6" }
+namidb-graph = { path = "crates/namidb-graph", version = "2.6.6" }
+namidb-ann = { path = "crates/namidb-ann", version = "2.6.6" }
+namidb-query = { path = "crates/namidb-query", version = "2.6.6" }
+namidb-bolt = { path = "crates/namidb-bolt", version = "2.6.6" }
 
 [profile.release]
 opt-level = 3

--- a/crates/namidb-py/pyproject.toml
+++ b/crates/namidb-py/pyproject.toml
@@ -7,7 +7,7 @@ name = "namidb"
 # Keep in sync with the workspace `version` in /Cargo.toml.
 # `python-wheels.yml` publishes a wheel whose filename uses THIS
 # version; the release tag `py-vX.Y.Z` must match X.Y.Z exactly.
-version = "2.6.5"
+version = "2.6.6"
 description = "Cloud-native graph database on object storage (Python bindings)"
 readme = "README.md"
 license = "BUSL-1.1"

--- a/crates/namidb-query/src/exec/walker.rs
+++ b/crates/namidb-query/src/exec/walker.rs
@@ -1810,7 +1810,7 @@ pub(crate) async fn execute_expand(
                 target_labels,
                 &unique_targets,
                 skip_target_materialize,
-                max == 1,
+                true,
             )
             .await?;
             for (step, neighbours) in step_neighbours {
@@ -1893,12 +1893,23 @@ pub(crate) async fn execute_expand(
                         }
                         None
                     } else if let ExpandTargets::Views(views) = &target_membership {
-                        // Single-hop expansion, labelled or not: the hop's
-                        // own materialisation answers directly, so a large
-                        // fan-out no longer depends on cache retention.
+                        // The hop's own materialisation answers directly, so a
+                        // large fan-out no longer depends on cache retention.
+                        // The batch resolves by id across every descriptor, so
+                        // it describes nodes of ANY label — which is what lets
+                        // a multi-hop traversal use it too.
                         match views.get(&target_id) {
                             Some(v) => {
                                 if target_labels.iter().all(|l| v.labels.contains(l)) {
+                                    Some(v.clone())
+                                } else if max > 1 {
+                                    // Multi-hop: the far-end label decides
+                                    // whether this node is a RESULT, never
+                                    // whether it may be traversed. Pruning the
+                                    // frontier on a mismatch is what made
+                                    // `(s)-[:R*1..n]->(a:L)` return empty when
+                                    // the intermediates were not themselves L.
+                                    target_is_result = false;
                                     Some(v.clone())
                                 } else {
                                     continue;
@@ -1909,10 +1920,16 @@ pub(crate) async fn execute_expand(
                             // reader so a batch that under-reports can never
                             // drop a real row.
                             None => match scan_node_for_id(snapshot, target_id).await? {
-                                Some(v) if target_labels.iter().all(|l| v.labels.contains(l)) => {
+                                Some(v) => {
+                                    let matches =
+                                        target_labels.iter().all(|l| v.labels.contains(l));
+                                    if !matches && max == 1 {
+                                        continue;
+                                    }
+                                    target_is_result = matches;
                                     Some(v)
                                 }
-                                _ => continue,
+                                None => continue,
                             },
                         }
                     } else if let Some(label) = target_labels.first() {
@@ -2023,12 +2040,17 @@ pub(crate) async fn execute_expand(
                     if let Some(k) = &edge_key {
                         new_rels.push(k.clone());
                     }
-                    // A single-hop expansion never runs another round, so the
-                    // frontier entry is dead on arrival — and it costs a DEEP
-                    // clone of the row (every binding, whole node values
-                    // included) per matched edge. At a 53k-degree hub that was
-                    // hundreds of MB of pure waste (sixth field report).
-                    if max > 1 {
+                    // The frontier feeds the NEXT round, so on the last hop
+                    // every entry is dead on arrival — and each one costs a
+                    // DEEP clone of the row (every binding, whole node values
+                    // included), its trail and its relationship list, per
+                    // matched edge. This was fixed for `max == 1` after a
+                    // 53k-degree hub turned it into hundreds of MB of pure
+                    // waste (sixth field report); `hop == max` is the same
+                    // waste for exactly the same reason, and a `*1..2` over a
+                    // 300x300 fan-out spent longer building the doomed
+                    // frontier than answering the query.
+                    if hop < max {
                         next_frontier.push(Step {
                             tail: target_id,
                             row: new_row.clone(),
@@ -8701,7 +8723,7 @@ async fn execute_expand_factor(
                 target_labels,
                 &unique_targets,
                 skip_target_materialize,
-                max == 1,
+                true,
             )
             .await?;
             for ((cur_parent, tail, rels), neighbours) in step_neighbours {
@@ -8746,12 +8768,23 @@ async fn execute_expand_factor(
                         }
                         None
                     } else if let ExpandTargets::Views(views) = &target_membership {
-                        // Single-hop expansion, labelled or not: the hop's
-                        // own materialisation answers directly, so a large
-                        // fan-out no longer depends on cache retention.
+                        // The hop's own materialisation answers directly, so a
+                        // large fan-out no longer depends on cache retention.
+                        // The batch resolves by id across every descriptor, so
+                        // it describes nodes of ANY label — which is what lets
+                        // a multi-hop traversal use it too.
                         match views.get(&target_id) {
                             Some(v) => {
                                 if target_labels.iter().all(|l| v.labels.contains(l)) {
+                                    Some(v.clone())
+                                } else if max > 1 {
+                                    // Multi-hop: the far-end label decides
+                                    // whether this node is a RESULT, never
+                                    // whether it may be traversed. Pruning the
+                                    // frontier on a mismatch is what made
+                                    // `(s)-[:R*1..n]->(a:L)` return empty when
+                                    // the intermediates were not themselves L.
+                                    target_is_result = false;
                                     Some(v.clone())
                                 } else {
                                     continue;
@@ -8762,10 +8795,16 @@ async fn execute_expand_factor(
                             // reader so a batch that under-reports can never
                             // drop a real row.
                             None => match scan_node_for_id(snapshot, target_id).await? {
-                                Some(v) if target_labels.iter().all(|l| v.labels.contains(l)) => {
+                                Some(v) => {
+                                    let matches =
+                                        target_labels.iter().all(|l| v.labels.contains(l));
+                                    if !matches && max == 1 {
+                                        continue;
+                                    }
+                                    target_is_result = matches;
                                     Some(v)
                                 }
-                                _ => continue,
+                                None => continue,
                             },
                         }
                     } else if let Some(label) = target_labels.first() {


### PR DESCRIPTION
## The bug

The batched endpoint materialisation was restricted to **single hops**, so every variable-length traversal of two hops or more fell back to one authoritative point read per edge — the same pathology fixed for unlabelled single hops in 2.6.4, reached through a different door.

Measured on a 300×300 fan-out (90,000 paths), all returning the same rows:

| pattern | before | after |
|---|---|---|
| `-[:A\|B*2..2]->(l:LEAF)` | **exceeded a 120 s deadline** | **1.73 s** |
| `-[:A\|B*1..2]->(l)` | **exceeded a 120 s deadline** | **0.41 s** |
| `-[:A]->(m:MID)-[:B]->(l:LEAF)` (explicit, reference) | 0.42 s | 0.42 s |
| `-[:A\|B*1..1]->(m)` | 0.08 s | 0.08 s |

## Why the restriction was there, and why it was wrong

The gate's comment read: *"the batch is label-scoped, while a variable-length traversal must be able to walk THROUGH nodes carrying other labels."*

The first half is not true. `batch_lookup_nodes` iterates `manifest.index.node_descriptors()` and uses its `label` argument only to namespace cache keys, so it describes nodes of **any** label.

The second half is a real invariant — and it was being enforced by disabling batching wholesale. It now lives where it belongs, in the consumer: a label mismatch on a multi-hop target marks the node as **not a result** while still traversing through it. That is the same rule the point-read path already applied.

`var_length_forward_reaches_far_label_through_other_labels` pins exactly this invariant (`(a:A)-[:R*1..3]->(g:Goal)` through a `Mid` intermediate) and now exercises the batched path. I also confirmed it live: `(s)-[:R*2..2]->(t:Target)` through a `Gate` node that is not a `Target` returns the target, and `*1..2` returns both the direct and the gated one.

## Second fix: the doomed frontier

An expansion no longer builds a frontier on its final hop. The frontier feeds the *next* round, so at `hop == max` every entry is discarded immediately — after a deep clone of the row, its trail and its relationship list, per matched edge.

This was already avoided for single-hop expansions, after a 53k-degree hub turned it into hundreds of MB of pure waste. `hop == max` is the same waste for the same reason; the guard said `max > 1` where it meant `hop < max`.

Worth noting: I expected this one to be the cause of the var-length timeouts. It was not — measuring after the change showed no improvement, which is what sent me to the real cause above. It is kept because it is correct, not because it moved the number.

## How this was found

By sweeping query shapes that should cost the same and comparing — the method that also produced 2.6.4 and 2.6.5. `*2..2` appeared as a shape timing out where its explicitly-spelled twin took 0.4 s.

## Verification

`namidb-query`: 559 lib tests and every integration suite (`--tests`, exit 0), with particular attention to `exec_match_expand` (66), `exec_shortest_path`, `exec_supernode`, `exec_alternation`, `exec_limits`, `exec_limit_pushdown` — the suites that regressed when this code was last touched.