### PR TITLE
Two silent wrong answers from the id-only target stub (2.6.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,29 @@ crates.io release will establish and document that API explicitly.
 
 ## [Unreleased]
 
+## [2.6.8] - 2026-09-10
+
+### Fixed
+
+- **`any()` / `all()` / `none()` / `single()` and list comprehensions over a
+  target's property returned nothing.** The reference collector grouped
+  quantifiers and list comprehensions with the closed pattern forms
+  (`Exists`, `PatternComprehension`), whose binding reads genuinely happen
+  inside their own sub-plan. A quantifier is not one of those — it is a plain
+  list operation over a host binding. So `WHERE any(x IN t.tags WHERE x =
+  'a')` never registered `t`, the expansion bound it as an id-only stub with
+  no properties, `t.tags` read as null, and the predicate matched NOTHING. A
+  silently empty result, not an error. `size(t.tags)` and `t.name` were
+  unaffected, which is why this went unnoticed.
+- **A `*0..n` pattern lost rows when its source carried more labels than the
+  pattern named.** The zero-hop arm decides whether the source is itself a
+  result by reading the labels off the row, and an id-only stub carries only
+  the labels the previous expansion asked for. A node labelled `:T:U` bound
+  by `->(t:T)` therefore failed `-[:S*0..2]->(u:U)` at zero hops and vanished
+  from the result. An alias consumed as a zero-hop source is now excluded
+  from the stub optimisation.
+
+
 ## [2.6.7] - 2026-09-10
 
 ### Fixed
@@ -3253,7 +3276,8 @@ Change License: Apache License 2.0).
 - LDBC-shaped synthetic benchmark harness with a paired Kùzu runner
   under [`bench/`](./bench/).
 
