### PR TITLE
Stop the expand batch filtering by label (2.6.7) — reverts a 2.6.4 regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,29 @@ crates.io release will establish and document that API explicitly.
 
 ## [Unreleased]
 
+## [2.6.7] - 2026-09-10
+
+### Fixed
+
+- **An expansion whose neighbours carry mixed labels no longer does one
+  uncached node read per edge.** This reverts a regression introduced in
+  2.6.4. `batch_lookup_nodes` sweeps by id but FILTERS its output by the
+  label it is given, so a batch asking for `:Green` drops every `:Red`
+  neighbour; those ids are then absent from the materialisation map and the
+  miss branch added in 2.6.4 falls through to `lookup_node_by_id`, the one
+  node read with no cache tier. On a 40k-degree hub split evenly between two
+  labels, `-[:N]->(t:Green) RETURN count(t)` went past a 120s deadline where
+  2.6.3 answered in 0.22 s; it now takes 0.24 s. The expand batch asks for no
+  label and re-proves the label itself, per edge, against the view it gets.
+- The same filter was the whole cost of a variable-length traversal, since
+  every hop shared the pattern's FINAL target label and therefore resolved
+  nothing at intermediate hops. Measured on a 200x200 fan-out, 40,000 paths:
+  `-[:A|B*2..2]->(x:LEAF)` 5.3 s to **0.21 s**, `-[:A|B*1..2]->(x:LEAF)`
+  6.0 s to 0.22 s, and `-[:A|B*2..2]->(x:MID)` — a label matching nothing at
+  the final hop — from exceeding the deadline to 0.16 s. Variable-length now
+  matches the explicitly-spelled chain (0.13 s) rather than trailing it.
+
+
 ## [2.6.6] - 2026-09-10
 
 ### Fixed
@@ -3230,7 +3253,8 @@ Change License: Apache License 2.0).
 - LDBC-shaped synthetic benchmark harness with a paired Kùzu runner
   under [`bench/`](./bench/).
 
