### PR TITLE
Bound an expansion's hydration under a pushed-down LIMIT (2.6.10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,18 @@ crates.io release will establish and document that API explicitly.
 
 ## [2.6.10] - 2026-09-10
 
+### Fixed
+
+- **Deleting a connected node without `DETACH` now returns 409, not 500.** The
+  error was raised as a runtime fault, so it fell to the unclassified arm and
+  surfaced as `HTTP 500` with `Neo.DatabaseError` — a permanent caller mistake
+  reported as a transient server fault. Retry middleware retried it forever,
+  and it counted against server error budgets. It is now a constraint
+  violation: `409 Conflict`,
+  `Neo.ClientError.Schema.ConstraintValidationFailed`, `gql_status 23000` —
+  exactly Neo4j's classification for this case. The message, which already
+  named the remedy, is unchanged.
+
 ### Performance
 
 - **`LIMIT` now bounds an expansion's work instead of costing the full

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,35 @@ crates.io release will establish and document that API explicitly.
 
 ## [Unreleased]
 
+## [2.6.10] - 2026-09-10
+
+### Performance
+
+- **`LIMIT` now bounds an expansion's work instead of costing the full
+  traversal.** A pushed-down limit was checked only at the seed boundary, so
+  the hop loop collected every partner and hydrated all of them before the
+  truncation happened above the operator: at degree 160,000 with ~1 KB
+  targets, `LIMIT 1` cost 2.04 s — the same as counting all 160,000 rows.
+  Endpoints are now hydrated in consecutive windows, the per-edge loop runs
+  over exactly one window, and another window is taken only if the limit is
+  still unmet. `LIMIT 1` is 0.32 s and `LIMIT 25` is 0.31 s, a 6.5x
+  improvement; a limit larger than the available rows costs what it always
+  did.
+
+  The window cannot simply truncate the endpoint list: the per-edge loop
+  rejects edges on many paths (label mismatch, membership, the trail rule,
+  visited pruning, an absent node), so hydrating "the first N" would return
+  FEWER rows than requested. Windows are consecutive and re-entered until
+  the limit is met, so the result stays an order-preserving prefix of the
+  uncapped one. Restricted to single-hop, non-back-reference expansions
+  outside shortest-path and endpoint-BFS modes, whose pruning state depends
+  on observing a whole level.
+
+  Verified live on a hub with 30,000 rejected neighbours among 40,000: every
+  limit from 1 to beyond the total returns exactly `min(limit, total)` rows
+  and matches the uncapped prefix.
+
+
 ## [2.6.9] - 2026-09-10
 
 ### Fixed
@@ -3294,7 +3323,8 @@ Change License: Apache License 2.0).
 - LDBC-shaped synthetic benchmark harness with a paired Kùzu runner
   under [`bench/`](./bench/).
 
