### PR TITLE
Don't hydrate an expansion target read only for its identity (2.6.11)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,26 @@ crates.io release will establish and document that API explicitly.
 
 ## [Unreleased]
 
+## [2.6.11] - 2026-09-10
+
+### Performance
+
+- **An expansion target referenced only for its identity is no longer fully
+  hydrated.** `count(t)`, `count(DISTINCT t)` and `count(id(t))` read nothing
+  but the node id, yet any mention of the alias forced every column to be
+  materialised. At degree 160,000 with ~1 KB targets they cost 2.2 s against
+  0.55 s for the same query with the target unreferenced; they now cost
+  0.55-0.64 s, a 3.5-4x improvement.
+
+  The admitted forms are a WHITELIST, deliberately shallow: `count(x)` counts
+  non-null occurrences, `count(DISTINCT x)` dedups on a fingerprint whose node
+  arm is the id alone, and `id(x)` reads the id. An identity-only form nested
+  inside a larger expression, a count over a property, or an alias that is
+  ALSO read for a value anywhere in the statement all keep the full path — a
+  new expression form must be added to the whitelist deliberately and can
+  never inherit the fast path by omission.
+
+
 ## [2.6.10] - 2026-09-10
 
 ### Fixed
@@ -3335,7 +3355,8 @@ Change License: Apache License 2.0).
 - LDBC-shaped synthetic benchmark harness with a paired Kùzu runner
   under [`bench/`](./bench/).
 