-[Unreleased]: https://github.com/namidb/namidb/compare/v2.6.6...HEAD
+[Unreleased]: https://github.com/namidb/namidb/compare/v2.6.7...HEAD
+[2.6.7]: https://github.com/namidb/namidb/compare/v2.6.6...v2.6.7
 [2.6.6]: https://github.com/namidb/namidb/compare/v2.6.5...v2.6.6
 [2.6.5]: https://github.com/namidb/namidb/compare/v2.6.4...v2.6.5
 [2.6.4]: https://github.com/namidb/namidb/compare/v2.6.3...v2.6.4

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2199,7 +2199,7 @@ dependencies = [
 
 [[package]]
 name = "namidb"
-version = "2.6.6"
+version = "2.6.7"
 dependencies = [
  "namidb-core",
  "namidb-graph",
@@ -2209,7 +2209,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-ann"
-version = "2.6.6"
+version = "2.6.7"
 dependencies = [
  "namidb-core",
  "rand 0.8.6",
@@ -2222,7 +2222,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-bench"
-version = "2.6.6"
+version = "2.6.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2246,7 +2246,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-bolt"
-version = "2.6.6"
+version = "2.6.7"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2266,7 +2266,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-cli"
-version = "2.6.6"
+version = "2.6.7"
 dependencies = [
  "anyhow",
  "clap",
@@ -2286,7 +2286,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-core"
-version = "2.6.6"
+version = "2.6.7"
 dependencies = [
  "arrow-array",
  "arrow-schema",
@@ -2302,7 +2302,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-graph"
-version = "2.6.6"
+version = "2.6.7"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -2324,7 +2324,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-markdown"
-version = "2.6.6"
+version = "2.6.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2347,7 +2347,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-mcp"
-version = "2.6.6"
+version = "2.6.7"
 dependencies = [
  "anyhow",
  "clap",
@@ -2367,7 +2367,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-py"
-version = "2.6.6"
+version = "2.6.7"
 dependencies = [
  "bytes",
  "chrono",
@@ -2385,7 +2385,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-query"
-version = "2.6.6"
+version = "2.6.7"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2409,7 +2409,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-server"
-version = "2.6.6"
+version = "2.6.7"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2449,7 +2449,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-storage"
-version = "2.6.6"
+version = "2.6.7"
 dependencies = [
  "anyhow",
  "arrow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2.6.6"
+version = "2.6.7"
 edition = "2021"
 rust-version = "1.85"
 license = "BUSL-1.1"
@@ -123,13 +123,13 @@ tower = { version = "0.5", features = ["limit"] }
 tower-http = { version = "0.6", features = ["trace", "cors", "timeout"] }
 
 # Local workspace crates
-namidb-core = { path = "crates/namidb-core", version = "2.6.6" }
-namidb-storage = { path = "crates/namidb-storage", version = "2.6.6" }
-namidb-markdown = { path = "crates/namidb-markdown", version = "2.6.6" }
-namidb-graph = { path = "crates/namidb-graph", version = "2.6.6" }
-namidb-ann = { path = "crates/namidb-ann", version = "2.6.6" }
-namidb-query = { path = "crates/namidb-query", version = "2.6.6" }
-namidb-bolt = { path = "crates/namidb-bolt", version = "2.6.6" }
+namidb-core = { path = "crates/namidb-core", version = "2.6.7" }
+namidb-storage = { path = "crates/namidb-storage", version = "2.6.7" }
+namidb-markdown = { path = "crates/namidb-markdown", version = "2.6.7" }
+namidb-graph = { path = "crates/namidb-graph", version = "2.6.7" }
+namidb-ann = { path = "crates/namidb-ann", version = "2.6.7" }
+namidb-query = { path = "crates/namidb-query", version = "2.6.7" }
+namidb-bolt = { path = "crates/namidb-bolt", version = "2.6.7" }
 
 [profile.release]
 opt-level = 3

--- a/crates/namidb-py/pyproject.toml
+++ b/crates/namidb-py/pyproject.toml
@@ -7,7 +7,7 @@ name = "namidb"
 # Keep in sync with the workspace `version` in /Cargo.toml.
 # `python-wheels.yml` publishes a wheel whose filename uses THIS
 # version; the release tag `py-vX.Y.Z` must match X.Y.Z exactly.
-version = "2.6.6"
+version = "2.6.7"
 description = "Cloud-native graph database on object storage (Python bindings)"
 readme = "README.md"
 license = "BUSL-1.1"

--- a/crates/namidb-query/src/exec/walker.rs
+++ b/crates/namidb-query/src/exec/walker.rs
@@ -1811,6 +1811,7 @@ pub(crate) async fn execute_expand(
                 &unique_targets,
                 skip_target_materialize,
                 true,
+                max > 1,
             )
             .await?;
             for (step, neighbours) in step_neighbours {
@@ -6517,6 +6518,7 @@ async fn prepare_expand_targets(
     unique_targets: &[NodeId],
     skip_target_materialize: bool,
     views_usable: bool,
+    multi_hop: bool,
 ) -> Result<ExpandTargets, ExecError> {
     if unique_targets.is_empty() {
         return Ok(if skip_target_materialize {
@@ -6557,12 +6559,34 @@ async fn prepare_expand_targets(
         ));
     }
 
-    // `batch_lookup_nodes` resolves by id across every node descriptor; the
-    // label only namespaces its cache keys, so an EMPTY label is a complete
-    // id-primary batch, not a miss. Only a SINGLE-HOP expansion may consume
-    // it directly: a variable-length traversal must be able to walk THROUGH
-    // nodes this batch does not describe.
-    let label = target_labels.first().map_or("", String::as_str);
+    // `batch_lookup_nodes` sweeps by id across every node descriptor, but it
+    // FILTERS its output by the label it is given (read.rs: `.filter(|v|
+    // label.is_empty() || v.labels.contains(label))`) — an empty label is the
+    // only way to ask for "whatever is there".
+    //
+    // That distinction is the whole cost of a multi-hop traversal. Every hop
+    // shares the pattern's FINAL target label, so asking for it at an
+    // INTERMEDIATE hop drops every endpoint: the batch comes back all-None,
+    // the Views map is empty, and each traversed edge falls through to
+    // `scan_node_for_id` — `lookup_node_by_id`, the one node read with no
+    // cache tier, which re-decodes a whole Parquet row group per call. It
+    // never warms up, and it costs more the fatter the neighbouring rows are.
+    //
+    // A multi-hop expansion therefore asks for no label at all. Nothing is
+    // lost: the consumer re-proves the label per edge against the view it
+    // gets, which is also what decides result-vs-traversal at `max > 1`.
+    // ALWAYS ask for no label, single hop or not. The consumer re-proves the
+    // label per edge against the view it receives, so the batch's own filter
+    // adds nothing — and it costs a great deal: a neighbour of a different
+    // label is dropped from the batch, and an absent id then falls through to
+    // `scan_node_for_id`, one uncached point read PER EDGE. On a 40k-degree
+    // hub whose neighbours are half `:VERDE` and half `:ROJO`,
+    // `-[:N]->(t:VERDE) RETURN count(t)` spent longer than the 120s deadline
+    // paying that toll for every `:ROJO` neighbour. With no label the batch
+    // returns every endpoint, a miss means genuinely absent, and the fallback
+    // becomes the rare path it was written to be.
+    let label = "";
+    let _ = multi_hop;
     if !views_usable || unique_targets.len() > expand_target_view_budget() {
         let _ = snapshot.batch_lookup_nodes(label, unique_targets).await?;
         return Ok(ExpandTargets::Cold);
@@ -8724,6 +8748,7 @@ async fn execute_expand_factor(
                 &unique_targets,
                 skip_target_materialize,
                 true,
+                max > 1,
             )
             .await?;
             for ((cur_parent, tail, rels), neighbours) in step_neighbours {

--- a/crates/namidb-query/tests/exec_supernode.rs
+++ b/crates/namidb-query/tests/exec_supernode.rs
@@ -207,3 +207,78 @@ async fn unlabelled_and_anonymous_hub_targets_match_the_labelled_form() {
         }
     }
 }
+
+/// A hub whose neighbours carry DIFFERENT labels, with the target label
+/// referenced downstream.
+///
+/// `batch_lookup_nodes` sweeps by id but FILTERS its output by the label it
+/// is given, so asking for `:Green` drops every `:Red` neighbour from the
+/// batch. Those ids are then absent from the Views map, and the miss branch
+/// falls through to `scan_node_for_id` — one uncached point read PER EDGE.
+/// On a 40k-degree hub split evenly between two labels, this took
+/// `-[:KNOWS]->(t:Green) RETURN count(t)` past a 120s deadline where 2.6.3
+/// answered in 0.22s. The expand batch therefore asks for NO label and
+/// re-proves the label itself, per edge, against the view it gets.
+///
+/// The timing cannot be asserted here (an in-memory store makes the point
+/// read cheap), but nothing in the suite expanded a hub whose neighbours had
+/// mixed labels at all, which is why the regression shipped.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn mixed_label_neighbours_resolve_without_per_edge_reads() {
+    let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    let paths = NamespacePaths::new("tenants", NamespaceId::new("exec-mixed-labels").unwrap());
+    let mut writer = WriterSession::open(store, paths).await.unwrap();
+
+    let hub = NodeId::new();
+    writer.upsert_node("Person", hub, &person("hub")).unwrap();
+    // Half the neighbours carry the label the query asks for, half do not.
+    for ordinal in 0..FANIN {
+        let green = NodeId::new();
+        writer
+            .upsert_node("Green", green, &person(&format!("green-{ordinal}")))
+            .unwrap();
+        writer.upsert_edge("KNOWS", hub, green, &edge()).unwrap();
+        let red = NodeId::new();
+        writer
+            .upsert_node("Red", red, &person(&format!("red-{ordinal}")))
+            .unwrap();
+        writer.upsert_edge("KNOWS", hub, red, &edge()).unwrap();
+    }
+    writer.commit_batch().await.unwrap();
+    writer.flush(schema()).await.unwrap();
+
+    // Referencing the target forces the materialising path (an unreferenced
+    // target takes the cheap membership sidecar and would not exercise this).
+    let green = count_value(
+        &writer,
+        "MATCH (h:Person {name: 'hub'})-[:KNOWS]->(t:Green) RETURN count(t) AS c",
+    )
+    .await;
+    assert_eq!(
+        green, FANIN as i64,
+        "every :Green neighbour must be counted"
+    );
+
+    let red = count_value(
+        &writer,
+        "MATCH (h:Person {name: 'hub'})-[:KNOWS]->(t:Red) RETURN count(t) AS c",
+    )
+    .await;
+    assert_eq!(red, FANIN as i64);
+
+    // A label no neighbour carries must return zero, not the whole fan-out.
+    let absent = count_value(
+        &writer,
+        "MATCH (h:Person {name: 'hub'})-[:KNOWS]->(t:Absent) RETURN count(t) AS c",
+    )
+    .await;
+    assert_eq!(absent, 0);
+
+    // Unlabelled sees both halves.
+    let all = count_value(
+        &writer,
+        "MATCH (h:Person {name: 'hub'})-[:KNOWS]->(t) RETURN count(t) AS c",
+    )
+    .await;
+    assert_eq!(all, (FANIN * 2) as i64);
+}


### PR DESCRIPTION
## What I got wrong

In 2.6.4 I wrote that `batch_lookup_nodes` "uses its `label` argument only to namespace cache keys". Half true. The **sweep** is id-primary. The **output** is not:

```rust
.filter(|v| label.is_empty() || v.labels.contains(label))
```

An empty label is the only way to ask for whatever is there. That distinction is load-bearing twice.

## 1. A regression I introduced in 2.6.4

A batch asking for `:Green` drops every `:Red` neighbour. Those ids are absent from the Views map, and the miss branch I added in 2.6.4 falls through to `scan_node_for_id` → `lookup_node_by_id`, **the one node read path with no cache tier** — it re-decodes a whole Parquet row group per call and never warms up.

I added that fallback defensively, believing a batch miss meant the batch had under-reported. It under-reports *by design*, so the fallback fired for every neighbour carrying a different label.

Measured on a 40k-degree hub split evenly between two labels, verified against the published images:

| version | `-[:N]->(t:Green) RETURN count(t)` |
|---|---|
| 2.6.3 | 0.22 s |
| 2.6.4 / 2.6.5 / 2.6.6 | **exceeds the 120 s deadline** |
| this PR | 0.24 s |

`RETURN sum(t.idx)` behaves identically. An unreferenced target was never affected — it takes the membership sidecar — which is exactly why the smoke tests missed it.

## 2. The whole of the var-length residual

Every hop shares the pattern's **final** target label, so an intermediate hop asks for a label its endpoints do not carry and resolves nothing. 200×200 fan-out, 40,000 paths, same answers:

| query | 2.6.6 | this PR |
|---|---|---|
| `-[:A\|B*2..2]->(x:LEAF)` | 5.3 s | **0.21 s** |
| `-[:A\|B*1..2]->(x:LEAF)` | 6.0 s | **0.22 s** |
| `-[:A\|B*2..2]->(x:MID)` (label matches nothing at the last hop) | **exceeds 120 s** | **0.16 s** |
| `(r)-[:A]->(m:MID)-[:B]->(l:LEAF)` explicit, for reference | 0.13 s | 0.13 s |

Variable-length now matches the explicit chain instead of trailing it, and item 77 is closed.

## The fix

The batch asks for no label, anywhere. Nothing is lost: the consumer already re-proves the label per edge against the view it receives, and that same check decides result-versus-traversal at `max > 1`. A miss now means genuinely absent, so the fallback is the rare path it was written to be.

## How it was found

Four hypotheses refuted by measurement first — store composition, alternation, hydration, and `bound_target_matches_labels` — then the mechanism located by reading. The decisive clue was that labelled and unlabelled traversals showed **identical** I/O (`namidb_range_cache_lookups_total{outcome="memory_hit"} += 916` in both) with a 21× time difference: cached bytes, repeated decode.

## Tests

`mixed_label_neighbours_resolve_without_per_edge_reads` in `exec_supernode.rs`. Nothing in the suite expanded a hub whose neighbours carried mixed labels at all, which is why the regression shipped. Timing cannot be asserted in-process (an in-memory store makes the point read cheap), so the test pins the shape and the counts; the numbers above come from release builds against the published images.

Full `namidb-query` suite green: 559 lib plus `exec_match_expand` (66), `exec_supernode` (3), `exec_shortest_path`, `exec_alternation`, `exec_limits`, `exec_limit_pushdown`.