### PR TITLE
A repeated type in an alternation no longer doubles every row (2.6.9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,24 @@ crates.io release will establish and document that API explicitly.
 
 ## [Unreleased]
 
+## [2.6.9] - 2026-09-10
+
+### Fixed
+
+- **A relationship type written twice in an alternation no longer doubles
+  every row.** `-[:E|E]->` returned each matching row once per listed type;
+  `-[:A|B|A]->` returned the `:A` rows twice. A type alternation is a SET —
+  RFC-024 defines the output as "one row per matching PATH, not one row per
+  tuple", and a path is a sequence of actual edges, so writing a type twice
+  cannot create a second edge. Both executors union one partner list per
+  listed type, so the list is now deduplicated at lowering, preserving
+  first-seen order. Genuine alternation, parallel-edge multiplicity and
+  flat/WCOJ parity are unchanged.
+
+  The likely way to hit this was never hand-written Cypher but a query
+  builder joining a type list that was not itself deduplicated.
+
+
 ## [2.6.8] - 2026-09-10
 
 ### Fixed
@@ -3276,7 +3294,8 @@ Change License: Apache License 2.0).
 - LDBC-shaped synthetic benchmark harness with a paired Kùzu runner
   under [`bench/`](./bench/).
 
-[Unreleased]: https://github.com/namidb/namidb/compare/v2.6.8...HEAD
+[Unreleased]: https://github.com/namidb/namidb/compare/v2.6.9...HEAD
+[2.6.9]: https://github.com/namidb/namidb/compare/v2.6.8...v2.6.9
 [2.6.8]: https://github.com/namidb/namidb/compare/v2.6.7...v2.6.8
 [2.6.7]: https://github.com/namidb/namidb/compare/v2.6.6...v2.6.7
 [2.6.6]: https://github.com/namidb/namidb/compare/v2.6.5...v2.6.6

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2199,7 +2199,7 @@ dependencies = [
 
 [[package]]
 name = "namidb"
-version = "2.6.8"
+version = "2.6.9"
 dependencies = [
  "namidb-core",
  "namidb-graph",
@@ -2209,7 +2209,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-ann"
-version = "2.6.8"
+version = "2.6.9"
 dependencies = [
  "namidb-core",
  "rand 0.8.6",
@@ -2222,7 +2222,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-bench"
-version = "2.6.8"
+version = "2.6.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2246,7 +2246,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-bolt"
-version = "2.6.8"
+version = "2.6.9"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2266,7 +2266,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-cli"
-version = "2.6.8"
+version = "2.6.9"
 dependencies = [
  "anyhow",
  "clap",
@@ -2286,7 +2286,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-core"
-version = "2.6.8"
+version = "2.6.9"
 dependencies = [
  "arrow-array",
  "arrow-schema",
@@ -2302,7 +2302,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-graph"
-version = "2.6.8"
+version = "2.6.9"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -2324,7 +2324,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-markdown"
-version = "2.6.8"
+version = "2.6.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2347,7 +2347,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-mcp"
-version = "2.6.8"
+version = "2.6.9"
 dependencies = [
  "anyhow",
  "clap",
@@ -2367,7 +2367,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-py"
-version = "2.6.8"
+version = "2.6.9"
 dependencies = [
  "bytes",
  "chrono",
@@ -2385,7 +2385,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-query"
-version = "2.6.8"
+version = "2.6.9"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2409,7 +2409,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-server"
-version = "2.6.8"
+version = "2.6.9"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2449,7 +2449,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-storage"
-version = "2.6.8"
+version = "2.6.9"
 dependencies = [
  "anyhow",
  "arrow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2.6.8"
+version = "2.6.9"
 edition = "2021"
 rust-version = "1.85"
 license = "BUSL-1.1"
@@ -123,13 +123,13 @@ tower = { version = "0.5", features = ["limit"] }
 tower-http = { version = "0.6", features = ["trace", "cors", "timeout"] }
 
 # Local workspace crates
-namidb-core = { path = "crates/namidb-core", version = "2.6.8" }
-namidb-storage = { path = "crates/namidb-storage", version = "2.6.8" }
-namidb-markdown = { path = "crates/namidb-markdown", version = "2.6.8" }
-namidb-graph = { path = "crates/namidb-graph", version = "2.6.8" }
-namidb-ann = { path = "crates/namidb-ann", version = "2.6.8" }
-namidb-query = { path = "crates/namidb-query", version = "2.6.8" }
-namidb-bolt = { path = "crates/namidb-bolt", version = "2.6.8" }
+namidb-core = { path = "crates/namidb-core", version = "2.6.9" }
+namidb-storage = { path = "crates/namidb-storage", version = "2.6.9" }
+namidb-markdown = { path = "crates/namidb-markdown", version = "2.6.9" }
+namidb-graph = { path = "crates/namidb-graph", version = "2.6.9" }
+namidb-ann = { path = "crates/namidb-ann", version = "2.6.9" }
+namidb-query = { path = "crates/namidb-query", version = "2.6.9" }
+namidb-bolt = { path = "crates/namidb-bolt", version = "2.6.9" }
 
 [profile.release]
 opt-level = 3

--- a/crates/namidb-py/pyproject.toml
+++ b/crates/namidb-py/pyproject.toml
@@ -7,7 +7,7 @@ name = "namidb"
 # Keep in sync with the workspace `version` in /Cargo.toml.
 # `python-wheels.yml` publishes a wheel whose filename uses THIS
 # version; the release tag `py-vX.Y.Z` must match X.Y.Z exactly.
-version = "2.6.8"
+version = "2.6.9"
 description = "Cloud-native graph database on object storage (Python bindings)"
 readme = "README.md"
 license = "BUSL-1.1"

--- a/crates/namidb-query/src/plan/lower.rs
+++ b/crates/namidb-query/src/plan/lower.rs
@@ -1300,9 +1300,24 @@ fn lower_rel_node(
                  // `[:A|:B|:C]` lowers to a non-empty Vec; `[]` (untyped) lowers to
                  // None. The executor unions the partner lists across listed types
                  // (RFC-024 §"Open questions" Q1).
+                 // An alternation is a SET of types — RFC-024 defines the output as "one
+                 // row per matching PATH, not one row per tuple", and a path is a sequence
+                 // of actual edges. Both executors union one partner list per LISTED type,
+                 // so a type written twice (`[:E|E]`) traversed the same edge twice and
+                 // doubled every row. Deduplicate here, preserving first-seen order, so the
+                 // flat and WCOJ paths both see a set.
     let edge_type: Option<Vec<String>> = match rel.types.as_slice() {
         [] => None,
-        types => Some(types.iter().map(|t| t.name.clone()).collect()),
+        types => {
+            let mut seen = std::collections::BTreeSet::new();
+            Some(
+                types
+                    .iter()
+                    .map(|t| t.name.clone())
+                    .filter(|name| seen.insert(name.clone()))
+                    .collect(),
+            )
+        }
     };
     let rel_alias = rel.binding.as_ref().map(|b| b.name.clone());
     if let Some(name) = &rel_alias {

--- a/crates/namidb-query/tests/exec_alternation.rs
+++ b/crates/namidb-query/tests/exec_alternation.rs
@@ -310,10 +310,22 @@ async fn expand_alternation_single_type_matches_legacy_path() {
 
     let single_rows = execute(&p_single, &snap, &Params::new()).await.unwrap();
     let alt_rows = execute(&p_alt, &snap, &Params::new()).await.unwrap();
-    // `[:KNOWS|:KNOWS]` should produce TWO rows per edge (one per listed
-    // type) — that's the per-path semantic the executor follows.
+    // A type alternation is a SET. RFC-024 defines the output as "one row per
+    // matching PATH, not one row per tuple", and a path is a sequence of
+    // actual edges — writing the same type twice does not create a second
+    // edge. `[:KNOWS|:KNOWS]` therefore describes exactly the edges `[:KNOWS]`
+    // does and must return exactly its rows.
+    //
+    // This previously asserted FOUR rows, "one per listed type". That was
+    // describing the behaviour, not deriving it: the assertion contradicted
+    // this test's own name and docstring, both of which are about singleton
+    // parity with the pre-RFC path.
     assert_eq!(single_rows.len(), 2);
-    assert_eq!(alt_rows.len(), 4, "two types × two edges = four rows");
+    assert_eq!(
+        alt_rows.len(),
+        2,
+        "a repeated type describes the same edge set, so the same rows"
+    );
 }
 
 // ─────────────────────── MultiwayJoin alternation ───────────────────────

--- a/crates/namidb-query/tests/exec_rewrite_equivalence.rs
+++ b/crates/namidb-query/tests/exec_rewrite_equivalence.rs
@@ -303,6 +303,20 @@ async fn meaning_preserving_rewrites_agree() {
     )
     .await;
 
+    // A type alternation is a SET: writing the same type twice describes the
+    // same edges, so it must return the same rows. It used to return each row
+    // once per listed type.
+    assert_equivalent(
+        &w,
+        "repeated type in an alternation",
+        &[
+            "MATCH (a:P)-[:E]->(b:Q) RETURN b.n AS n",
+            "MATCH (a:P)-[:E|E]->(b:Q) RETURN b.n AS n",
+            "MATCH (a:P)-[:E|E|E]->(b:Q) RETURN b.n AS n",
+        ],
+    )
+    .await;
+
     assert_equivalent(
         &w,
         "conjunctive multi-label vs labels() predicate",

--- a/docs/testing/25tb-readiness.md
+++ b/docs/testing/25tb-readiness.md
@@ -1111,49 +1111,73 @@ flag (`--http-request-timeout`, `0s` disables) whose default is derived
 to clear the largest configured query/write budget, with a boot warning
 when an explicit value would truncate them.
 
-### 75. [OPEN — measured] `LIMIT` does not bound an expansion's work
+### 75. [OPEN — measured, design ready] `LIMIT` does not bound an expansion's work
 
-Measured on 2.6.6, ~1 KB targets, `MATCH (h:HUB)-[:TIENE]->(t:FAT)`:
+Re-measured on 2.6.9, degree 160,000, ~1 KB targets,
+`MATCH (h:HUB)-[:TIENE]->(t:FAT)`:
 
-| degree | `RETURN t.idx LIMIT 25` | `RETURN count(t)` | ratio |
-|---|---|---|---|
-| 10,000 | 0.44 s | 0.44 s | 1.00 |
-| 40,000 | 0.59 s | 0.63 s | 0.94 |
-| 160,000 | 2.42 s | 2.55 s | 0.95 |
+| query | time |
+|---|---|
+| `RETURN count(*)` (target unreferenced -> membership sidecar) | **0.65 s** |
+| `RETURN count(t)` (hydrates) | 2.18 s |
+| `RETURN t.idx LIMIT 25` | 2.01 s |
+| `RETURN t.idx LIMIT 1` | **2.04 s** |
 
-`LIMIT 25` costs the same as consuming the whole adjacency, and grows
-linearly with degree. `execute_expand` checks its pushed-down cap only at
-the SEED boundary (the contract is that every consumed seed contributes
-its COMPLETE edge set); the hop loop collects every partner into
-`unique_targets` before any cap applies, `prepare_expand_targets`
-hydrates all of them, and the truncation to 25 happens above the operator.
+`LIMIT 1` costs what the full scan costs. The cap is checked only at the
+SEED boundary — the contract being that every consumed seed contributes
+its COMPLETE edge set — so the hop loop collects every partner into
+`unique_targets`, `prepare_expand_targets` hydrates all of them, and the
+truncation happens above the operator.
 
-**Where the time actually goes.** Isolated at degree 160,000 — note that
-all four shapes must be compared on ONE dataset, since the cheap
-membership path needs a LABELLED target and comparing across fixtures
-gives a misleading split:
+Split: hydration ~1.4 s (**~70%**), adjacency read plus membership
+~0.65 s (**~30%**). Bounding hydration takes `LIMIT 25` to roughly 0.7 s.
+The remaining 30% needs the limit inside `out_edges`, which has no limit
+parameter — that is the storage half, and it is where the hierarchical
+adjacency work from finding #3 actually earns its keep.
 
-| shape | time | path |
-|---|---|---|
-| `(t:FAT)` + `count(*)` | **0.63 s** | adjacency read + label-membership sidecar |
-| `(t:FAT)` + `count(t)` | 2.37 s | + full hydration |
-| `()` + `count(*)` | 2.24 s | unlabelled: no membership path available |
+**Why a plain truncation is WRONG.** The per-edge loop has eight
+`continue` paths (label mismatch, membership, trail rule, visited-set
+pruning, node absent). Taking the first N edges UNDERFILLS whenever any
+edge is rejected — fewer rows than the user asked for, a wrong answer
+rather than a slow one, and the fourth such bug class this codebase has
+produced this week.
 
-So hydration is ~1.74 s of 2.37 s (**~73%**) and the adjacency read plus
-membership is ~0.63 s (**~27%**).
+**The design, ready to execute.** A wave loop: hydrate a bounded chunk,
+run the per-edge loop over exactly that chunk, take another chunk only if
+the cap is not yet met. Order is preserved because chunks are consecutive.
 
-1. *Executor — recovers the ~73%.* Bounding the hydration set cannot be a
-   plain truncation of `unique_targets`: the per-edge loop has eight
-   `continue` paths (label mismatch, membership, trail rule, visited-set
-   pruning), so taking the first N edges UNDERFILLS whenever any edge is
-   rejected — fewer rows than asked for, a wrong answer rather than a slow
-   one. It needs a wave loop: hydrate a bounded chunk, run the per-edge
-   loop over exactly that chunk, take another chunk only if the cap is not
-   yet met. Order is preserved because the chunks are consecutive.
-2. *Storage — the remaining ~27%.* `out_edges(edge_type, src) ->
-   EdgeListView` has no limit parameter and materialises the whole partner
-   list, so no executor-side change can avoid it. This is the part that
-   genuinely wants the hierarchical adjacency work from finding #3.
+- Guard, computed once beside `endpoint_bfs`:
+  `cap.is_some() && max == 1 && !back_reference && shortest == ShortestMode::None && !endpoint_bfs`.
+  Each clause earns its place: `max == 1` means the frontier holds exactly
+  one `Step` per seed and the hop loop runs once, so a wave is literally a
+  chunk of one `Arc<Vec<EdgeView>>`; the other three switch on the
+  loop-carried pruning state below.
+- Loop-carried state, and where each must live. With that guard:
+  `level_seen`, `visited` and `visited_at_hop` are all dead (they need
+  `prune_visits` / `hop_keyed_prune`, which need shortest or endpoint_bfs);
+  `next_frontier` is never pushed (`hop < max` is false at `max == 1`);
+  `guard_tick` is a counter and hoists above the wave loop; `matched_any`
+  must persist ACROSS waves. `unique_targets` / `seen_targets` are
+  per-wave. Getting one of these wrong is a silent wrong answer, which is
+  why they are enumerated here rather than rediscovered.
+- Phase 1 (the adjacency read into `step_neighbours`) stays OUTSIDE the
+  wave loop — it is the 30% that no executor change can avoid.
+- Cursor `(step_index, edge_index)` advances across waves; stop when the
+  cursor exhausts or `out.len() + hop_results.len() >= cap`.
+- Initial chunk `max(cap * 4, 512)`, doubling. Sizing is a starting point,
+  not a measured optimum — tune against the 160k-degree fixture.
+- Oracle: `LIMIT n` must return exactly `min(n, total)` rows. Build the
+  underfill case deliberately — a hub whose neighbours are half a
+  non-matching label, `LIMIT 25`, assert exactly 25.
+
+**Deliberately not done in the 2026-09-10 session.** This restructures
+~250 lines of the per-edge loop so it can run over a range. That function
+was modified four times that day, twice to correct the previous change,
+and the payoff here is 3x on one query shape rather than a correctness
+fix. Shipping it as the seventh release of a long day is how a third
+regression gets introduced. The measurement and the design above are the
+part worth having; the edit should be made deliberately, with the
+equivalence suite and the underfill oracle in place first.
 
 ### 76. [OPEN — measured, correct by design] An unlabelled unreferenced target cannot use the membership path
 


### PR DESCRIPTION
## The behaviour

`-[:E|E]->` returned each matching row **once per listed type**. `-[:A|B|A]->` returned the `:A` rows twice.

Measured live across eight shapes on a fixture with 3 `:A` edges and 1 `:B` edge:

| pattern | before | after | correct |
|---|---|---|---|
| `[:A]` | 3 | 3 | 3 |
| `[:A\|A]` | **6** | 3 | 3 |
| `[:A\|A\|A]` | **9** | 3 | 3 |
| `[:A\|B]` | 4 | 4 | 4 |
| `[:B\|A]` | 4 | 4 | 4 |
| `[:A\|B\|A]` | **7** | 4 | 4 |
| `[:B]` | 1 | 1 | 1 |
| untyped | 4 | 4 | 4 |

## Why this is a defect and not a semantic

A type alternation is a **set**. RFC-024 defines the output as *"one row per matching PATH, not one row per tuple"*, and a path is a sequence of actual edges — writing a type twice cannot create a second edge. `[:E]` and `[:E|E]` describe the same edges.

Both executors union one partner list per **listed** type, so the list is now deduplicated at lowering, preserving first-seen order. The flat and WCOJ paths both see a set.

## I nearly left this alone

`exec_alternation.rs` asserted the doubling deliberately:

```rust
// `[:KNOWS|:KNOWS]` should produce TWO rows per edge (one per listed
// type) — that's the per-path semantic the executor follows.
assert_eq!(alt_rows.len(), 4, "two types × two edges = four rows");
```

I flagged it as an owner's call rather than change it unilaterally. What settled it was reading the test itself: it is named `expand_alternation_single_type_matches_legacy_path`, and its docstring says it checks that a **singleton** alternation matches the pre-RFC path. It then queries `[:KNOWS|:KNOWS]` — a *repeated* type, not a singleton — and asserts the doubling.

The assertion was describing observed behaviour, not deriving it, and it contradicted both the test's own stated purpose and the RFC it was written for. That is the same failure mode as the four wrong-answer bugs this week: an expectation written from what the engine did, which then locks the behaviour in.

## Unchanged

Genuine alternation across distinct types, parallel-edge multiplicity (two edges between the same endpoints are still two paths, and `expand_alternation_parallel_edges_yield_distinct_rows` still passes), and flat/WCOJ per-path parity (`multiway_join_alternation_per_path_count_matches_binary_in_all_cases`). All 12 alternation tests pass; only the degenerate case moves.

A family was added to `exec_rewrite_equivalence.rs` asserting `[:E]`, `[:E|E]` and `[:E|E|E]` agree.

## How it was found

The differential harness added in 2.6.8 — running families of rewrites that must return identical rows. Twelve of thirteen families agreed; this was the one that did not.