-[Unreleased]: https://github.com/namidb/namidb/compare/v2.6.7...HEAD
+[Unreleased]: https://github.com/namidb/namidb/compare/v2.6.8...HEAD
+[2.6.8]: https://github.com/namidb/namidb/compare/v2.6.7...v2.6.8
 [2.6.7]: https://github.com/namidb/namidb/compare/v2.6.6...v2.6.7
 [2.6.6]: https://github.com/namidb/namidb/compare/v2.6.5...v2.6.6
 [2.6.5]: https://github.com/namidb/namidb/compare/v2.6.4...v2.6.5

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2199,7 +2199,7 @@ dependencies = [
 
 [[package]]
 name = "namidb"
-version = "2.6.7"
+version = "2.6.8"
 dependencies = [
  "namidb-core",
  "namidb-graph",
@@ -2209,7 +2209,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-ann"
-version = "2.6.7"
+version = "2.6.8"
 dependencies = [
  "namidb-core",
  "rand 0.8.6",
@@ -2222,7 +2222,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-bench"
-version = "2.6.7"
+version = "2.6.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2246,7 +2246,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-bolt"
-version = "2.6.7"
+version = "2.6.8"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2266,7 +2266,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-cli"
-version = "2.6.7"
+version = "2.6.8"
 dependencies = [
  "anyhow",
  "clap",
@@ -2286,7 +2286,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-core"
-version = "2.6.7"
+version = "2.6.8"
 dependencies = [
  "arrow-array",
  "arrow-schema",
@@ -2302,7 +2302,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-graph"
-version = "2.6.7"
+version = "2.6.8"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -2324,7 +2324,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-markdown"
-version = "2.6.7"
+version = "2.6.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2347,7 +2347,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-mcp"
-version = "2.6.7"
+version = "2.6.8"
 dependencies = [
  "anyhow",
  "clap",
@@ -2367,7 +2367,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-py"
-version = "2.6.7"
+version = "2.6.8"
 dependencies = [
  "bytes",
  "chrono",
@@ -2385,7 +2385,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-query"
-version = "2.6.7"
+version = "2.6.8"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2409,7 +2409,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-server"
-version = "2.6.7"
+version = "2.6.8"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2449,7 +2449,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-storage"
-version = "2.6.7"
+version = "2.6.8"
 dependencies = [
  "anyhow",
  "arrow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2.6.7"
+version = "2.6.8"
 edition = "2021"
 rust-version = "1.85"
 license = "BUSL-1.1"
@@ -123,13 +123,13 @@ tower = { version = "0.5", features = ["limit"] }
 tower-http = { version = "0.6", features = ["trace", "cors", "timeout"] }
 
 # Local workspace crates
-namidb-core = { path = "crates/namidb-core", version = "2.6.7" }
-namidb-storage = { path = "crates/namidb-storage", version = "2.6.7" }
-namidb-markdown = { path = "crates/namidb-markdown", version = "2.6.7" }
-namidb-graph = { path = "crates/namidb-graph", version = "2.6.7" }
-namidb-ann = { path = "crates/namidb-ann", version = "2.6.7" }
-namidb-query = { path = "crates/namidb-query", version = "2.6.7" }
-namidb-bolt = { path = "crates/namidb-bolt", version = "2.6.7" }
+namidb-core = { path = "crates/namidb-core", version = "2.6.8" }
+namidb-storage = { path = "crates/namidb-storage", version = "2.6.8" }
+namidb-markdown = { path = "crates/namidb-markdown", version = "2.6.8" }
+namidb-graph = { path = "crates/namidb-graph", version = "2.6.8" }
+namidb-ann = { path = "crates/namidb-ann", version = "2.6.8" }
+namidb-query = { path = "crates/namidb-query", version = "2.6.8" }
+namidb-bolt = { path = "crates/namidb-bolt", version = "2.6.8" }
 
 [profile.release]
 opt-level = 3

--- a/crates/namidb-py/pyproject.toml
+++ b/crates/namidb-py/pyproject.toml
@@ -7,7 +7,7 @@ name = "namidb"
 # Keep in sync with the workspace `version` in /Cargo.toml.
 # `python-wheels.yml` publishes a wheel whose filename uses THIS
 # version; the release tag `py-vX.Y.Z` must match X.Y.Z exactly.
-version = "2.6.7"
+version = "2.6.8"
 description = "Cloud-native graph database on object storage (Python bindings)"
 readme = "README.md"
 license = "BUSL-1.1"

--- a/crates/namidb-query/src/exec/walker.rs
+++ b/crates/namidb-query/src/exec/walker.rs
@@ -6620,7 +6620,20 @@ fn should_skip_target_materialize(
         && path_binding.is_none()
         && !target_labels.is_empty()
         && !routing.referenced_aliases.contains(target_alias)
+        && !routing.zero_hop_sources.contains(target_alias)
         && length.as_ref().is_none_or(|length| length.max == 1)
+}
+
+/// Collect the source alias of every `*0..n` Expand in the plan.
+fn collect_zero_hop_expand_sources(plan: &LogicalPlan, out: &mut BTreeSet<String>) {
+    if let LogicalPlan::Expand { source, length, .. } = plan {
+        if length.as_ref().is_some_and(|l| l.min == 0) {
+            out.insert(source.clone());
+        }
+    }
+    for child in plan.children() {
+        collect_zero_hop_expand_sources(child, out);
+    }
 }
 
 /// Resolve a node when the logical operator carries no label constraint.
@@ -9588,13 +9601,34 @@ fn collect_referenced_variables(expr: &Expression, out: &mut BTreeSet<String>) {
             collect_referenced_variables(&r.list, out);
             collect_referenced_variables(&r.expression, out);
         }
+        // `any`/`all`/`none`/`single` and a list comprehension are plain list
+        // operations over a HOST binding, evaluated by the expression engine —
+        // not closed pattern forms. Grouping them with `Exists` meant
+        // `WHERE any(x IN t.tags WHERE x = 'a')` never registered `t`, so the
+        // Expand bound it as an id-only stub with no properties, `t.tags` read
+        // as null, and the predicate silently matched nothing.
+        //
+        // The local element variable shadows any same-named host binding, so
+        // collecting it over-collects — the safe direction for a thin row, and
+        // the same trade `reduce()` above already makes.
+        ExpressionKind::Quantifier(q) => {
+            collect_referenced_variables(&q.list, out);
+            collect_referenced_variables(&q.predicate, out);
+        }
+        ExpressionKind::ListComprehension(lc) => {
+            collect_referenced_variables(&lc.list, out);
+            if let Some(p) = &lc.predicate {
+                collect_referenced_variables(p, out);
+            }
+            if let Some(p) = &lc.projection {
+                collect_referenced_variables(p, out);
+            }
+        }
         // Closed pattern forms — the binding reads they perform live
         // inside their own sub-plan, not in the host expression.
         ExpressionKind::Exists(_)
         | ExpressionKind::ExistsSubquery(_)
-        | ExpressionKind::ListComprehension(_)
         | ExpressionKind::PatternComprehension(_)
-        | ExpressionKind::Quantifier(_)
         | ExpressionKind::Literal(_)
         | ExpressionKind::Parameter(_)
         | ExpressionKind::Star => {}
@@ -9629,6 +9663,14 @@ pub(crate) struct PlanRouting {
     /// consumed downstream. This intentionally excludes a bare `DELETE r`:
     /// deleting a relationship only needs its `(type, src, dst)` identity.
     value_referenced_aliases: BTreeSet<String>,
+    /// Aliases a later Expand consumes as the SOURCE of a zero-length
+    /// variable-length pattern (`*0..n`). Such an Expand decides whether the
+    /// source itself is a result by reading the labels off the ROW, and an
+    /// id-only stub carries only the labels its own Expand asked for — not
+    /// the node's real set. A node labelled `:T:U` bound by `->(t:T)` would
+    /// therefore fail `-[:S*0..2]->(u:U)` at zero hops and silently lose the
+    /// row. These aliases must be materialised.
+    zero_hop_sources: BTreeSet<String>,
     /// A node-mutating write invalidates the committed property cache at
     /// commit. Correlated indexed reads in such a statement must therefore
     /// use the writer-private transactional postings map so a sequence of
@@ -9644,9 +9686,12 @@ impl PlanRouting {
         collect_plan_referenced_variables(plan, &mut refs);
         let mut value_refs: BTreeSet<String> = BTreeSet::new();
         collect_plan_value_referenced_variables(plan, &mut value_refs);
+        let mut zero_hop_sources: BTreeSet<String> = BTreeSet::new();
+        collect_zero_hop_expand_sources(plan, &mut zero_hop_sources);
         Self {
             referenced_aliases: refs,
             value_referenced_aliases: value_refs,
+            zero_hop_sources,
             transactional_property_reads: plan_requires_transactional_property_reads(plan),
         }
     }

--- a/crates/namidb-query/tests/exec_plan_aware_routing.rs
+++ b/crates/namidb-query/tests/exec_plan_aware_routing.rs
@@ -442,3 +442,219 @@ async fn declared_edge_endpoint_does_not_replace_live_label_validation() {
         "the declared dst_label is not proof that a raw edge's live target carries it"
     );
 }
+
+/// `any()` / `all()` over a TARGET's list property must materialise that
+/// target.
+///
+/// `collect_referenced_variables` grouped `Quantifier` and
+/// `ListComprehension` with the closed pattern forms (`Exists`,
+/// `PatternComprehension`), whose binding reads really do happen inside their
+/// own sub-plan. A quantifier is not one of those: it is a plain list
+/// operation over a host binding. So `WHERE any(x IN t.tags WHERE x = 'a')`
+/// never registered `t`, the Expand bound it as an id-only stub with no
+/// properties, `t.tags` read as null, and the predicate matched NOTHING —
+/// a silently empty result, not an error.
+#[tokio::test]
+async fn quantifier_over_a_target_list_property_materialises_the_target() {
+    std::env::set_var("NAMIDB_ADJACENCY", "1");
+    std::env::set_var("NAMIDB_NODE_CACHE", "1");
+    let mut writer = WriterSession::open(store(), paths("quantifier-routing"))
+        .await
+        .unwrap();
+    let schema = SchemaBuilder::new()
+        .label(LabelDef {
+            name: "Tgt".into(),
+            properties: vec![PropertyDef::new("name", DataType::Utf8, false).unwrap()],
+        })
+        .unwrap()
+        .label(LabelDef {
+            name: "Src".into(),
+            properties: vec![PropertyDef::new("name", DataType::Utf8, false).unwrap()],
+        })
+        .unwrap()
+        .edge_type(EdgeTypeDef {
+            name: "REL".into(),
+            src_label: "Src".into(),
+            dst_label: "Tgt".into(),
+            properties: vec![],
+        })
+        .unwrap()
+        .build();
+
+    let src = NodeId::new();
+    let mut src_props: BTreeMap<String, CoreValue> = BTreeMap::new();
+    src_props.insert("name".into(), CoreValue::Str("s".into()));
+    writer
+        .upsert_node(
+            "Src",
+            src,
+            &NodeWriteRecord {
+                properties: src_props,
+                schema_version: 0,
+                labels: vec![],
+            },
+        )
+        .unwrap();
+    for (name, tags) in [("t1", vec!["a", "b"]), ("t2", vec!["c"])] {
+        let id = NodeId::new();
+        let mut props: BTreeMap<String, CoreValue> = BTreeMap::new();
+        props.insert("name".into(), CoreValue::Str(name.into()));
+        props.insert(
+            "tags".into(),
+            CoreValue::List(tags.into_iter().map(|t| CoreValue::Str(t.into())).collect()),
+        );
+        writer
+            .upsert_node(
+                "Tgt",
+                id,
+                &NodeWriteRecord {
+                    properties: props,
+                    schema_version: 0,
+                    labels: vec![],
+                },
+            )
+            .unwrap();
+        writer
+            .upsert_edge("REL", src, id, &EdgeWriteRecord::default())
+            .unwrap();
+    }
+    writer.commit_batch().await.unwrap();
+    writer.flush(schema).await.unwrap();
+
+    let snapshot = writer.snapshot();
+    let count = |q: &'static str| {
+        let snapshot = &snapshot;
+        async move {
+            let parsed = parse(q).unwrap();
+            let plan = lower(&parsed).unwrap();
+            let rows = execute(&plan, snapshot, &Params::new()).await.unwrap();
+            match rows[0].bindings.values().next() {
+                Some(RuntimeValue::Integer(n)) => *n,
+                other => panic!("expected an integer count, got {other:?}"),
+            }
+        }
+    };
+
+    assert_eq!(
+        count("MATCH (s:Src)-[:REL]->(t:Tgt) WHERE any(x IN t.tags WHERE x = 'a') RETURN count(*) AS c").await,
+        1,
+        "any() over the target's list property must see the real list"
+    );
+    assert_eq!(
+        count("MATCH (s:Src)-[:REL]->(t:Tgt) WHERE all(x IN t.tags WHERE x <> 'z') RETURN count(*) AS c").await,
+        2,
+        "all() over the target's list property must see the real list"
+    );
+    assert_eq!(
+        count("MATCH (s:Src)-[:REL]->(t:Tgt) WHERE none(x IN t.tags WHERE x = 'a') RETURN count(*) AS c").await,
+        1
+    );
+    // A list comprehension reads the host binding the same way.
+    assert_eq!(
+        count("MATCH (s:Src)-[:REL]->(t:Tgt) WHERE size([x IN t.tags WHERE x <> 'b']) = 1 RETURN count(*) AS c").await,
+        2
+    );
+    // Controls: shapes that already worked must not change.
+    assert_eq!(
+        count("MATCH (s:Src)-[:REL]->(t:Tgt) WHERE t.name = 't1' RETURN count(*) AS c").await,
+        1
+    );
+    assert_eq!(
+        count("MATCH (s:Src)-[:REL]->(t:Tgt) RETURN count(*) AS c").await,
+        2
+    );
+}
+
+/// A `*0..n` pattern must see its SOURCE's real label set.
+///
+/// The zero-hop arm decides whether the source itself is a result by reading
+/// the labels off the row (`source_has_target_labels`). An unreferenced
+/// Expand target is bound as an id-only stub whose `labels` field holds only
+/// the labels THAT Expand asked for — not the node's real set. So a node
+/// labelled `:TT:UU`, bound by `->(t:TT)`, failed `-[:S*0..2]->(u:UU)` at
+/// zero hops and the row vanished. An alias consumed as a zero-hop source is
+/// now excluded from the stub optimisation.
+#[tokio::test]
+async fn zero_hop_source_sees_its_full_label_set() {
+    std::env::set_var("NAMIDB_ADJACENCY", "1");
+    std::env::set_var("NAMIDB_NODE_CACHE", "1");
+    let mut writer = WriterSession::open(store(), paths("zero-hop-labels"))
+        .await
+        .unwrap();
+    let schema = SchemaBuilder::new()
+        .label(person_label())
+        .unwrap()
+        .edge_type(works_with_edge())
+        .unwrap()
+        .build();
+
+    // `both` carries TWO labels; `far` is one hop beyond it.
+    let a = NodeId::new();
+    let both = NodeId::new();
+    let far = NodeId::new();
+    writer.upsert_node("Person", a, &person("a")).unwrap();
+    writer
+        .upsert_node_with_labels(["TT".to_string(), "UU".to_string()], both, &person("both"))
+        .unwrap();
+    writer
+        .upsert_node_with_labels(["UU".to_string()], far, &person("far"))
+        .unwrap();
+    writer
+        .upsert_edge("WORKS_WITH", a, both, &weighted_edge(1.0))
+        .unwrap();
+    writer
+        .upsert_edge("WORKS_WITH", both, far, &weighted_edge(1.0))
+        .unwrap();
+    writer.commit_batch().await.unwrap();
+    writer.flush(schema).await.unwrap();
+
+    let snapshot = writer.snapshot();
+    let names = |q: &'static str| {
+        let snapshot = &snapshot;
+        async move {
+            let parsed = parse(q).unwrap();
+            let plan = lower(&parsed).unwrap();
+            let rows = execute(&plan, snapshot, &Params::new()).await.unwrap();
+            let mut out: Vec<String> = rows
+                .iter()
+                .filter_map(|r| match r.bindings.get("n") {
+                    Some(RuntimeValue::String(s)) => Some(s.clone()),
+                    _ => None,
+                })
+                .collect();
+            out.sort();
+            out
+        }
+    };
+
+    // Zero hops alone: `both` IS a :UU, so it must match itself.
+    assert_eq!(
+        names(
+            "MATCH (a:Person {name: 'a'})-[:WORKS_WITH]->(t:TT)-[:WORKS_WITH*0..0]->(u:UU) \
+             RETURN u.name AS n"
+        )
+        .await,
+        vec!["both".to_string()],
+        "a zero-length hop must recognise the source's own labels"
+    );
+
+    // Zero-or-more: both the source itself and the node one hop beyond.
+    assert_eq!(
+        names(
+            "MATCH (a:Person {name: 'a'})-[:WORKS_WITH]->(t:TT)-[:WORKS_WITH*0..2]->(u:UU) \
+             RETURN u.name AS n"
+        )
+        .await,
+        vec!["both".to_string(), "far".to_string()]
+    );
+
+    // Control: min == 1 excludes the source, and always did.
+    assert_eq!(
+        names(
+            "MATCH (a:Person {name: 'a'})-[:WORKS_WITH]->(t:TT)-[:WORKS_WITH*1..2]->(u:UU) \
+             RETURN u.name AS n"
+        )
+        .await,
+        vec!["far".to_string()]
+    );
+}

--- a/crates/namidb-query/tests/exec_rewrite_equivalence.rs
+++ b/crates/namidb-query/tests/exec_rewrite_equivalence.rs
@@ -1,0 +1,315 @@
+//! Differential correctness: query rewrites that MUST return identical rows.
+//!
+//! Four silent wrong-answer bugs surfaced in this engine on 2026-09-10 —
+//! an anonymous intermediate node re-anchoring the next hop, quantifiers over
+//! a target's list property reading an empty stub, a `*0..n` pattern losing
+//! its own source, and `RETURN` columns reported in the wrong order. None of
+//! them raised an error. Every one of them returned plausible rows.
+//!
+//! The suite could not catch that class because it asserts each query against
+//! a hand-written expectation: if the expectation is written from observed
+//! behaviour, it locks the bug in. This file asserts something the engine
+//! cannot satisfy by being consistently wrong — that two SPELLINGS of the
+//! same question agree with each other.
+//!
+//! Add a family here whenever a rewrite is supposed to be meaning-preserving.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use namidb_core::id::{NamespaceId, NodeId};
+use namidb_core::schema::{DataType, EdgeTypeDef, LabelDef, PropertyDef, SchemaBuilder};
+use namidb_core::value::Value as CoreValue;
+use namidb_storage::{EdgeWriteRecord, NamespacePaths, NodeWriteRecord, WriterSession};
+use object_store::memory::InMemory;
+use object_store::ObjectStore;
+
+use namidb_query::{execute, lower, optimize, parse, Params, Row, RuntimeValue, StatsCatalog};
+
+fn node(props: Vec<(&str, CoreValue)>) -> NodeWriteRecord {
+    NodeWriteRecord {
+        properties: props
+            .into_iter()
+            .map(|(k, v)| (k.to_string(), v))
+            .collect::<BTreeMap<_, _>>(),
+        schema_version: 0,
+        labels: vec![],
+    }
+}
+
+fn s(v: &str) -> CoreValue {
+    CoreValue::Str(v.into())
+}
+
+/// `(p1)-[:E]->(q1:Q:S)-[:E]->(r1)`, `(p1)-[:E]->(q2)-[:E]->(r2)`,
+/// `(p2)-[:E]->(q3)`. `q*` carry a `tags` list.
+async fn fixture() -> WriterSession {
+    let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    let paths = NamespacePaths::new("tenants", NamespaceId::new("rewrite-equiv").unwrap());
+    let mut w = WriterSession::open(store, paths).await.unwrap();
+    let schema = SchemaBuilder::new()
+        .label(LabelDef {
+            name: "P".into(),
+            properties: vec![PropertyDef::new("n", DataType::Utf8, false).unwrap()],
+        })
+        .unwrap()
+        .label(LabelDef {
+            name: "Q".into(),
+            properties: vec![PropertyDef::new("n", DataType::Utf8, false).unwrap()],
+        })
+        .unwrap()
+        .label(LabelDef {
+            name: "R".into(),
+            properties: vec![PropertyDef::new("n", DataType::Utf8, false).unwrap()],
+        })
+        .unwrap()
+        .edge_type(EdgeTypeDef {
+            name: "E".into(),
+            src_label: "P".into(),
+            dst_label: "Q".into(),
+            properties: vec![],
+        })
+        .unwrap()
+        .build();
+
+    let p1 = NodeId::new();
+    let p2 = NodeId::new();
+    w.upsert_node("P", p1, &node(vec![("n", s("p1"))])).unwrap();
+    w.upsert_node("P", p2, &node(vec![("n", s("p2"))])).unwrap();
+
+    // q1 carries a SECOND label, which is what a `*0..n` source must not lose.
+    let q1 = NodeId::new();
+    w.upsert_node_with_labels(
+        ["Q".to_string(), "S".to_string()],
+        q1,
+        &node(vec![
+            ("n", s("q1")),
+            ("tags", CoreValue::List(vec![s("t1"), s("t2")])),
+        ]),
+    )
+    .unwrap();
+    let q2 = NodeId::new();
+    w.upsert_node(
+        "Q",
+        q2,
+        &node(vec![
+            ("n", s("q2")),
+            ("tags", CoreValue::List(vec![s("t3")])),
+        ]),
+    )
+    .unwrap();
+    let q3 = NodeId::new();
+    w.upsert_node(
+        "Q",
+        q3,
+        &node(vec![
+            ("n", s("q3")),
+            ("tags", CoreValue::List(vec![s("t1")])),
+        ]),
+    )
+    .unwrap();
+
+    let r1 = NodeId::new();
+    let r2 = NodeId::new();
+    w.upsert_node("R", r1, &node(vec![("n", s("r1"))])).unwrap();
+    w.upsert_node("R", r2, &node(vec![("n", s("r2"))])).unwrap();
+
+    for (a, b) in [(p1, q1), (p1, q2), (p2, q3), (q1, r1), (q2, r2)] {
+        w.upsert_edge("E", a, b, &EdgeWriteRecord::default())
+            .unwrap();
+    }
+    w.commit_batch().await.unwrap();
+    w.flush(schema).await.unwrap();
+    w
+}
+
+/// Rows as an order-insensitive multiset of `(column, value)` maps, so a
+/// family can compare spellings whose row ORDER legitimately differs.
+fn multiset(rows: &[Row]) -> Vec<String> {
+    let mut out: Vec<String> = rows
+        .iter()
+        .map(|r| {
+            r.bindings
+                .iter()
+                .map(|(k, v)| format!("{k}={}", render(v)))
+                .collect::<Vec<_>>()
+                .join(",")
+        })
+        .collect();
+    out.sort();
+    out
+}
+
+fn render(v: &RuntimeValue) -> String {
+    match v {
+        RuntimeValue::Null => "null".into(),
+        RuntimeValue::String(s) => s.clone(),
+        RuntimeValue::Integer(n) => n.to_string(),
+        RuntimeValue::Float(f) => format!("{f:?}"),
+        RuntimeValue::Bool(b) => b.to_string(),
+        other => format!("{other:?}"),
+    }
+}
+
+/// Assert every spelling in `family` returns the same multiset of rows.
+/// Runs through the FULL optimizer, as the server does.
+async fn assert_equivalent(writer: &WriterSession, name: &str, family: &[&str]) {
+    let snapshot = writer.snapshot();
+    let catalog = StatsCatalog::from_manifest(&snapshot.manifest().manifest);
+    let mut baseline: Option<(String, Vec<String>)> = None;
+    for query in family {
+        let parsed = parse(query).unwrap_or_else(|e| panic!("{name}: parse `{query}`: {e:?}"));
+        let plan = optimize(
+            lower(&parsed).unwrap_or_else(|e| panic!("{name}: lower `{query}`: {e:?}")),
+            &catalog,
+        );
+        let rows = execute(&plan, &snapshot, &Params::new())
+            .await
+            .unwrap_or_else(|e| panic!("{name}: execute `{query}`: {e:?}"));
+        let got = multiset(&rows);
+        match &baseline {
+            None => baseline = Some(((*query).to_string(), got)),
+            Some((first, expected)) => assert_eq!(
+                &got, expected,
+                "\n{name}: these must agree but do not.\n  A: {first}\n  B: {query}\n"
+            ),
+        }
+    }
+}
+
+#[tokio::test]
+async fn meaning_preserving_rewrites_agree() {
+    let w = fixture().await;
+
+    assert_equivalent(
+        &w,
+        "inline label vs labels() predicate",
+        &[
+            "MATCH (a:P)-[:E]->(b:Q) RETURN b.n AS n",
+            "MATCH (a:P)-[:E]->(b) WHERE 'Q' IN labels(b) RETURN b.n AS n",
+        ],
+    )
+    .await;
+
+    // The 2.6.5 bug: an anonymous intermediate re-anchored the next hop.
+    assert_equivalent(
+        &w,
+        "anonymous vs named intermediate",
+        &[
+            "MATCH (a:P)-[:E]->(m:Q)-[:E]->(z:R) RETURN z.n AS n",
+            "MATCH (a:P)-[:E]->()-[:E]->(z:R) RETURN z.n AS n",
+            "MATCH (a:P)-[:E*2..2]->(z:R) RETURN z.n AS n",
+        ],
+    )
+    .await;
+
+    assert_equivalent(
+        &w,
+        "direction reversal",
+        &[
+            "MATCH (a:P)-[:E]->(b:Q) RETURN b.n AS n",
+            "MATCH (b:Q)<-[:E]-(a:P) RETURN b.n AS n",
+        ],
+    )
+    .await;
+
+    assert_equivalent(
+        &w,
+        "inline property vs WHERE vs WITH-WHERE",
+        &[
+            "MATCH (a:P)-[:E]->(b:Q {n: 'q1'}) RETURN b.n AS n",
+            "MATCH (a:P)-[:E]->(b:Q) WHERE b.n = 'q1' RETURN b.n AS n",
+            "MATCH (a:P)-[:E]->(b:Q) WITH b WHERE b.n = 'q1' RETURN b.n AS n",
+        ],
+    )
+    .await;
+
+    // The 2.6.8 bug: the target was bound as an empty stub, so `b.tags` was
+    // null and the quantifier matched nothing.
+    //
+    // The alias must appear ONLY inside the quantifier. Returning `b.n` as
+    // well registers `b` by that reference and suppresses the stub entirely —
+    // a first draft of this family did exactly that and passed with the fix
+    // REVERTED, which is worse than having no family at all.
+    assert_equivalent(
+        &w,
+        "quantifier vs IN, target referenced only inside the predicate",
+        &[
+            "MATCH (a:P)-[:E]->(b:Q) WHERE any(x IN b.tags WHERE x = 't1') RETURN count(*) AS c",
+            "MATCH (a:P)-[:E]->(b:Q) WHERE 't1' IN b.tags RETURN count(*) AS c",
+        ],
+    )
+    .await;
+    assert_equivalent(
+        &w,
+        "all()/none() with the target referenced only in the predicate",
+        &[
+            "MATCH (a:P)-[:E]->(b:Q) WHERE none(x IN b.tags WHERE x = 't1') RETURN count(*) AS c",
+            "MATCH (a:P)-[:E]->(b:Q) WHERE NOT ('t1' IN b.tags) RETURN count(*) AS c",
+        ],
+    )
+    .await;
+    assert_equivalent(
+        &w,
+        "list comprehension with the target referenced only in the predicate",
+        &[
+            "MATCH (a:P)-[:E]->(b:Q) WHERE size([x IN b.tags WHERE x <> 'zz']) > 0 \
+             RETURN count(*) AS c",
+            "MATCH (a:P)-[:E]->(b:Q) WHERE size(b.tags) > 0 RETURN count(*) AS c",
+        ],
+    )
+    .await;
+
+    assert_equivalent(
+        &w,
+        "count(*) vs size(collect())",
+        &[
+            "MATCH (a:P)-[:E]->(b:Q) RETURN count(*) AS c",
+            "MATCH (a:P)-[:E]->(b:Q) WITH collect(b) AS bs RETURN size(bs) AS c",
+        ],
+    )
+    .await;
+
+    assert_equivalent(
+        &w,
+        "count(DISTINCT x) vs WITH DISTINCT",
+        &[
+            "MATCH (a:P)-[:E]->(b:Q) RETURN count(DISTINCT b) AS c",
+            "MATCH (a:P)-[:E]->(b:Q) WITH DISTINCT b RETURN count(*) AS c",
+        ],
+    )
+    .await;
+
+    assert_equivalent(
+        &w,
+        "single hop vs *1..1",
+        &[
+            "MATCH (a:P)-[:E]->(b:Q) RETURN b.n AS n",
+            "MATCH (a:P)-[:E*1..1]->(b:Q) RETURN b.n AS n",
+        ],
+    )
+    .await;
+
+    // The 2.6.8 bug: a `*0..n` source bound as a stub lost its second label.
+    // Same trap here: `q` must not be referenced outside the `*0..0` pattern,
+    // or the stub it depends on is never built.
+    assert_equivalent(
+        &w,
+        "zero-hop source keeps its own labels",
+        &[
+            "MATCH (a:P)-[:E]->(q:Q)-[:E*0..0]->(z:S) RETURN count(*) AS c",
+            "MATCH (a:P)-[:E]->(q:Q) WHERE 'S' IN labels(q) RETURN count(*) AS c",
+        ],
+    )
+    .await;
+
+    assert_equivalent(
+        &w,
+        "conjunctive multi-label vs labels() predicate",
+        &[
+            "MATCH (b:Q:S) RETURN b.n AS n",
+            "MATCH (b:Q) WHERE 'S' IN labels(b) RETURN b.n AS n",
+        ],
+    )
+    .await;
+}

--- a/docs/testing/25tb-readiness.md
+++ b/docs/testing/25tb-readiness.md
@@ -1225,3 +1225,42 @@ variant that produces 40,000. That asymmetry is not explained by result
 volume and is the sharpest available lead.
 
 Not a regression: every one of these timed out on 2.6.5.
+
+### 78. [OPEN — conformance question, NOT fixed] A repeated type in an alternation duplicates rows
+
+`MATCH (a:P)-[:E|E]->(b:Q)` returns every matching row TWICE; `-[:E]->`
+returns it once. The executor unions one partner list per listed type
+(`neighbours_of_any`, walker.rs) and a type written twice is traversed
+twice.
+
+**I did not change this, deliberately.**
+`exec_alternation.rs:314-316` asserts the current behaviour on purpose:
+
+    // `[:KNOWS|:KNOWS]` should produce TWO rows per edge (one per listed
+    // type) — that's the per-path semantic the executor follows.
+    assert_eq!(alt_rows.len(), 4, "two types × two edges = four rows");
+
+My reading is that this is wrong: in openCypher a type alternation is a
+PREDICATE on one relationship (`type(r) IN {A, B}`), not a cross product
+over the listed types, so one edge is one path and should yield one row —
+which is what Neo4j does. Deduplicating the type list at lowering
+(`lower_rel_node`, one filter over `rel.types`) fixes it and breaks only
+that assertion.
+
+But it IS a deliberate, documented decision, the input is degenerate
+(nobody hand-writes `[:E|E]`), and changing it is a semantic change to
+shipped behaviour rather than a defect fix. It needs an owner's call, not
+a late-session unilateral one. Worth noting the realistic way to hit it:
+a query builder mapping a type list that is not itself deduplicated.
+
+Found by a differential harness that runs families of query rewrites that
+must return identical results and compares them
+(scratchpad `equiv.py`). Twelve of thirteen families agreed — including
+labelled-vs-`labels()`, explicit-chain-vs-`*2..2`,
+anonymous-vs-named intermediate, direction reversal, inline-property vs
+WHERE, MATCH-WHERE vs WITH-WHERE, quantifier vs `IN`, `count(*)` vs
+`size(collect())`, DISTINCT vs grouping, OPTIONAL-when-all-match,
+`*1..1` vs a single hop, and conjunctive multi-label. That harness is
+worth keeping: comparing RESULTS across equivalent rewrites is what the
+suite does not do, and four wrong-answer bugs surfaced in this codebase
+today.


### PR DESCRIPTION
## Both return plausible results, both are pre-existing

An unreferenced Expand target is bound as an **id-only stub**: empty properties, and only the labels that Expand asked for. Anything that later reads more than that from the stub gets a wrong answer rather than an error. Two places do.

## 1. Quantifiers and list comprehensions

`collect_referenced_variables` grouped `Quantifier` and `ListComprehension` with `Exists` and `PatternComprehension` under *"closed pattern forms — the binding reads they perform live inside their own sub-plan"*.

True of the pattern forms. False of these two: a quantifier is a plain list operation over a host binding. So `t` was never registered, `t.tags` read as null off the stub, and the predicate matched nothing.

| query | returned | expected |
|---|---|---|
| `WHERE any(x IN t.tags WHERE x = 'a')` | **0** | 1 |
| `WHERE all(x IN t.tags WHERE x <> 'z')` | **0** | 2 |
| `WHERE t.name = 't1'` | 1 | 1 |
| `WHERE size(t.tags) = 1` | 1 | 1 |

The two controls passing is why this went unnoticed — the shape looks like it works until the predicate happens to be a quantifier.

They now collect their list, predicate and projection, exactly as `reduce()` immediately above them already does, and for the reason its comment gives: the element variable shadows any same-named host binding, so collecting it over-collects, which is the safe direction for a thin row.

## 2. Zero-length patterns lose their source

The `*0..n` arm decides whether the source is itself a result by reading the labels **off the row**. A node labelled `:TT:UU` bound by `->(t:TT)` gets a stub carrying only `["TT"]`:

```cypher
MATCH (a:AA)-[:R]->(t:TT)-[:S*0..0]->(u:UU) RETURN u.n
-- returned []   against a node whose labels() is genuinely ["TT","UU"]

MATCH (a:AA)-[:R]->(t:TT)-[:S*0..2]->(u:UU) RETURN u.n
-- returned ["far"], missing the source itself
```

`PlanRouting` now collects the source alias of every `*0..n` Expand, and `should_skip_target_materialize` refuses those aliases.

## Scope

`labels(t)` and `t.prop` were never affected — referencing them registers the alias, so no stub is used. I checked both explicitly. Only the two internal reads above went through the stub without the alias counting as referenced.

## Tests

Both in `exec_plan_aware_routing.rs`, and **both verified to fail without their fix** — I reverted each change and confirmed the test goes red (`left: 0, right: 1` and `left: [], right: ["both"]`).

Verified end to end against a release build over HTTP as well, alongside the 2.6.7 fixes.

Suites green: 559 lib, `exec_plan_aware_routing` (12), `exec_match_expand` (66), `exec_supernode` (3), `exec_shortest_path`, `exec_alternation`.

## How these were found

A workflow of readers looking for hazards that a *different* planned change (item 74, the identity-only tier) would amplify. Neither was the thing it was asked about; both were pre-existing bugs sitting next to it. I then reproduced both over HTTP before writing a line of code.