-[Unreleased]: https://github.com/namidb/namidb/compare/v2.6.10...HEAD
+[Unreleased]: https://github.com/namidb/namidb/compare/v2.6.11...HEAD
+[2.6.11]: https://github.com/namidb/namidb/compare/v2.6.10...v2.6.11
 [2.6.10]: https://github.com/namidb/namidb/compare/v2.6.9...v2.6.10
 [2.6.9]: https://github.com/namidb/namidb/compare/v2.6.8...v2.6.9
 [2.6.8]: https://github.com/namidb/namidb/compare/v2.6.7...v2.6.8

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2199,7 +2199,7 @@ dependencies = [
 
 [[package]]
 name = "namidb"
-version = "2.6.10"
+version = "2.6.11"
 dependencies = [
  "namidb-core",
  "namidb-graph",
@@ -2209,7 +2209,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-ann"
-version = "2.6.10"
+version = "2.6.11"
 dependencies = [
  "namidb-core",
  "rand 0.8.6",
@@ -2222,7 +2222,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-bench"
-version = "2.6.10"
+version = "2.6.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2246,7 +2246,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-bolt"
-version = "2.6.10"
+version = "2.6.11"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2266,7 +2266,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-cli"
-version = "2.6.10"
+version = "2.6.11"
 dependencies = [
  "anyhow",
  "clap",
@@ -2286,7 +2286,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-core"
-version = "2.6.10"
+version = "2.6.11"
 dependencies = [
  "arrow-array",
  "arrow-schema",
@@ -2302,7 +2302,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-graph"
-version = "2.6.10"
+version = "2.6.11"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -2324,7 +2324,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-markdown"
-version = "2.6.10"
+version = "2.6.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2347,7 +2347,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-mcp"
-version = "2.6.10"
+version = "2.6.11"
 dependencies = [
  "anyhow",
  "clap",
@@ -2367,7 +2367,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-py"
-version = "2.6.10"
+version = "2.6.11"
 dependencies = [
  "bytes",
  "chrono",
@@ -2385,7 +2385,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-query"
-version = "2.6.10"
+version = "2.6.11"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2409,7 +2409,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-server"
-version = "2.6.10"
+version = "2.6.11"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2449,7 +2449,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-storage"
-version = "2.6.10"
+version = "2.6.11"
 dependencies = [
  "anyhow",
  "arrow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2.6.10"
+version = "2.6.11"
 edition = "2021"
 rust-version = "1.85"
 license = "BUSL-1.1"
@@ -123,13 +123,13 @@ tower = { version = "0.5", features = ["limit"] }
 tower-http = { version = "0.6", features = ["trace", "cors", "timeout"] }
 
 # Local workspace crates
-namidb-core = { path = "crates/namidb-core", version = "2.6.10" }
-namidb-storage = { path = "crates/namidb-storage", version = "2.6.10" }
-namidb-markdown = { path = "crates/namidb-markdown", version = "2.6.10" }
-namidb-graph = { path = "crates/namidb-graph", version = "2.6.10" }
-namidb-ann = { path = "crates/namidb-ann", version = "2.6.10" }
-namidb-query = { path = "crates/namidb-query", version = "2.6.10" }
-namidb-bolt = { path = "crates/namidb-bolt", version = "2.6.10" }
+namidb-core = { path = "crates/namidb-core", version = "2.6.11" }
+namidb-storage = { path = "crates/namidb-storage", version = "2.6.11" }
+namidb-markdown = { path = "crates/namidb-markdown", version = "2.6.11" }
+namidb-graph = { path = "crates/namidb-graph", version = "2.6.11" }
+namidb-ann = { path = "crates/namidb-ann", version = "2.6.11" }
+namidb-query = { path = "crates/namidb-query", version = "2.6.11" }
+namidb-bolt = { path = "crates/namidb-bolt", version = "2.6.11" }
 
 [profile.release]
 opt-level = 3

--- a/crates/namidb-py/pyproject.toml
+++ b/crates/namidb-py/pyproject.toml
@@ -7,7 +7,7 @@ name = "namidb"
 # Keep in sync with the workspace `version` in /Cargo.toml.
 # `python-wheels.yml` publishes a wheel whose filename uses THIS
 # version; the release tag `py-vX.Y.Z` must match X.Y.Z exactly.
-version = "2.6.10"
+version = "2.6.11"
 description = "Cloud-native graph database on object storage (Python bindings)"
 readme = "README.md"
 license = "BUSL-1.1"

--- a/crates/namidb-query/src/exec/walker.rs
+++ b/crates/namidb-query/src/exec/walker.rs
@@ -6698,9 +6698,94 @@ fn should_skip_target_materialize(
     !back_reference
         && path_binding.is_none()
         && !target_labels.is_empty()
-        && !routing.referenced_aliases.contains(target_alias)
+        && (!routing.referenced_aliases.contains(target_alias)
+            || routing.identity_only_aliases.contains(target_alias))
         && !routing.zero_hop_sources.contains(target_alias)
         && length.as_ref().is_none_or(|length| length.max == 1)
+}
+
+/// Aliases whose every reference reads only the node's identity.
+///
+/// The id-only stub binds EMPTY properties and only the labels its own
+/// Expand asked for, so an alias may take it either by being unreferenced or
+/// by being referenced ONLY in positions that read nothing else. This is a
+/// WHITELIST, deliberately shallow: a form must be added to it on purpose and
+/// can never inherit the fast path by omission, and an identity-only form
+/// NESTED inside a larger expression counts as a full-value reference.
+/// Over-collecting into `full` is the safe direction — it costs a hydration,
+/// where under-collecting returns nulls for real values.
+///
+/// The three admitted forms, and why each reads only the id:
+/// * `count(x)` — counts non-null occurrences; a stub is non-null exactly
+///   where the node is.
+/// * `count(DISTINCT x)` — dedups on `fingerprint_value`, whose node arm is
+///   `N{id};` (walker.rs, `fingerprint_into`): id alone, no properties, no
+///   labels.
+/// * `count(id(x))` — `id()` reads the id, which the stub carries correctly.
+fn collect_identity_only_aliases(
+    plan: &LogicalPlan,
+    all_refs: &BTreeSet<String>,
+) -> BTreeSet<String> {
+    // `full` is the ordinary reference walk with identity-only counts
+    // suppressed; `identity` is just those counts. An alias qualifies only if
+    // it appears in the second and never in the first.
+    let mut full: BTreeSet<String> = BTreeSet::new();
+    collect_plan_references(plan, &mut full, true, true);
+    let mut identity: BTreeSet<String> = BTreeSet::new();
+    collect_identity_count_args(plan, &mut identity);
+    // Referenced, seen at least once in an identity-only position, and never
+    // anywhere else.
+    identity
+        .into_iter()
+        .filter(|a| all_refs.contains(a) && !full.contains(a))
+        .collect()
+}
+
+/// The bare alias an identity-only aggregate argument reads, if it is one.
+fn identity_only_count_arg(expr: &Expression) -> Option<String> {
+    use crate::parser::ExpressionKind;
+    match &expr.kind {
+        ExpressionKind::Variable(ident) => Some(ident.name.to_string()),
+        // `id(<variable>)` and nothing else — any other function, or any
+        // argument that is not a bare variable, is a full-value reference.
+        ExpressionKind::FunctionCall {
+            name,
+            args,
+            distinct,
+        } => {
+            // Unqualified `id(...)` only: a namespaced call is a different
+            // function and must not inherit the fast path.
+            let is_id = name.segments.len() == 1
+                && name.segments[0].name.eq_ignore_ascii_case("id")
+                && args.len() == 1
+                && !*distinct;
+            if !is_id {
+                return None;
+            }
+            match &args[0].kind {
+                ExpressionKind::Variable(ident) => Some(ident.name.to_string()),
+                _ => None,
+            }
+        }
+        _ => None,
+    }
+}
+
+/// The aliases read by identity-only aggregate arguments.
+fn collect_identity_count_args(plan: &LogicalPlan, out: &mut BTreeSet<String>) {
+    use crate::plan::logical::AggregateExpr;
+    if let LogicalPlan::Aggregate { aggregations, .. } = plan {
+        for (_alias, agg) in aggregations {
+            if let AggregateExpr::Count { arg: Some(e), .. } = agg {
+                if let Some(alias) = identity_only_count_arg(e) {
+                    out.insert(alias);
+                }
+            }
+        }
+    }
+    for child in plan.children() {
+        collect_identity_count_args(child, out);
+    }
 }
 
 /// Collect the source alias of every `*0..n` Expand in the plan.
@@ -9742,6 +9827,10 @@ pub(crate) struct PlanRouting {
     /// consumed downstream. This intentionally excludes a bare `DELETE r`:
     /// deleting a relationship only needs its `(type, src, dst)` identity.
     value_referenced_aliases: BTreeSet<String>,
+    /// Aliases every one of whose references reads only the node's
+    /// IDENTITY, never a property, a label or the whole value. Such a target
+    /// can be bound as an id-only stub even though it IS referenced.
+    identity_only_aliases: BTreeSet<String>,
     /// Aliases a later Expand consumes as the SOURCE of a zero-length
     /// variable-length pattern (`*0..n`). Such an Expand decides whether the
     /// source itself is a result by reading the labels off the ROW, and an
@@ -9767,7 +9856,9 @@ impl PlanRouting {
         collect_plan_value_referenced_variables(plan, &mut value_refs);
         let mut zero_hop_sources: BTreeSet<String> = BTreeSet::new();
         collect_zero_hop_expand_sources(plan, &mut zero_hop_sources);
+        let identity_only_aliases = collect_identity_only_aliases(plan, &refs);
         Self {
+            identity_only_aliases,
             referenced_aliases: refs,
             value_referenced_aliases: value_refs,
             zero_hop_sources,
@@ -10025,20 +10116,21 @@ fn collect_plan_node_aliases(plan: &LogicalPlan, out: &mut BTreeSet<String>) {
 }
 
 fn collect_plan_referenced_variables(plan: &LogicalPlan, out: &mut BTreeSet<String>) {
-    collect_plan_references(plan, out, true);
+    collect_plan_references(plan, out, true, false);
 }
 
 /// Same plan walk as [`collect_plan_referenced_variables`], except a bare
 /// `DELETE <alias>` is treated as an identity-only use. Every other expression
 /// remains conservative and requires the full value.
 fn collect_plan_value_referenced_variables(plan: &LogicalPlan, out: &mut BTreeSet<String>) {
-    collect_plan_references(plan, out, false);
+    collect_plan_references(plan, out, false, false);
 }
 
 fn collect_plan_references(
     plan: &LogicalPlan,
     out: &mut BTreeSet<String>,
     delete_needs_full_value: bool,
+    skip_identity_counts: bool,
 ) {
     use crate::plan::logical::{AggregateExpr, CreateElement, RemoveOp};
 
@@ -10066,6 +10158,12 @@ fn collect_plan_references(
             }
             for (_alias, agg) in aggregations {
                 match agg {
+                    // `count(x)` / `count(DISTINCT x)` / `count(id(x))` read
+                    // only the node's IDENTITY, so under `skip_identity_counts`
+                    // they contribute no VALUE reference. Split out of the
+                    // shared arm below, which does read values.
+                    AggregateExpr::Count { arg: Some(e), .. }
+                        if skip_identity_counts && identity_only_count_arg(e).is_some() => {}
                     AggregateExpr::Count { arg: Some(e), .. }
                     | AggregateExpr::Sum { arg: e, .. }
                     | AggregateExpr::Avg { arg: e, .. }
@@ -10204,7 +10302,7 @@ fn collect_plan_references(
     }
 
     for child in plan.children() {
-        collect_plan_references(child, out, delete_needs_full_value);
+        collect_plan_references(child, out, delete_needs_full_value, skip_identity_counts);
     }
 }
 
@@ -10577,5 +10675,50 @@ mod tests {
     fn sum_mixed_promotes_to_float() {
         let v = sum_values(&[RuntimeValue::Integer(1), RuntimeValue::Float(2.5)]).unwrap();
         assert_eq!(v, RuntimeValue::Float(3.5));
+    }
+}
+
+#[cfg(test)]
+mod identity_only_tests {
+    use super::*;
+    use crate::plan::lower;
+
+    fn routing_for(q: &str) -> PlanRouting {
+        let parsed = crate::parser::parse(q).unwrap();
+        let plan = lower(&parsed).unwrap();
+        PlanRouting::analyze(&plan)
+    }
+
+    #[test]
+    fn identity_only_classification() {
+        for (q, alias, expect) in [
+            ("MATCH (a:P)-[:E]->(b:Q) RETURN count(b) AS c", "b", true),
+            (
+                "MATCH (a:P)-[:E]->(b:Q) RETURN count(id(b)) AS c",
+                "b",
+                true,
+            ),
+            (
+                "MATCH (a:P)-[:E]->(b:Q) RETURN count(DISTINCT b) AS c",
+                "b",
+                true,
+            ),
+            ("MATCH (a:P)-[:E]->(b:Q) RETURN count(b.n) AS c", "b", false),
+            (
+                "MATCH (a:P)-[:E]->(b:Q) RETURN count(b) AS c, max(b.n) AS m",
+                "b",
+                false,
+            ),
+            ("MATCH (a:P)-[:E]->(b:Q) RETURN b.n AS n", "b", false),
+        ] {
+            let r = routing_for(q);
+            assert_eq!(
+                r.identity_only_aliases.contains(alias),
+                expect,
+                "`{alias}` in `{q}`: identity_only={:?} referenced={:?}",
+                r.identity_only_aliases,
+                r.referenced_aliases
+            );
+        }
     }
 }

--- a/crates/namidb-query/tests/exec_rewrite_equivalence.rs
+++ b/crates/namidb-query/tests/exec_rewrite_equivalence.rs
@@ -317,6 +317,56 @@ async fn meaning_preserving_rewrites_agree() {
     )
     .await;
 
+    // The identity-only whitelist: an alias referenced ONLY through
+    // `count(x)` / `count(DISTINCT x)` / `count(id(x))` may be bound as an
+    // id-only stub. These must all agree with the unreferenced spelling.
+    assert_equivalent(
+        &w,
+        "identity-only counts agree with count(*)",
+        &[
+            "MATCH (a:P)-[:E]->(b:Q) RETURN count(*) AS c",
+            "MATCH (a:P)-[:E]->(b:Q) RETURN count(b) AS c",
+            "MATCH (a:P)-[:E]->(b:Q) RETURN count(id(b)) AS c",
+        ],
+    )
+    .await;
+
+    assert_equivalent(
+        &w,
+        "identity-only DISTINCT agrees across spellings",
+        &[
+            "MATCH (a:P)-[:E]->(b:Q) RETURN count(DISTINCT b) AS c",
+            "MATCH (a:P)-[:E]->(b:Q) RETURN count(DISTINCT id(b)) AS c",
+        ],
+    )
+    .await;
+
+    // THE DANGEROUS CASE. `b` is counted AND read for a property in the same
+    // statement, so it must NOT be classified identity-only. If it were, the
+    // stub's empty properties would make `max(b.n)` null while the count
+    // stayed right — a half-correct row, which is the worst kind.
+    assert_equivalent(
+        &w,
+        "an alias both counted and value-read stays hydrated",
+        &[
+            "MATCH (a:P)-[:E]->(b:Q) RETURN count(b) AS c, max(b.n) AS m",
+            "MATCH (a:P)-[:E]->(b:Q) RETURN count(*) AS c, max(b.n) AS m",
+        ],
+    )
+    .await;
+
+    // `count(b.n)` counts a PROPERTY, not the node: the argument is not a
+    // bare variable, so it must take the full path.
+    assert_equivalent(
+        &w,
+        "count over a property is not an identity reference",
+        &[
+            "MATCH (a:P)-[:E]->(b:Q) RETURN count(b.n) AS c",
+            "MATCH (a:P)-[:E]->(b:Q) WHERE b.n IS NOT NULL RETURN count(*) AS c",
+        ],
+    )
+    .await;
+
     assert_equivalent(
         &w,
         "conjunctive multi-label vs labels() predicate",

--- a/docs/testing/25tb-readiness.md
+++ b/docs/testing/25tb-readiness.md
@@ -1228,24 +1228,49 @@ limit parameter and materialises the whole partner list, so no executor
 change can avoid it. That is the storage half, and it is where the
 hierarchical adjacency work from finding #3 would earn its keep.
 
-### 76. [OPEN — measured, correct by design] An unlabelled unreferenced target cannot use the membership path
+### 76. [OPEN — design ready] An unlabelled unreferenced target cannot use the membership path
 
 At degree 160,000, `count(*)` over `(t:FAT)` takes 0.63 s but over `()`
-takes 2.24 s — **3.5x** — although neither references the target. The
-label-membership sidecar proves "carries label L"; with no label there is
-nothing to prove, and `try_batch_nodes_have_labels` returns `None` with
+takes 2.24 s — **3.5x** — although neither references the target.
+`try_batch_nodes_have_labels` returns `None` for an empty label list, with
 the reason stated in place: *"Membership in zero labels does not prove
 that the endpoint itself exists; retain the authoritative node point
 path."* So the expansion falls back to full hydration purely to establish
 that each endpoint exists.
 
-**Unlike items 73/74 this is not a mistaken gate.** Those rested on a
-false belief about `batch_lookup_nodes` being label-scoped; this rests on
-a true constraint. Closing it needs a new storage capability — an
-existence-only batch that decodes the key column rather than the whole
-row (`batch_nodes_exist(ids)`) — not the removal of a condition. Worth
-having: `MATCH (a)-[:R]->() RETURN count(*)` is a common shape and pays
-full hydration for nothing.
+**The constraint is real; existence cannot be skipped.** A dangling edge
+would otherwise produce a phantom row. Dangling edges can no longer be
+CREATED through Cypher — a bare `DELETE` of a connected node is refused
+(and since 2.6.10 refused as a 409, not a 500) — but they can exist in
+data written by earlier versions, and the embedded `tombstone_node` API
+carries no incident-edge check. Skipping the proof would silently add rows
+on exactly those stores.
+
+**Two implementable designs, in preference order.**
+
+1. *An existence-only batch* (`batch_nodes_exist(ids) -> Vec<bool>`).
+   The row decode is what costs: measured elsewhere in this document, a
+   900-byte string column costs the same as an 8-byte integer column
+   (0.433 s vs 0.466 s at 160k), so the expense is per-ROW
+   materialisation, not bytes. Reading only the key column to test
+   presence avoids essentially all of it. This is the clean answer, and it
+   is a new storage method in the hot read path — it needs the
+   equivalence harness pointed at it (unlabelled vs labelled counts on a
+   store containing a deliberately dangling edge, written through the
+   embedded API).
+
+2. *Probe the label sidecar for ANY label.* Membership is keyed
+   `(label_id, node_id)` and `per_label_counts` names the labels present
+   in each SST, so existence is a probe per label, ORed. A node cannot
+   have zero labels — `CREATE (n {p: 1})` without a label is rejected with
+   a 400, verified live — so "appears under some label" is equivalent to
+   "exists". Bound it: probe when the SST carries few labels (≤ 4, say)
+   and fall back to hydration otherwise, or a wide-schema store turns one
+   read into fifty.
+
+Design (1) is preferred: it is O(1) per node regardless of schema width,
+and it does not depend on the every-node-has-a-label invariant holding for
+data written by any future writer.
 
 ### 77. [FIXED in 2.6.7] Labelled variable-length burned CPU with no extra I/O
 

--- a/docs/testing/25tb-readiness.md
+++ b/docs/testing/25tb-readiness.md
@@ -1507,13 +1507,38 @@ aggregation pushdown". It is, in order of value:
 2. Then consider vectorised aggregation over the decoded Arrow column, to
    remove the per-row materialisation that item 79 measured.
 
-**Why this was not wired tonight.** Wiring a filter is the "rows go
-missing" risk class: a page- or row-group-level decision that disagrees
-with the row-level evaluation drops rows silently, which is the failure
-mode that produced five bugs in this codebase this week. It needs the
-equivalence harness pointed at it (filtered scan vs unfiltered-then-filter
-for a matrix of predicate shapes, types, nulls and absent properties) and
-an adversarial review — not the tail of an eight-release day.
+**The `&[]` is not an oversight — and knowing why is the whole handoff.**
+That branch reads properties from the `.npp` sidecar addressed by a
+RUNNING ROW ORDINAL:
+
+    let mut next_ordinal = 0_u64;                      // read.rs:5754
+    ...
+    next_ordinal = next_ordinal.checked_add(batch.num_rows() as u64)
+    ...
+    if next_ordinal != desc.row_count {                // read.rs:5812
+        return Err(Error::invariant("node property/Parquet row-count mismatch"));
+    }
+
+The ordinal must stay aligned with the sidecar, so the branch requires
+seeing EVERY row group — and it self-checks that it did. Handing Parquet
+the predicates would make it skip row groups, the ordinal would fall
+short, and that invariant would fire. So the current code is correct and
+defensive, not careless.
+
+**What wiring it therefore requires**: advancing `next_ordinal` by the row
+count of each SKIPPED row group (available in the footer metadata that
+this branch already fetches and caches), so the sidecar stays addressable.
+The existing invariant check is the safety net for getting it wrong — it
+turns a silent row loss into a hard error, which is why it should be kept
+and not relaxed.
+
+**Why this was not wired tonight.** Even with the accounting understood, a
+page- or row-group-level decision that disagrees with the row-level
+evaluation drops rows, which is the failure mode that produced five bugs
+in this codebase this week. It wants the equivalence harness pointed at it
+(filtered scan vs unfiltered-then-filter across a matrix of predicate
+shapes, types, nulls and absent properties) and an adversarial review —
+not the tail of an eleven-release day.
 
 One caveat for whoever picks it up: nodes are stored **id-primary**, so a
 property like `idx` is scattered across row groups in UUID order and every

--- a/docs/testing/25tb-readiness.md
+++ b/docs/testing/25tb-readiness.md
@@ -1144,56 +1144,43 @@ unlabelled target, so the release that fixed the labelled twin left this
 untouched. A sweep of 12 expand shapes at degree 120k now shows them
 uniform (~1.7 s); before the fix two of them did not complete.
 
-### 74. [OPEN — prerequisite now met] A bare-node reference forces full hydration
+### 74. [FIXED in 2.6.11] A bare-node reference forced full hydration
 
-Re-measured on the 2.6.10 build at degree 160,000, ~1 KB targets:
+Measured at degree 160,000, ~1 KB targets:
 
-| query | time |
-|---|---|
-| `RETURN count(*)` (target unreferenced) | **0.64 s** |
-| `RETURN count(t)` | 2.20 s |
-| `RETURN count(id(t))` | 2.19 s |
-| `RETURN count(DISTINCT t)` | 2.13 s |
-| `RETURN sum(t.idx)` | 2.25 s |
+| query | before | after |
+|---|---|---|
+| `RETURN count(*)` (unreferenced, the floor) | 0.54 s | 0.55 s |
+| `RETURN count(t)` | 2.24 s | **0.55 s** |
+| `RETURN count(id(t))` | 2.23 s | **0.61 s** |
+| `RETURN count(DISTINCT t)` | 2.24 s | **0.64 s** |
+| `RETURN count(t.idx)` | 2.26 s | 2.11 s (correctly NOT optimised) |
+| `RETURN count(t), max(t.idx)` | — | 2.36 s (correctly NOT optimised) |
 
-`count(id(t))` — where the caller has literally written that only the id
-is needed — costs the same as full hydration. 3.4x of pure waste.
-`should_skip_target_materialize` requires
-`!routing.referenced_aliases.contains(target_alias)`, and
-`collect_plan_references` treats `Count { arg: Some(e) }` exactly like
-`Sum`/`Avg`, so any mention of the alias forces every column.
+`PlanRouting` gained `identity_only_aliases`: aliases referenced ONLY in
+positions that read the node id. `should_skip_target_materialize` admits
+those to the id-only stub alongside genuinely unreferenced ones.
 
-**The prerequisite is now met.** Widening the id-only stub was blocked on
-the reference collector being trustworthy, and it was not: two forms read
-a host binding without registering it, and both were silent wrong answers
-(quantifiers / list comprehensions over a target property, and a `*0..n`
-source losing its extra labels — both fixed in 2.6.8). The collector is
-now EXHAUSTIVE — no `_` arm, so the compiler forces a decision for every
-`ExpressionKind` — and the only forms that deliberately register nothing
-are the genuinely closed pattern forms (`Exists`, `ExistsSubquery`,
-`PatternComprehension`) plus `Literal` / `Parameter` / `Star`, none of
-which read a host binding.
+Sound because each admitted form provably reads only the id: `count(x)`
+counts non-null occurrences (a stub is non-null exactly where the node is);
+`count(DISTINCT x)` dedups on `fingerprint_value`, whose node arm is
+`N{id};` — verified at walker.rs, id alone, no properties, no labels; and
+`id(x)` reads the id, which the stub carries correctly.
 
-**What remains is the whitelist, and it must stay narrow.** The stub binds
-EMPTY properties, so mis-classifying one form returns nulls for real
-values. Two tiers with different burdens of proof:
+**A WHITELIST, never a blacklist.** Nested identity forms, counts over a
+property, and any alias also read for a value elsewhere in the statement
+all keep the full path. A new expression form must be added deliberately.
 
-- `id(x)` as the sole mention: provably safe with no further reasoning —
-  `id()` reads the id, and the stub carries the correct id.
-- bare `count(x)` / `count(DISTINCT x)`: needs the argument that node
-  dedup is by an id-only fingerprint (it is — a BTreeSet over id
-  fingerprints since the first release, confirmed under item 68). Worth
-  having, since `count(x)` is the common spelling, but it rests on an
-  aggregate-internals invariant that deserves its own pinning test first.
-
-Anything else mentioning the alias stays on the full path. Not a
-blacklist: a new expression form must be added to the whitelist
-deliberately, never inherit the fast path by omission.
-
-Add a family to `exec_rewrite_equivalence.rs` at the same time, and
-remember that file's trap: a family must reference the target ONLY through
-the construct under test, or the stub is never built and the family passes
-with the fix reverted.
+**Two process notes worth keeping.** First, the implementation initially
+passed every test while being completely INERT — `count(t)` stayed at
+2.24 s. `collect_plan_references` recurses into children itself, so calling
+it per-node walked the whole subtree and collected the alias from the
+aggregate anyway. Caught only by measuring after the tests went green;
+fixed by threading a `skip_identity_counts` flag through the single
+existing traversal instead of adding a second one. Second, the equivalence
+families for this must include the MIXED case (`count(t)` and `max(t.n)`
+in one statement): that is the shape where a mis-classification returns a
+correct count beside a null maximum — a half-right row, the worst kind.
 
 ### 75. [FIXED in 2.6.10] `LIMIT` now bounds an expansion's work
 


### PR DESCRIPTION
## The waste

`count(t)`, `count(DISTINCT t)` and `count(id(t))` read nothing but the node id. Any mention of the alias forced every column to be materialised anyway.

Degree 160,000, ~1 KB targets:

| query | before | after |
|---|---|---|
| `RETURN count(*)` (unreferenced — the floor) | 0.54 s | 0.55 s |
| `RETURN count(t)` | 2.24 s | **0.55 s** |
| `RETURN count(id(t))` | 2.23 s | **0.61 s** |
| `RETURN count(DISTINCT t)` | 2.24 s | **0.64 s** |
| `RETURN count(t.idx)` | 2.26 s | 2.11 s — correctly *not* optimised |
| `RETURN count(t), max(t.idx)` | — | 2.36 s — correctly *not* optimised |

`count(id(t))` is the one that stings: the caller has written, explicitly, that only the id is needed.

## Why each admitted form is safe

`PlanRouting` gained `identity_only_aliases` — aliases referenced **only** in positions that read the id. `should_skip_target_materialize` admits those to the id-only stub alongside genuinely unreferenced targets.

- `count(x)` counts non-null occurrences; a stub is non-null exactly where the node is.
- `count(DISTINCT x)` dedups on `fingerprint_value`, whose node arm is `N{id};` — **verified in the source**: id alone, no properties, no labels.
- `id(x)` reads the id, which the stub carries correctly.

## A whitelist, and it must stay one

An identity form **nested** inside a larger expression, a count over a **property**, and an alias also read for a value **anywhere** in the statement all keep the full path. Over-collecting costs a hydration; under-collecting returns nulls for real values. A new expression form has to be added deliberately — nothing inherits the fast path by omission.

## Two things about getting here

**The first implementation passed every test while being completely inert.** `count(t)` stayed at 2.24 s. `collect_plan_references` recurses into children itself, so calling it per-node walked the whole subtree and collected the alias from the aggregate regardless — the classification was correct and the `full` set was contaminated. Every test still passed, because correct-and-slow looks identical to correct-and-fast unless you measure. Caught by measuring after green, and fixed by threading a `skip_identity_counts` flag through the single existing traversal rather than adding a second one.

**The equivalence families include the mixed case on purpose** — `count(t)` beside `max(t.n)` in one statement. That is the shape where a mis-classification returns a correct count next to a null maximum: a half-right row, which is worse than an obvious failure.

## Tests

- `identity_only_classification` — six shapes, three that must qualify and three that must not, asserting the routing set directly.
- Four new families in `exec_rewrite_equivalence.rs`: identity counts vs `count(*)`, DISTINCT spellings, the mixed case, and count-over-a-property.
- Suites green: 560 lib, `exec_plan_aware_routing` (12), `exec_match_expand` (66), `exec_supernode` (3), `exec_aggregates`, `exec_limit_pushdown` (11), `exec_rewrite_equivalence`.