-[Unreleased]: https://github.com/namidb/namidb/compare/v2.6.9...HEAD
+[Unreleased]: https://github.com/namidb/namidb/compare/v2.6.10...HEAD
+[2.6.10]: https://github.com/namidb/namidb/compare/v2.6.9...v2.6.10
 [2.6.9]: https://github.com/namidb/namidb/compare/v2.6.8...v2.6.9
 [2.6.8]: https://github.com/namidb/namidb/compare/v2.6.7...v2.6.8
 [2.6.7]: https://github.com/namidb/namidb/compare/v2.6.6...v2.6.7

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2199,7 +2199,7 @@ dependencies = [
 
 [[package]]
 name = "namidb"
-version = "2.6.9"
+version = "2.6.10"
 dependencies = [
  "namidb-core",
  "namidb-graph",
@@ -2209,7 +2209,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-ann"
-version = "2.6.9"
+version = "2.6.10"
 dependencies = [
  "namidb-core",
  "rand 0.8.6",
@@ -2222,7 +2222,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-bench"
-version = "2.6.9"
+version = "2.6.10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2246,7 +2246,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-bolt"
-version = "2.6.9"
+version = "2.6.10"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2266,7 +2266,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-cli"
-version = "2.6.9"
+version = "2.6.10"
 dependencies = [
  "anyhow",
  "clap",
@@ -2286,7 +2286,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-core"
-version = "2.6.9"
+version = "2.6.10"
 dependencies = [
  "arrow-array",
  "arrow-schema",
@@ -2302,7 +2302,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-graph"
-version = "2.6.9"
+version = "2.6.10"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -2324,7 +2324,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-markdown"
-version = "2.6.9"
+version = "2.6.10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2347,7 +2347,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-mcp"
-version = "2.6.9"
+version = "2.6.10"
 dependencies = [
  "anyhow",
  "clap",
@@ -2367,7 +2367,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-py"
-version = "2.6.9"
+version = "2.6.10"
 dependencies = [
  "bytes",
  "chrono",
@@ -2385,7 +2385,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-query"
-version = "2.6.9"
+version = "2.6.10"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2409,7 +2409,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-server"
-version = "2.6.9"
+version = "2.6.10"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2449,7 +2449,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-storage"
-version = "2.6.9"
+version = "2.6.10"
 dependencies = [
  "anyhow",
  "arrow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2.6.9"
+version = "2.6.10"
 edition = "2021"
 rust-version = "1.85"
 license = "BUSL-1.1"
@@ -123,13 +123,13 @@ tower = { version = "0.5", features = ["limit"] }
 tower-http = { version = "0.6", features = ["trace", "cors", "timeout"] }
 
 # Local workspace crates
-namidb-core = { path = "crates/namidb-core", version = "2.6.9" }
-namidb-storage = { path = "crates/namidb-storage", version = "2.6.9" }
-namidb-markdown = { path = "crates/namidb-markdown", version = "2.6.9" }
-namidb-graph = { path = "crates/namidb-graph", version = "2.6.9" }
-namidb-ann = { path = "crates/namidb-ann", version = "2.6.9" }
-namidb-query = { path = "crates/namidb-query", version = "2.6.9" }
-namidb-bolt = { path = "crates/namidb-bolt", version = "2.6.9" }
+namidb-core = { path = "crates/namidb-core", version = "2.6.10" }
+namidb-storage = { path = "crates/namidb-storage", version = "2.6.10" }
+namidb-markdown = { path = "crates/namidb-markdown", version = "2.6.10" }
+namidb-graph = { path = "crates/namidb-graph", version = "2.6.10" }
+namidb-ann = { path = "crates/namidb-ann", version = "2.6.10" }
+namidb-query = { path = "crates/namidb-query", version = "2.6.10" }
+namidb-bolt = { path = "crates/namidb-bolt", version = "2.6.10" }
 
 [profile.release]
 opt-level = 3

--- a/crates/namidb-py/pyproject.toml
+++ b/crates/namidb-py/pyproject.toml
@@ -7,7 +7,7 @@ name = "namidb"
 # Keep in sync with the workspace `version` in /Cargo.toml.
 # `python-wheels.yml` publishes a wheel whose filename uses THIS
 # version; the release tag `py-vX.Y.Z` must match X.Y.Z exactly.
-version = "2.6.9"
+version = "2.6.10"
 description = "Cloud-native graph database on object storage (Python bindings)"
 readme = "README.md"
 license = "BUSL-1.1"

--- a/crates/namidb-query/src/exec/walker.rs
+++ b/crates/namidb-query/src/exec/walker.rs
@@ -1750,9 +1750,6 @@ pub(crate) async fn execute_expand(
             // (2 k+ uncached lookups × 4.2 ms each in the SF1 profile).
             let mut step_neighbours: Vec<(Step, Arc<Vec<EdgeView>>)> =
                 Vec::with_capacity(frontier.len());
-            let mut unique_targets: Vec<NodeId> = Vec::new();
-            let mut seen_targets: std::collections::HashSet<NodeId> =
-                std::collections::HashSet::new();
             for step in frontier.drain(..) {
                 let neighbours: Arc<Vec<EdgeView>> = if back_reference && max == 1 {
                     Arc::new(match existing_target_id {
@@ -1790,310 +1787,392 @@ pub(crate) async fn execute_expand(
                     }
                     fetched
                 };
+                step_neighbours.push((step, neighbours));
+            }
+            // Phase 2, in WAVES when a pushed-down LIMIT is in play.
+            //
+            // Hydrating every endpoint before emitting anything makes
+            // `LIMIT 1` cost what the whole traversal costs: at degree
+            // 160k that is ~2.0s where the adjacency read alone is 0.65s.
+            // But the cap CANNOT simply truncate the endpoint list: the
+            // per-edge loop below rejects edges on a dozen paths (label
+            // mismatch, membership, the trail rule, visited pruning, an
+            // absent node), so hydrating "the first N" and stopping
+            // UNDERFILLS whenever one is rejected — fewer rows than asked
+            // for, a wrong answer rather than a slow one.
+            //
+            // So: hydrate a window, run the per-edge loop over exactly that
+            // window, and take another window only if the cap is still
+            // unmet. Windows are consecutive, so `out` stays an
+            // order-preserving prefix of the uncapped result. The window
+            // doubles, bounding the number of hydration round-trips at
+            // log(degree) while keeping the first one small.
+            //
+            // Restricted to the shape where a window is provably
+            // independent: `max == 1` (one round, so nothing carries into a
+            // next hop), no back-reference, no shortest-path mode and no
+            // endpoint BFS (all three carry pruning state whose meaning
+            // depends on seeing a whole level).
+            let total_edges: usize = step_neighbours.iter().map(|(_, n)| n.len()).sum();
+            let wave_hydration = cap.is_some()
+                && max == 1
+                && !back_reference
+                && shortest == crate::plan::ShortestMode::None
+                && !endpoint_bfs;
+            let mut wave_start = 0usize;
+            let mut wave_size = if wave_hydration {
+                cap.map_or(total_edges, |c| c.saturating_mul(4).max(512))
+            } else {
+                total_edges
+            };
+            while wave_start < total_edges || wave_start == 0 {
+                let wave_end = wave_start.saturating_add(wave_size).min(total_edges);
+                // Collect the endpoints of THIS window only.
+                let mut unique_targets: Vec<NodeId> = Vec::new();
+                let mut seen_targets: std::collections::HashSet<NodeId> =
+                    std::collections::HashSet::new();
                 if !back_reference {
-                    for edge in neighbours.iter() {
-                        let tid = partner_id(edge, direction, step.tail);
-                        if seen_targets.insert(tid) {
-                            unique_targets.push(tid);
+                    let mut edge_index = 0usize;
+                    for (step, ns) in step_neighbours.iter() {
+                        for edge in ns.iter() {
+                            let i = edge_index;
+                            edge_index += 1;
+                            if i < wave_start {
+                                continue;
+                            }
+                            if i >= wave_end {
+                                break;
+                            }
+                            let tid = partner_id(edge, direction, step.tail);
+                            if seen_targets.insert(tid) {
+                                unique_targets.push(tid);
+                            }
+                        }
+                        if edge_index >= wave_end {
+                            break;
                         }
                     }
                 }
-                step_neighbours.push((step, neighbours));
-            }
-            // Phase 2: either prove endpoint labels through the compact
-            // `(LabelId,NodeId)` sidecar (identity-only target), or prewarm
-            // the ordinary point cache once for the whole hop. This keeps
-            // work proportional to touched endpoints and avoids hydrating
-            // large vectors solely to evaluate `(:Label)`.
-            let target_membership = prepare_expand_targets(
-                snapshot,
-                target_labels,
-                &unique_targets,
-                skip_target_materialize,
-                true,
-                max > 1,
-            )
-            .await?;
-            for (step, neighbours) in step_neighbours {
-                for edge in neighbours.iter() {
-                    // Periodic in-loop guard: the (step × edge) space is the
-                    // deg^hop blowup itself, so probe the budgets every few
-                    // thousand edges rather than once per hop.
-                    guard_tick = guard_tick.wrapping_add(1);
-                    if guard_tick % 4096 == 0 {
-                        crate::exec::limits::check_deadline()?;
-                        crate::exec::limits::check_row_cap(
-                            out.len() + hop_results.len() + next_frontier.len(),
-                        )?;
-                    }
-                    let target_id = partner_id(edge, direction, step.tail);
-                    if prune_visits {
-                        // Reached at an earlier level → any path through it now
-                        // is longer than shortest (endpoint BFS: already
-                        // expanded and emitted at its first level); skip both
-                        // as a result and as a frontier extension.
-                        if visited.contains(&target_id) {
+                // Either prove endpoint labels through the compact
+                // `(LabelId,NodeId)` sidecar (identity-only target), or
+                // prewarm the ordinary point cache for this window. This
+                // keeps work proportional to touched endpoints and avoids
+                // hydrating large vectors solely to evaluate `(:Label)`.
+                let target_membership = prepare_expand_targets(
+                    snapshot,
+                    target_labels,
+                    &unique_targets,
+                    skip_target_materialize,
+                    true,
+                    max > 1,
+                )
+                .await?;
+                // Flattened so a window is a plain slice of the (step, edge)
+                // sequence. `shortest == First` breaking out of this loop is
+                // what the per-step break did before: once a hit is found in
+                // that mode the whole BFS for this seed stops.
+                let mut edge_index = 0usize;
+                'wave_edges: for (step, ns) in step_neighbours.iter() {
+                    for edge in ns.iter() {
+                        let i = edge_index;
+                        edge_index += 1;
+                        if i < wave_start {
                             continue;
                         }
-                        // One walk per node per level suffices for `First` and
-                        // for the endpoint BFS; `All` keeps every same-level
-                        // arrival (each is a distinct shortest path).
-                        if (shortest == crate::plan::ShortestMode::First || endpoint_bfs)
-                            && !level_seen.insert(target_id)
-                        {
-                            continue;
+                        if i >= wave_end {
+                            break 'wave_edges;
                         }
-                    }
-                    // Cypher relationship uniqueness (trail semantics): a
-                    // relationship may appear at most once per matched path.
-                    // Skip an edge already traversed on this path so a
-                    // variable-length pattern cannot walk the same edge back
-                    // (e.g. `-[:R*2..2]-` over a single edge → a-r-b-r-a). Only
-                    // enforced for multi-hop expansions; a single hop can never
-                    // repeat a relationship. The identity is the STORED edge
-                    // `(edge_type, src, dst)`, so a Both-direction traversal of
-                    // the same edge in either orientation collapses to one key.
-                    let edge_key = if max > 1 {
-                        Some((edge.edge_type.clone(), edge.src, edge.dst))
-                    } else {
-                        None
-                    };
-                    if let Some(k) = &edge_key {
-                        if step.rels.contains(k) {
-                            continue;
+                        // Periodic in-loop guard: the (step × edge) space is the
+                        // deg^hop blowup itself, so probe the budgets every few
+                        // thousand edges rather than once per hop.
+                        guard_tick = guard_tick.wrapping_add(1);
+                        if guard_tick % 4096 == 0 {
+                            crate::exec::limits::check_deadline()?;
+                            crate::exec::limits::check_row_cap(
+                                out.len() + hop_results.len() + next_frontier.len(),
+                            )?;
                         }
-                    }
-                    // (node, hop) dedup AFTER the trail check, so a walk the
-                    // trail rule rejects cannot consume the slot a valid
-                    // alternative arrival needed.
-                    if hop_keyed_prune && !visited_at_hop.insert((target_id, hop)) {
-                        continue;
-                    }
-                    // Back-reference fast path: skip the lookup_node
-                    // (the binding's NodeView is already on the row).
-                    // For non-back-reference, fetch the view so we
-                    // can populate / label-filter.
-                    // The far-end label(s) constrain which reached nodes are
-                    // RESULTS — not which may be traversed THROUGH. For a
-                    // multi-hop (`*`) expansion we therefore traverse every
-                    // existing neighbour and let `target_is_result` gate the hit.
-                    // Pruning the frontier on a label mismatch (the pre-fix bug)
-                    // made `(s)-[:R*1..n]->(a:Label)` return empty whenever the
-                    // intermediate nodes were not themselves `Label`.
-                    let mut target_is_result = true;
-                    let target_view_opt = if back_reference {
-                        None
-                    } else if skip_target_materialize {
-                        if !match &target_membership {
-                            ExpandTargets::Membership(membership) => {
-                                membership.get(&target_id).copied().unwrap_or(false)
+                        let target_id = partner_id(edge, direction, step.tail);
+                        if prune_visits {
+                            // Reached at an earlier level → any path through it now
+                            // is longer than shortest (endpoint BFS: already
+                            // expanded and emitted at its first level); skip both
+                            // as a result and as a frontier extension.
+                            if visited.contains(&target_id) {
+                                continue;
                             }
-                            _ => false,
-                        } {
-                            continue;
-                        }
-                        None
-                    } else if let ExpandTargets::Views(views) = &target_membership {
-                        // The hop's own materialisation answers directly, so a
-                        // large fan-out no longer depends on cache retention.
-                        // The batch resolves by id across every descriptor, so
-                        // it describes nodes of ANY label — which is what lets
-                        // a multi-hop traversal use it too.
-                        match views.get(&target_id) {
-                            Some(v) => {
-                                if target_labels.iter().all(|l| v.labels.contains(l)) {
-                                    Some(v.clone())
-                                } else if max > 1 {
-                                    // Multi-hop: the far-end label decides
-                                    // whether this node is a RESULT, never
-                                    // whether it may be traversed. Pruning the
-                                    // frontier on a mismatch is what made
-                                    // `(s)-[:R*1..n]->(a:L)` return empty when
-                                    // the intermediates were not themselves L.
-                                    target_is_result = false;
-                                    Some(v.clone())
-                                } else {
-                                    continue;
-                                }
-                            }
-                            // Absent from the batch is NOT absent from the
-                            // graph: fall back to the authoritative point
-                            // reader so a batch that under-reports can never
-                            // drop a real row.
-                            None => match scan_node_for_id(snapshot, target_id).await? {
-                                Some(v) => {
-                                    let matches =
-                                        target_labels.iter().all(|l| v.labels.contains(l));
-                                    if !matches && max == 1 {
-                                        continue;
-                                    }
-                                    target_is_result = matches;
-                                    Some(v)
-                                }
-                                None => continue,
-                            },
-                        }
-                    } else if let Some(label) = target_labels.first() {
-                        if max > 1 {
-                            // Multi-hop: traverse through any existing node; the
-                            // far-end label gates only whether it is a result.
-                            match scan_node_for_id(snapshot, target_id).await? {
-                                Some(v) => {
-                                    target_is_result =
-                                        target_labels.iter().all(|l| v.labels.contains(l));
-                                    Some(v)
-                                }
-                                None => continue,
-                            }
-                        } else {
-                            // Single hop: the target IS the result, so a label
-                            // mismatch excludes the edge (no traversal beyond it).
-                            // Conjunctive multi-label: must carry EVERY label.
-                            match snapshot.lookup_node(label, target_id).await? {
-                                Some(v) if target_labels.iter().all(|l| v.labels.contains(l)) => {
-                                    Some(v)
-                                }
-                                _ => continue,
+                            // One walk per node per level suffices for `First` and
+                            // for the endpoint BFS; `All` keeps every same-level
+                            // arrival (each is a distinct shortest path).
+                            if (shortest == crate::plan::ShortestMode::First || endpoint_bfs)
+                                && !level_seen.insert(target_id)
+                            {
+                                continue;
                             }
                         }
-                    } else {
-                        match scan_node_for_id(snapshot, target_id).await? {
-                            Some(v) => Some(v),
-                            None => continue,
-                        }
-                    };
-                    let rel_value = RuntimeValue::Rel(Box::new(RelValue::from(edge.clone())));
-                    let mut new_row = step.row.clone();
-                    let mut new_rel_values = step.rel_values.clone();
-                    if bind_rel_list {
-                        if rel_alias.is_some() {
-                            new_rel_values.push(rel_value.clone());
-                        }
-                    } else if let Some(name) = rel_alias {
-                        // A fixed single relationship (`[r:KNOWS]`, no `*`)
-                        // binds the scalar relationship.
-                        new_row.set(name, rel_value.clone());
-                    }
-                    // For shortestPath trail materialisation we need a
-                    // target NodeValue regardless of `skip_target_materialize`.
-                    // Compute it once below and reuse for both the row binding
-                    // and the trail.
-                    let target_node_value: Option<NodeValue> =
-                        if let Some(view) = target_view_opt.as_ref() {
-                            Some(NodeValue::from(view.clone()))
-                        } else if back_reference {
-                            if materialise_trail && Some(target_id) != existing_target_id {
-                                // The trail must carry the node actually
-                                // reached at THIS hop. The pre-bound value is
-                                // only correct at the final target; reusing
-                                // it for intermediates made `nodes(p)` repeat
-                                // the endpoint (["n0", "n2", "n2"]).
-                                scan_node_for_id(snapshot, target_id)
-                                    .await?
-                                    .map(NodeValue::from)
-                            } else {
-                                // Back-reference uses the pre-bound NodeView
-                                // from the existing target_alias on the row.
-                                match row.get(target_alias) {
-                                    Some(RuntimeValue::Node(n)) => Some(n.as_ref().clone()),
-                                    _ => None,
-                                }
-                            }
-                        } else if skip_target_materialize {
-                            Some(NodeValue {
-                                id: target_id,
-                                labels: target_labels.iter().map(|l| l.to_string()).collect(),
-                                properties: std::collections::BTreeMap::new(),
-                            })
+                        // Cypher relationship uniqueness (trail semantics): a
+                        // relationship may appear at most once per matched path.
+                        // Skip an edge already traversed on this path so a
+                        // variable-length pattern cannot walk the same edge back
+                        // (e.g. `-[:R*2..2]-` over a single edge → a-r-b-r-a). Only
+                        // enforced for multi-hop expansions; a single hop can never
+                        // repeat a relationship. The identity is the STORED edge
+                        // `(edge_type, src, dst)`, so a Both-direction traversal of
+                        // the same edge in either orientation collapses to one key.
+                        let edge_key = if max > 1 {
+                            Some((edge.edge_type.clone(), edge.src, edge.dst))
                         } else {
                             None
                         };
-
-                    if let Some(view) = target_view_opt {
-                        new_row.set(
-                            target_alias.to_string(),
-                            RuntimeValue::Node(Box::new(NodeValue::from(view))),
-                        );
-                    } else if skip_target_materialize && !back_reference {
-                        // id-only stub: enough for the next Expand to read
-                        // `.id`; `label` is preserved so RuntimeValue::Node
-                        // still type-checks for downstream Expand source reads.
-                        if let Some(nv) = &target_node_value {
-                            new_row.set(
-                                target_alias.to_string(),
-                                RuntimeValue::Node(Box::new(nv.clone())),
-                            );
+                        if let Some(k) = &edge_key {
+                            if step.rels.contains(k) {
+                                continue;
+                            }
                         }
-                    }
-                    // Back-reference: the binding stays at the
-                    // original existing target; new_row already
-                    // carries it from row.clone() above.
-                    let mut new_trail = step.trail.clone();
-                    if materialise_trail {
-                        new_trail.push(rel_value);
-                        if let Some(nv) = target_node_value {
-                            new_trail.push(RuntimeValue::Node(Box::new(nv)));
-                        } else {
-                            new_trail.push(RuntimeValue::Null);
+                        // (node, hop) dedup AFTER the trail check, so a walk the
+                        // trail rule rejects cannot consume the slot a valid
+                        // alternative arrival needed.
+                        if hop_keyed_prune && !visited_at_hop.insert((target_id, hop)) {
+                            continue;
                         }
-                    }
-                    let mut new_rels = step.rels.clone();
-                    if let Some(k) = &edge_key {
-                        new_rels.push(k.clone());
-                    }
-                    // The frontier feeds the NEXT round, so on the last hop
-                    // every entry is dead on arrival — and each one costs a
-                    // DEEP clone of the row (every binding, whole node values
-                    // included), its trail and its relationship list, per
-                    // matched edge. This was fixed for `max == 1` after a
-                    // 53k-degree hub turned it into hundreds of MB of pure
-                    // waste (sixth field report); `hop == max` is the same
-                    // waste for exactly the same reason, and a `*1..2` over a
-                    // 300x300 fan-out spent longer building the doomed
-                    // frontier than answering the query.
-                    if hop < max {
-                        next_frontier.push(Step {
-                            tail: target_id,
-                            row: new_row.clone(),
-                            trail: new_trail.clone(),
-                            rels: new_rels,
-                            rel_values: new_rel_values.clone(),
-                        });
-                    }
-                    if hop >= min.max(1) {
-                        let keeps = bound_target_matches_labels
-                            && target_is_result
-                            && match existing_target_id {
-                                Some(existing) => target_id == existing,
-                                None => true,
-                            };
-                        if keeps {
-                            let mut hit_row = new_row;
-                            if bind_rel_list {
-                                if let Some(name) = rel_alias {
-                                    hit_row.set(
-                                        name.to_string(),
-                                        RuntimeValue::List(new_rel_values.clone()),
-                                    );
+                        // Back-reference fast path: skip the lookup_node
+                        // (the binding's NodeView is already on the row).
+                        // For non-back-reference, fetch the view so we
+                        // can populate / label-filter.
+                        // The far-end label(s) constrain which reached nodes are
+                        // RESULTS — not which may be traversed THROUGH. For a
+                        // multi-hop (`*`) expansion we therefore traverse every
+                        // existing neighbour and let `target_is_result` gate the hit.
+                        // Pruning the frontier on a label mismatch (the pre-fix bug)
+                        // made `(s)-[:R*1..n]->(a:Label)` return empty whenever the
+                        // intermediate nodes were not themselves `Label`.
+                        let mut target_is_result = true;
+                        let target_view_opt = if back_reference {
+                            None
+                        } else if skip_target_materialize {
+                            if !match &target_membership {
+                                ExpandTargets::Membership(membership) => {
+                                    membership.get(&target_id).copied().unwrap_or(false)
+                                }
+                                _ => false,
+                            } {
+                                continue;
+                            }
+                            None
+                        } else if let ExpandTargets::Views(views) = &target_membership {
+                            // The hop's own materialisation answers directly, so a
+                            // large fan-out no longer depends on cache retention.
+                            // The batch resolves by id across every descriptor, so
+                            // it describes nodes of ANY label — which is what lets
+                            // a multi-hop traversal use it too.
+                            match views.get(&target_id) {
+                                Some(v) => {
+                                    if target_labels.iter().all(|l| v.labels.contains(l)) {
+                                        Some(v.clone())
+                                    } else if max > 1 {
+                                        // Multi-hop: the far-end label decides
+                                        // whether this node is a RESULT, never
+                                        // whether it may be traversed. Pruning the
+                                        // frontier on a mismatch is what made
+                                        // `(s)-[:R*1..n]->(a:L)` return empty when
+                                        // the intermediates were not themselves L.
+                                        target_is_result = false;
+                                        Some(v.clone())
+                                    } else {
+                                        continue;
+                                    }
+                                }
+                                // Absent from the batch is NOT absent from the
+                                // graph: fall back to the authoritative point
+                                // reader so a batch that under-reports can never
+                                // drop a real row.
+                                None => match scan_node_for_id(snapshot, target_id).await? {
+                                    Some(v) => {
+                                        let matches =
+                                            target_labels.iter().all(|l| v.labels.contains(l));
+                                        if !matches && max == 1 {
+                                            continue;
+                                        }
+                                        target_is_result = matches;
+                                        Some(v)
+                                    }
+                                    None => continue,
+                                },
+                            }
+                        } else if let Some(label) = target_labels.first() {
+                            if max > 1 {
+                                // Multi-hop: traverse through any existing node; the
+                                // far-end label gates only whether it is a result.
+                                match scan_node_for_id(snapshot, target_id).await? {
+                                    Some(v) => {
+                                        target_is_result =
+                                            target_labels.iter().all(|l| v.labels.contains(l));
+                                        Some(v)
+                                    }
+                                    None => continue,
+                                }
+                            } else {
+                                // Single hop: the target IS the result, so a label
+                                // mismatch excludes the edge (no traversal beyond it).
+                                // Conjunctive multi-label: must carry EVERY label.
+                                match snapshot.lookup_node(label, target_id).await? {
+                                    Some(v)
+                                        if target_labels.iter().all(|l| v.labels.contains(l)) =>
+                                    {
+                                        Some(v)
+                                    }
+                                    _ => continue,
                                 }
                             }
-                            if let Some(name) = path_binding {
-                                hit_row.set(name.to_string(), RuntimeValue::Path(new_trail));
+                        } else {
+                            match scan_node_for_id(snapshot, target_id).await? {
+                                Some(v) => Some(v),
+                                None => continue,
                             }
-                            hop_results.push(hit_row);
-                            matched_any = true;
-                            // shortestPath: at most one row per
-                            // (source, target). Stop the whole BFS
-                            // for this seed row.
-                            if shortest == crate::plan::ShortestMode::First {
-                                break;
+                        };
+                        let rel_value = RuntimeValue::Rel(Box::new(RelValue::from(edge.clone())));
+                        let mut new_row = step.row.clone();
+                        let mut new_rel_values = step.rel_values.clone();
+                        if bind_rel_list {
+                            if rel_alias.is_some() {
+                                new_rel_values.push(rel_value.clone());
+                            }
+                        } else if let Some(name) = rel_alias {
+                            // A fixed single relationship (`[r:KNOWS]`, no `*`)
+                            // binds the scalar relationship.
+                            new_row.set(name, rel_value.clone());
+                        }
+                        // For shortestPath trail materialisation we need a
+                        // target NodeValue regardless of `skip_target_materialize`.
+                        // Compute it once below and reuse for both the row binding
+                        // and the trail.
+                        let target_node_value: Option<NodeValue> =
+                            if let Some(view) = target_view_opt.as_ref() {
+                                Some(NodeValue::from(view.clone()))
+                            } else if back_reference {
+                                if materialise_trail && Some(target_id) != existing_target_id {
+                                    // The trail must carry the node actually
+                                    // reached at THIS hop. The pre-bound value is
+                                    // only correct at the final target; reusing
+                                    // it for intermediates made `nodes(p)` repeat
+                                    // the endpoint (["n0", "n2", "n2"]).
+                                    scan_node_for_id(snapshot, target_id)
+                                        .await?
+                                        .map(NodeValue::from)
+                                } else {
+                                    // Back-reference uses the pre-bound NodeView
+                                    // from the existing target_alias on the row.
+                                    match row.get(target_alias) {
+                                        Some(RuntimeValue::Node(n)) => Some(n.as_ref().clone()),
+                                        _ => None,
+                                    }
+                                }
+                            } else if skip_target_materialize {
+                                Some(NodeValue {
+                                    id: target_id,
+                                    labels: target_labels.iter().map(|l| l.to_string()).collect(),
+                                    properties: std::collections::BTreeMap::new(),
+                                })
+                            } else {
+                                None
+                            };
+
+                        if let Some(view) = target_view_opt {
+                            new_row.set(
+                                target_alias.to_string(),
+                                RuntimeValue::Node(Box::new(NodeValue::from(view))),
+                            );
+                        } else if skip_target_materialize && !back_reference {
+                            // id-only stub: enough for the next Expand to read
+                            // `.id`; `label` is preserved so RuntimeValue::Node
+                            // still type-checks for downstream Expand source reads.
+                            if let Some(nv) = &target_node_value {
+                                new_row.set(
+                                    target_alias.to_string(),
+                                    RuntimeValue::Node(Box::new(nv.clone())),
+                                );
+                            }
+                        }
+                        // Back-reference: the binding stays at the
+                        // original existing target; new_row already
+                        // carries it from row.clone() above.
+                        let mut new_trail = step.trail.clone();
+                        if materialise_trail {
+                            new_trail.push(rel_value);
+                            if let Some(nv) = target_node_value {
+                                new_trail.push(RuntimeValue::Node(Box::new(nv)));
+                            } else {
+                                new_trail.push(RuntimeValue::Null);
+                            }
+                        }
+                        let mut new_rels = step.rels.clone();
+                        if let Some(k) = &edge_key {
+                            new_rels.push(k.clone());
+                        }
+                        // The frontier feeds the NEXT round, so on the last hop
+                        // every entry is dead on arrival — and each one costs a
+                        // DEEP clone of the row (every binding, whole node values
+                        // included), its trail and its relationship list, per
+                        // matched edge. This was fixed for `max == 1` after a
+                        // 53k-degree hub turned it into hundreds of MB of pure
+                        // waste (sixth field report); `hop == max` is the same
+                        // waste for exactly the same reason, and a `*1..2` over a
+                        // 300x300 fan-out spent longer building the doomed
+                        // frontier than answering the query.
+                        if hop < max {
+                            next_frontier.push(Step {
+                                tail: target_id,
+                                row: new_row.clone(),
+                                trail: new_trail.clone(),
+                                rels: new_rels,
+                                rel_values: new_rel_values.clone(),
+                            });
+                        }
+                        if hop >= min.max(1) {
+                            let keeps = bound_target_matches_labels
+                                && target_is_result
+                                && match existing_target_id {
+                                    Some(existing) => target_id == existing,
+                                    None => true,
+                                };
+                            if keeps {
+                                let mut hit_row = new_row;
+                                if bind_rel_list {
+                                    if let Some(name) = rel_alias {
+                                        hit_row.set(
+                                            name.to_string(),
+                                            RuntimeValue::List(new_rel_values.clone()),
+                                        );
+                                    }
+                                }
+                                if let Some(name) = path_binding {
+                                    hit_row.set(name.to_string(), RuntimeValue::Path(new_trail));
+                                }
+                                hop_results.push(hit_row);
+                                matched_any = true;
+                                // shortestPath: at most one row per
+                                // (source, target). Stop the whole BFS
+                                // for this seed row.
+                                if shortest == crate::plan::ShortestMode::First {
+                                    break 'wave_edges;
+                                }
                             }
                         }
                     }
+                }
+                wave_start = wave_end;
+                if !wave_hydration || wave_start >= total_edges {
+                    break;
                 }
                 if shortest == crate::plan::ShortestMode::First && matched_any {
                     break;
                 }
+                if let Some(c) = cap {
+                    if out.len() + hop_results.len() >= c {
+                        break;
+                    }
+                }
+                wave_size = wave_size.saturating_mul(2);
             }
             // shortestPath: hit found this hop → don't extend the
             // frontier into hop+1.

--- a/crates/namidb-query/src/exec/writer.rs
+++ b/crates/namidb-query/src/exec/writer.rs
@@ -3176,7 +3176,15 @@ async fn apply_delete(
                     // without DETACH is an error, never a silent commit of
                     // dangling edges — which reads would then resurrect as
                     // half-broken traversal results.
-                    return Err(ExecError::Runtime(format!(
+                    // A Constraint, not a Runtime error: this is the
+                    // caller's statement being wrong, and it classifies as
+                    // 409 + `Neo.ClientError.Schema.ConstraintValidationFailed`
+                    // — exactly what Neo4j returns here. As a Runtime error it
+                    // surfaced as HTTP 500 + `Neo.DatabaseError`, so drivers
+                    // and retry middleware treated a permanent user mistake as
+                    // a transient server fault and retried it forever, and it
+                    // counted against server error budgets.
+                    return Err(ExecError::Constraint(format!(
                         "cannot DELETE a node that still has relationships \
                          (found {edge_type}); use DETACH DELETE to remove the \
                          node and its relationships"

--- a/crates/namidb-query/tests/exec_limit_pushdown.rs
+++ b/crates/namidb-query/tests/exec_limit_pushdown.rs
@@ -285,3 +285,98 @@ async fn param_limit_not_provided_errors() {
         "expected a missing-parameter error, got: {err}"
     );
 }
+
+/// A capped expansion must return exactly `min(limit, total)` rows even when
+/// most edges are REJECTED inside the per-edge loop.
+///
+/// This is the oracle for bounding an expansion's hydration. The per-edge
+/// loop has many `continue` paths — label mismatch, membership, the trail
+/// rule, visited-set pruning, an absent node — so any scheme that hydrates
+/// "the first N endpoints" and stops UNDERFILLS whenever an endpoint is
+/// rejected: fewer rows than the user asked for, which is a wrong answer,
+/// not a slow one.
+///
+/// The fixture makes rejection the common case: one hub with 400 neighbours
+/// of which only every fourth carries the queried label, so satisfying
+/// `LIMIT 25` requires walking ~100 edges and discarding 75 of them.
+#[tokio::test]
+async fn cap_never_underfills_when_most_edges_are_rejected() {
+    let mut writer = WriterSession::open(store(), paths("cap-underfill"))
+        .await
+        .unwrap();
+    let hub = NodeId::new();
+    writer
+        .upsert_node("Hub", hub, &node_with("hid", 0))
+        .unwrap();
+
+    // 400 neighbours; every 4th is a :Wanted, the rest are :Other.
+    const NEIGHBOURS: i64 = 400;
+    let mut wanted_total = 0i64;
+    for i in 0..NEIGHBOURS {
+        let id = NodeId::new();
+        if i % 4 == 0 {
+            writer
+                .upsert_node("Wanted", id, &node_with("v", i))
+                .unwrap();
+            wanted_total += 1;
+        } else {
+            writer.upsert_node("Other", id, &node_with("v", i)).unwrap();
+        }
+        writer.upsert_edge("NEAR", hub, id, &edge()).unwrap();
+    }
+    writer.commit_batch().await.unwrap();
+    let snapshot = writer.snapshot();
+
+    let rows_for = |query: String| {
+        let snapshot = &snapshot;
+        async move {
+            let q = parse(&query).unwrap();
+            let plan = lower(&q).unwrap();
+            execute_flat_path(&plan, snapshot, &Params::new())
+                .await
+                .unwrap()
+        }
+    };
+
+    let baseline = rows_for("MATCH (h:Hub)-[:NEAR]->(t:Wanted) RETURN t.v AS v".to_string()).await;
+    assert_eq!(
+        baseline.len() as i64,
+        wanted_total,
+        "fixture sanity: every :Wanted neighbour matches"
+    );
+
+    // Every limit from under to over the available rows must be exact, and
+    // must be an order-preserving PREFIX of the uncapped result.
+    let full: Vec<i64> = baseline
+        .iter()
+        .map(|r| match r.get("v") {
+            Some(RuntimeValue::Integer(v)) => *v,
+            other => panic!("unexpected row shape: {other:?}"),
+        })
+        .collect();
+    for limit in [1usize, 2, 25, 99, 100, 101, 400] {
+        let rows = rows_for(format!(
+            "MATCH (h:Hub)-[:NEAR]->(t:Wanted) RETURN t.v AS v LIMIT {limit}"
+        ))
+        .await;
+        let expected = limit.min(full.len());
+        assert_eq!(
+            rows.len(),
+            expected,
+            "LIMIT {limit} must return exactly min(limit, {}) rows",
+            full.len()
+        );
+        let got: Vec<i64> = rows
+            .iter()
+            .map(|r| match r.get("v") {
+                Some(RuntimeValue::Integer(v)) => *v,
+                other => panic!("unexpected row shape: {other:?}"),
+            })
+            .collect();
+        assert_eq!(
+            got,
+            full[..expected].to_vec(),
+            "LIMIT {limit} must be an order-preserving prefix of the uncapped result"
+        );
+    }
+}

--- a/crates/namidb-server/src/lib.rs
+++ b/crates/namidb-server/src/lib.rs
@@ -6430,6 +6430,46 @@ mod tests {
     /// NDB-03: resource exhaustion carries its own taxonomy — a client must
     /// be able to tell "too expensive" from "malformed" without string
     /// matching, on both the `code` and the Neo4j/GQL-shaped fields.
+    /// Deleting a connected node without DETACH is the CALLER's statement
+    /// being wrong, so it must classify as a client error.
+    ///
+    /// It was raised as `ExecError::Runtime`, which falls to the unclassified
+    /// arm: HTTP 500 + `Neo.DatabaseError`. Drivers and retry middleware read
+    /// that as a transient server fault and retry a permanently-failing
+    /// statement, and it counts against server error budgets. Neo4j returns
+    /// `Neo.ClientError.Schema.ConstraintValidationFailed` for exactly this
+    /// case, which is what `ExecError::Constraint` already maps to.
+    #[tokio::test]
+    async fn delete_with_relationships_is_a_client_error_not_a_server_fault() {
+        let response = exec_failure_response(
+            "write execution failed",
+            &namidb_query::exec::ExecError::Constraint(
+                "cannot DELETE a node that still has relationships (found REL); \
+                 use DETACH DELETE to remove the node and its relationships"
+                    .into(),
+            ),
+        );
+        assert_eq!(
+            response.status(),
+            StatusCode::CONFLICT,
+            "a caller mistake must not be reported as 5xx"
+        );
+        let body = to_bytes(response.into_body(), usize::MAX).await.unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json["code"], "constraint");
+        assert_eq!(
+            json["neo4j_code"],
+            "Neo.ClientError.Schema.ConstraintValidationFailed"
+        );
+        assert_eq!(json["gql_status"], "23000");
+        // The remedy must survive into the wire message.
+        assert!(
+            json["error"].as_str().unwrap().contains("DETACH DELETE"),
+            "the error must still name the fix: {}",
+            json["error"]
+        );
+    }
+
     #[tokio::test]
     async fn timeout_response_exposes_taxonomy_fields() {
         let response = exec_failure_response(

--- a/docs/testing/25tb-readiness.md
+++ b/docs/testing/25tb-readiness.md
@@ -1111,73 +1111,51 @@ flag (`--http-request-timeout`, `0s` disables) whose default is derived
 to clear the largest configured query/write budget, with a boot warning
 when an explicit value would truncate them.
 
-### 75. [OPEN — measured, design ready] `LIMIT` does not bound an expansion's work
+### 75. [FIXED in 2.6.10] `LIMIT` now bounds an expansion's work
 
-Re-measured on 2.6.9, degree 160,000, ~1 KB targets,
-`MATCH (h:HUB)-[:TIENE]->(t:FAT)`:
+Was: a pushed-down cap was checked only at the SEED boundary, so the hop
+loop collected every partner, `prepare_expand_targets` hydrated all of
+them, and truncation happened above the operator. `LIMIT 1` cost what
+counting every row cost.
 
-| query | time |
-|---|---|
-| `RETURN count(*)` (target unreferenced -> membership sidecar) | **0.65 s** |
-| `RETURN count(t)` (hydrates) | 2.18 s |
-| `RETURN t.idx LIMIT 25` | 2.01 s |
-| `RETURN t.idx LIMIT 1` | **2.04 s** |
+Fixed by hydrating in consecutive WINDOWS: run the per-edge loop over
+exactly one window, take another only if the cap is still unmet. Measured
+at degree 160,000, ~1 KB targets:
 
-`LIMIT 1` costs what the full scan costs. The cap is checked only at the
-SEED boundary — the contract being that every consumed seed contributes
-its COMPLETE edge set — so the hop loop collects every partner into
-`unique_targets`, `prepare_expand_targets` hydrates all of them, and the
-truncation happens above the operator.
+| query | before | after |
+|---|---|---|
+| `RETURN t.idx LIMIT 1` | 2.04 s | **0.32 s** |
+| `RETURN t.idx LIMIT 25` | 2.01 s | **0.31 s** |
+| `RETURN t.idx LIMIT 1000` | ~2.0 s | 0.34 s |
+| `LIMIT 200000` (beyond the total) | 2.28 s | 2.28 s |
+| `RETURN count(t)` (uncapped) | 2.23 s | 2.23 s |
 
-Split: hydration ~1.4 s (**~70%**), adjacency read plus membership
-~0.65 s (**~30%**). Bounding hydration takes `LIMIT 25` to roughly 0.7 s.
-The remaining 30% needs the limit inside `out_edges`, which has no limit
-parameter — that is the storage half, and it is where the hierarchical
-adjacency work from finding #3 actually earns its keep.
+**Why a window and not a truncation.** The per-edge loop rejects edges on
+many paths (label mismatch, membership, the trail rule, visited pruning, an
+absent node), so hydrating "the first N endpoints" returns FEWER rows than
+requested whenever one is rejected — a wrong answer, not a slow one.
+Windows are consecutive and re-entered until the cap is met, so the result
+stays an order-preserving prefix of the uncapped one.
 
-**Why a plain truncation is WRONG.** The per-edge loop has eight
-`continue` paths (label mismatch, membership, trail rule, visited-set
-pruning, node absent). Taking the first N edges UNDERFILLS whenever any
-edge is rejected — fewer rows than the user asked for, a wrong answer
-rather than a slow one, and the fourth such bug class this codebase has
-produced this week.
+Guarded to `cap.is_some() && max == 1 && !back_reference && shortest ==
+None && !endpoint_bfs`. At `max == 1` a window is provably independent:
+one round, nothing carries into a next hop, and `next_frontier` is never
+pushed. The other three modes carry pruning state (`visited`,
+`visited_at_hop`, `level_seen`) whose meaning depends on observing a whole
+level.
 
-**The design, ready to execute.** A wave loop: hydrate a bounded chunk,
-run the per-edge loop over exactly that chunk, take another chunk only if
-the cap is not yet met. Order is preserved because chunks are consecutive.
+Oracle: `exec_limit_pushdown::cap_never_underfills_when_most_edges_are_rejected`
+— a hub where only every fourth neighbour carries the queried label, so
+`LIMIT 25` must walk ~100 edges and discard 75. Verified live too, on a hub
+with 30,000 rejected neighbours among 40,000: every limit from 1 to beyond
+the total returns exactly `min(limit, total)` rows and matches the uncapped
+prefix.
 
-- Guard, computed once beside `endpoint_bfs`:
-  `cap.is_some() && max == 1 && !back_reference && shortest == ShortestMode::None && !endpoint_bfs`.
-  Each clause earns its place: `max == 1` means the frontier holds exactly
-  one `Step` per seed and the hop loop runs once, so a wave is literally a
-  chunk of one `Arc<Vec<EdgeView>>`; the other three switch on the
-  loop-carried pruning state below.
-- Loop-carried state, and where each must live. With that guard:
-  `level_seen`, `visited` and `visited_at_hop` are all dead (they need
-  `prune_visits` / `hop_keyed_prune`, which need shortest or endpoint_bfs);
-  `next_frontier` is never pushed (`hop < max` is false at `max == 1`);
-  `guard_tick` is a counter and hoists above the wave loop; `matched_any`
-  must persist ACROSS waves. `unique_targets` / `seen_targets` are
-  per-wave. Getting one of these wrong is a silent wrong answer, which is
-  why they are enumerated here rather than rediscovered.
-- Phase 1 (the adjacency read into `step_neighbours`) stays OUTSIDE the
-  wave loop — it is the 30% that no executor change can avoid.
-- Cursor `(step_index, edge_index)` advances across waves; stop when the
-  cursor exhausts or `out.len() + hop_results.len() >= cap`.
-- Initial chunk `max(cap * 4, 512)`, doubling. Sizing is a starting point,
-  not a measured optimum — tune against the 160k-degree fixture.
-- Oracle: `LIMIT n` must return exactly `min(n, total)` rows. Build the
-  underfill case deliberately — a hub whose neighbours are half a
-  non-matching label, `LIMIT 25`, assert exactly 25.
-
-**Deliberately not done in the 2026-09-10 session.** This restructures
-~250 lines of the per-edge loop so it can run over a range. That function
-was modified four times that day, twice to correct the previous change,
-and the payoff here is 3x on one query shape rather than a correctness
-fix. Shipping it as the seventh release of a long day is how a third
-regression gets introduced. The measurement and the design above are the
-part worth having; the edit should be made deliberately, with the
-equivalence suite and the underfill oracle in place first.
+**Residual, unchanged:** the adjacency read itself (~0.3 s of the 0.32 s)
+is Phase 1, outside the window loop. `out_edges(edge_type, src)` has no
+limit parameter and materialises the whole partner list, so no executor
+change can avoid it. That is the storage half, and it is where the
+hierarchical adjacency work from finding #3 would earn its keep.
 
 ### 76. [OPEN — measured, correct by design] An unlabelled unreferenced target cannot use the membership path
 

--- a/docs/testing/25tb-readiness.md
+++ b/docs/testing/25tb-readiness.md
@@ -1266,3 +1266,65 @@ WHERE, MATCH-WHERE vs WITH-WHERE, quantifier vs `IN`, `count(*)` vs
 worth keeping: comparing RESULTS across equivalent rewrites is what the
 suite does not do, and four wrong-answer bugs surfaced in this codebase
 today.
+
+### 79. [DESIGN CORRECTION for finding #8] Manifest min/max are BOUNDS, not exact values — do not answer MIN()/MAX() from them
+
+The proposed first increment for finding #8 was "answer `MIN(n.p)` /
+`MAX(n.p)` / `count(n.p)` from manifest stats, as a direct extension of the
+`count(*)` fast path". **That is unsound as stated**, and would ship a
+silent wrong answer.
+
+Current state, measured at 160,000 nodes:
+
+| query | time | path |
+|---|---|---|
+| `MATCH (t:FAT) RETURN count(*)` | **0.00 s** | manifest fast path (already exists) |
+| `MATCH (t:FAT) RETURN count(t)` | **0.00 s** | manifest fast path |
+| `RETURN min(t.idx)` | 0.47 s | full projected column scan |
+| `RETURN max(t.idx)` | 0.47 s | full projected column scan |
+| `RETURN count(t.idx)` | 0.46 s | full projected column scan |
+| `RETURN sum(t.idx)` | 0.47 s | full projected column scan |
+
+And the good news the earlier recon got right: `PerLabelPropertyStat`
+(manifest.rs:409) ALREADY carries `min`, `max`, `null_count` and an HLL
+`ndv_estimate`. No format change, no writer change — it looked like a
+reader-only increment.
+
+**Why it is unsound.** The chain, all read from the source:
+
+1. `PerLabelStatsCollector::observe` is fed only `MemOp::Upsert` rows —
+   tombstones are skipped (flush.rs:1294-1296). Correct in itself.
+2. Stats are per-SST rows in the manifest.
+3. The read side folds them with a plain `merge_min`/`merge_max` across
+   every SST (`cost/stats.rs:415-428`), with no tombstone awareness.
+4. So deleting the row that holds the maximum writes a tombstone into a
+   NEW SST while the OLD SST keeps its stat row — and the merged maximum
+   still reports the deleted value.
+5. Only compaction fixes it, because compaction recomputes the stats from
+   the surviving rows (compact.rs:3088).
+
+Between a delete and the compaction that merges its SST away — which can
+be a long time, and is exactly the window a bulk-load-then-query workload
+lives in — `MAX()` answered from stats returns a value that is no longer
+in the graph. Silently. The same holds for a property UPDATE that lowers
+the maximum, and `null_count` has the same staleness for `count(prop)`.
+
+There is a second hazard even without deletes: `min_scalar` / `max_scalar`
+(sst/nodes.rs:1912-1926) order via `scalar_lt`, which compares ACROSS
+`StatScalar` variants. A property holding both `Int64` and `Utf8` values
+therefore gets a min/max under an ordering that is not Cypher's
+comparison semantics.
+
+**The sound design is pruning, not answering.** A bound is enough to SKIP
+work: to find the maximum, visit only the row groups whose recorded max is
+greater than the best value found so far, and read the actual rows from
+those. The answer always comes from real rows, so staleness costs a
+wasted read rather than a wrong result — and the existing row-group
+machinery (`ScanPredicate`, `eval_row_group`, `node_scan_plan` in
+sst/nodes.rs:735-869) is the right place to hang it. That is a bigger
+change than the one proposed, and it is the honest version of it.
+
+If an exact-answer fast path is ever wanted, it needs a per-label
+"stats are exact" bit that flush clears on any tombstone and compaction
+sets when it recomputes from survivors. That does not exist today, and
+inventing it is a manifest format change.

--- a/docs/testing/25tb-readiness.md
+++ b/docs/testing/25tb-readiness.md
@@ -1111,6 +1111,90 @@ flag (`--http-request-timeout`, `0s` disables) whose default is derived
 to clear the largest configured query/write budget, with a boot warning
 when an explicit value would truncate them.
 
+## Self-audit by measurement (2026-09-10) — items 73-74
+
+Found by sweeping query shapes that SHOULD cost the same and comparing,
+not by reading code. The 2.6.2 cliff fix had been verified only on the
+shape the reporter sent.
+
+### 73. [CONFIRMED — fixed in 2.6.4] An unlabelled expand target read one node per edge
+
+The 2.6.2 fan-out fix (`ExpandTargets::Views`) was gated on the target
+carrying a label, so `(a)-[:R]->(x)` and `(a)-[:R]->()` kept the old
+per-edge point-read path. Measured on a 197k-degree hub with ~1 KB
+targets, all three spellings returning the same 197,000 rows:
+
+| pattern | 2.6.3 | 2.6.4 |
+|---|---|---|
+| `-[:TIENE]->(t:FAT)` | 3.47 s | 3.09 s |
+| `-[:TIENE]->(t)` | timed out at 300 s | 2.93 s |
+| `-[:TIENE]->()` | timed out at 300 s | 2.76 s |
+
+The gate rested on a misreading: `batch_lookup_nodes` iterates
+`manifest.index.node_descriptors()` and uses its `label` argument only to
+namespace cache keys, so an empty label is a complete id-primary batch.
+The old code called the batch, discarded the result, and did the per-edge
+reads anyway. Only `max == 1` still gates it (a var-length traversal must
+walk THROUGH nodes the batch does not describe). A batch MISS now falls
+back to the point reader rather than skipping the edge — the old arm
+collapsed "absent from batch" and "wrong label" into one `continue`.
+
+**Process note:** nothing in the suite expanded a hub through an
+unlabelled target, so the release that fixed the labelled twin left this
+untouched. A sweep of 12 expand shapes at degree 120k now shows them
+uniform (~1.7 s); before the fix two of them did not complete.
+
+### 74. [OPEN — prerequisite now met] A bare-node reference forces full hydration
+
+Re-measured on the 2.6.10 build at degree 160,000, ~1 KB targets:
+
+| query | time |
+|---|---|
+| `RETURN count(*)` (target unreferenced) | **0.64 s** |
+| `RETURN count(t)` | 2.20 s |
+| `RETURN count(id(t))` | 2.19 s |
+| `RETURN count(DISTINCT t)` | 2.13 s |
+| `RETURN sum(t.idx)` | 2.25 s |
+
+`count(id(t))` — where the caller has literally written that only the id
+is needed — costs the same as full hydration. 3.4x of pure waste.
+`should_skip_target_materialize` requires
+`!routing.referenced_aliases.contains(target_alias)`, and
+`collect_plan_references` treats `Count { arg: Some(e) }` exactly like
+`Sum`/`Avg`, so any mention of the alias forces every column.
+
+**The prerequisite is now met.** Widening the id-only stub was blocked on
+the reference collector being trustworthy, and it was not: two forms read
+a host binding without registering it, and both were silent wrong answers
+(quantifiers / list comprehensions over a target property, and a `*0..n`
+source losing its extra labels — both fixed in 2.6.8). The collector is
+now EXHAUSTIVE — no `_` arm, so the compiler forces a decision for every
+`ExpressionKind` — and the only forms that deliberately register nothing
+are the genuinely closed pattern forms (`Exists`, `ExistsSubquery`,
+`PatternComprehension`) plus `Literal` / `Parameter` / `Star`, none of
+which read a host binding.
+
+**What remains is the whitelist, and it must stay narrow.** The stub binds
+EMPTY properties, so mis-classifying one form returns nulls for real
+values. Two tiers with different burdens of proof:
+
+- `id(x)` as the sole mention: provably safe with no further reasoning —
+  `id()` reads the id, and the stub carries the correct id.
+- bare `count(x)` / `count(DISTINCT x)`: needs the argument that node
+  dedup is by an id-only fingerprint (it is — a BTreeSet over id
+  fingerprints since the first release, confirmed under item 68). Worth
+  having, since `count(x)` is the common spelling, but it rests on an
+  aggregate-internals invariant that deserves its own pinning test first.
+
+Anything else mentioning the alias stays on the full path. Not a
+blacklist: a new expression form must be added to the whitelist
+deliberately, never inherit the fast path by omission.
+
+Add a family to `exec_rewrite_equivalence.rs` at the same time, and
+remember that file's trap: a family must reference the target ONLY through
+the construct under test, or the stub is never built and the family passes
+with the fix reverted.
+
 ### 75. [FIXED in 2.6.10] `LIMIT` now bounds an expansion's work
 
 Was: a pushed-down cap was checked only at the SEED boundary, so the hop
@@ -1176,7 +1260,20 @@ row (`batch_nodes_exist(ids)`) — not the removal of a condition. Worth
 having: `MATCH (a)-[:R]->() RETURN count(*)` is a common shape and pays
 full hydration for nothing.
 
-### 77. [OPEN — measured] Labelled variable-length burns CPU with no extra I/O
+### 77. [FIXED in 2.6.7] Labelled variable-length burned CPU with no extra I/O
+
+**Root cause found and fixed:** `batch_lookup_nodes` sweeps by id but
+FILTERS its output by the label it is given, and every hop of a
+variable-length pattern shares the pattern's FINAL target label — so
+intermediate hops resolved nothing and each edge fell through to
+`lookup_node_by_id`, the one node read with no cache tier. The expand
+batch now asks for no label and re-proves labels per edge.
+`-[:A|B*2..2]->(x:LEAF)` went 5.3s -> 0.21s and `->(x:MID)` from
+exceeding the deadline to 0.16s, matching the explicit chain (0.13s).
+The investigation below is kept because its REFUTED hypotheses are what
+narrowed the search.
+
+#### Original entry (hypotheses refuted by measurement)
 
 2.6.6 is a strict improvement, but a large residual remains and one shape
 still does not complete. Same fixture and store on both images (200x200,
@@ -1228,7 +1325,20 @@ volume and is the sharpest available lead.
 
 Not a regression: every one of these timed out on 2.6.5.
 
-### 78. [OPEN — conformance question, NOT fixed] A repeated type in an alternation duplicates rows
+### 78. [FIXED in 2.6.9] A repeated type in an alternation duplicated rows
+
+Resolved as a defect, not a semantic choice. What settled it: the test
+asserting the doubling is NAMED
+`expand_alternation_single_type_matches_legacy_path` and its docstring is
+about SINGLETON parity, yet it queries `[:KNOWS|:KNOWS]` — a repeated
+type — and asserts the doubling. The assertion described behaviour instead
+of deriving it, and contradicted RFC-024's own definition ("one row per
+matching PATH, not one row per tuple"; a path is a sequence of actual
+edges). The type list is now deduplicated at lowering. Verified across
+eight shapes; genuine alternation, parallel-edge multiplicity and
+flat/WCOJ parity unchanged.
+
+#### Original entry
 
 `MATCH (a:P)-[:E|E]->(b:Q)` returns every matching row TWICE; `-[:E]->`
 returns it once. The executor unions one partner list per listed type

--- a/docs/testing/25tb-readiness.md
+++ b/docs/testing/25tb-readiness.md
@@ -1438,3 +1438,75 @@ If an exact-answer fast path is ever wanted, it needs a per-label
 "stats are exact" bit that flush clears on any tombstone and compaction
 sets when it recomputes from survivors. That does not exist today, and
 inventing it is a manifest format change.
+
+### 80. [OPEN — root cause found] Filtered scans prune nothing: the predicate never reaches storage
+
+Measured at 160,000 nodes, one label, one projected column. The times do
+not depend on selectivity at all:
+
+| query | rows returned | time |
+|---|---|---|
+| `WHERE t.idx > 999999` (outside every value in the store) | **0** | 0.377 s |
+| `WHERE t.idx < -5` (outside, low side) | **0** | 0.468 s |
+| `WHERE t.idx = 12345` | 1 | 0.375 s |
+| `WHERE t.idx > 159990` | 9 | 0.412 s |
+| `WHERE t.idx > 80000` | 79,999 | 0.417 s |
+| no filter (manifest fast path) | 160,000 | **0.001 s** |
+
+A predicate that provably matches nothing costs the same as one matching
+half the store. Nothing is being skipped.
+
+**Root cause, and it is not a missing feature — it is two implemented
+features that are not wired.**
+
+1. *Parquet row-group pruning.* `EnabledStatistics::Chunk` is configured
+   (sst/nodes.rs:1515) so per-row-group column statistics ARE written, and
+   `eval_row_group` + `PropertyColumnStats` (sst/predicates.rs:93) decide
+   Absent/MaybePresent from them. But the branch that serves a PROJECTED
+   scan — the common shape, and the one EXPLAIN shows here
+   (`projection=[idx] predicates=[t.idx > 159990]`) — builds a
+   `LimitedNodeBatchContext` carrying `predicates` and then opens the
+   stream with `node_scan_limited_async(..., &[], Some(&[]), ...)`
+   (read.rs:5735-5741): empty predicates, empty projection. Four of the
+   five call sites in read.rs pass `&[]`; only one passes `predicates`.
+2. *Property-page predicate filtering.* `NodePropertyPageReader::filter_node_ids`
+   (property_pages.rs:2088) and the whole `NodePropertyPredicate` IR
+   (property_pages.rs:255) are implemented and unit-tested — and **dead in
+   production**: the only callers are at property_pages.rs:3518 and 3541,
+   both inside the `#[cfg(test)]` module that begins at line 3372, and
+   `NodePropertyPredicate::` is never constructed anywhere outside its own
+   file.
+
+So a filtered projected scan reads and materialises every row and
+evaluates the predicate row-by-row.
+
+**Also measured: the cost is per-ROW, not per-byte.** `count(t.pad)` over
+a 900-byte string column costs 0.433 s against `count(t.idx)` over an
+8-byte integer column at 0.466 s — indistinguishable. Two columns cost
+0.676 s against one at 0.466 s. That is a fixed per-row overhead
+(materialisation into `Row` / `RuntimeValue`) dominating, which is why
+scalar aggregates (item 79) sit at ~0.47 s regardless of the column.
+
+**What this means for finding #8.** The remaining work is not "build
+aggregation pushdown". It is, in order of value:
+1. Wire ONE of the two existing predicate paths into the projected-scan
+   branch. This makes every selective filter selective, not just
+   aggregates.
+2. Then consider vectorised aggregation over the decoded Arrow column, to
+   remove the per-row materialisation that item 79 measured.
+
+**Why this was not wired tonight.** Wiring a filter is the "rows go
+missing" risk class: a page- or row-group-level decision that disagrees
+with the row-level evaluation drops rows silently, which is the failure
+mode that produced five bugs in this codebase this week. It needs the
+equivalence harness pointed at it (filtered scan vs unfiltered-then-filter
+for a matrix of predicate shapes, types, nulls and absent properties) and
+an adversarial review — not the tail of an eight-release day.
+
+One caveat for whoever picks it up: nodes are stored **id-primary**, so a
+property like `idx` is scattered across row groups in UUID order and every
+row group's `[min,max]` may span nearly the whole value range. Row-group
+pruning will therefore help a lot for a property CORRELATED with insertion
+identity and very little for one that is not. The property-page path (2)
+does not have that limitation and is the better first target; verify
+against a real fixture before choosing.


### PR DESCRIPTION
## The problem

A pushed-down cap was checked only at the **seed boundary** — the contract being that every consumed seed contributes its complete edge set — so the hop loop collected every partner, `prepare_expand_targets` hydrated all of them, and truncation happened above the operator.

At degree 160,000 with ~1 KB targets:

| query | before | after |
|---|---|---|
| `RETURN t.idx LIMIT 1` | **2.04 s** | **0.32 s** |
| `RETURN t.idx LIMIT 25` | 2.01 s | **0.31 s** |
| `RETURN t.idx LIMIT 1000` | ~2.0 s | 0.34 s |
| `LIMIT 200000` (beyond the total) | 2.28 s | 2.28 s |
| `RETURN count(t)` (uncapped) | 2.23 s | 2.23 s |

`LIMIT 1` cost exactly what counting all 160,000 rows cost.

## Why a window and not a truncation

The per-edge loop rejects edges on many paths — label mismatch, membership, the trail rule, visited pruning, an absent node. Hydrating "the first N endpoints" and stopping therefore **underfills** whenever one is rejected: fewer rows than the user asked for, which is a wrong answer rather than a slow one.

Endpoints are hydrated in **consecutive windows**. The per-edge loop runs over exactly one window; another is taken only if the cap is still unmet. Because windows are consecutive, the result stays an order-preserving prefix of the uncapped one.

## Guard

`cap.is_some() && max == 1 && !back_reference && shortest == None && !endpoint_bfs`

At `max == 1` a window is provably independent: one round, nothing carries into a next hop, `next_frontier` is never pushed. The other three modes carry pruning state (`visited`, `visited_at_hop`, `level_seen`) whose meaning depends on observing a whole level.

Window sizing starts at `max(cap * 4, 512)` and doubles, bounding hydration round-trips at log(degree) while keeping the first one small.

## The body is unchanged

The iteration was flattened to a plain `(step, edge)` sequence so a window is a slice of it — rather than duplicating ~250 lines into a capped and an uncapped copy. That duplication is how the next regression would have been introduced.

## The oracle was written first

`cap_never_underfills_when_most_edges_are_rejected`: a hub where only every fourth neighbour carries the queried label, so `LIMIT 25` must walk ~100 edges and discard 75. It asserts `min(limit, total)` exactly, and an order-preserving prefix, for limits from 1 to beyond the total. It was added and passing **before** the executor was touched.

Verified live too, on a hub with 30,000 rejected neighbours among 40,000 — every limit from 1 to 100,000 returns exactly `min(limit, total)` rows and matches the uncapped prefix.

## Residual

The adjacency read itself (~0.3 s of the 0.32 s) is Phase 1, outside the window loop. `out_edges(edge_type, src)` has no limit parameter and materialises the whole partner list, so no executor change can avoid it. That is the storage half — finding #3's hierarchical adjacency work.

## Suites

559 lib, `exec_limit_pushdown` (11), `exec_rewrite_equivalence`, `exec_match_expand` (66), `exec_supernode` (3), `exec_shortest_path` (10), `exec_alternation` (12), `exec_plan_aware_routing` (12), `exec_limits` (8).