### PR TITLE
WHERE comparing an int property to a float literal returned no rows (2.6.12)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,34 @@ crates.io release will establish and document that API explicitly.
 
 ## [Unreleased]
 
+## [2.6.12] - 2026-09-10
+
+### Fixed
+
+- **A `WHERE` comparing an integer property to a float literal — or a float
+  property to an integer literal — silently returned NO ROWS.**
+  `WHERE n.amount > 0` over a float column matched nothing, while
+  `RETURN n.amount > 0` on the same row returned true: the same comparison
+  disagreeing with itself depending on whether it was a filter or an
+  expression. Affected `=`, `<`, `<=`, `>`, `>=` and `IN`, on both the
+  memtable and the flushed-SST paths.
+
+  Cypher compares numbers across Int and Float, and the executor already
+  did (`is_equal` uses `(x as f64) == y`, `compare` uses
+  `(x as f64).partial_cmp(y)`). The scan-side evaluator had no cross-numeric
+  arms, so every mixed comparison fell through to "incomparable", which
+  every caller resolves as `false`. It now mirrors the executor exactly.
+
+  This also showed up as a route divergence: the same predicate matched
+  through a composite index (which canonicalises numeric members to f64)
+  and did not match through the single-property path, so adding an
+  unrelated `AND` conjunct changed the answer.
+
+  Row-group pruning shared the gap but was already fail-safe there — an
+  incomparable pair resolved to `MaybePresent`, so it never over-pruned. It
+  now compares, so a mixed predicate can also skip row groups.
+
+
 ## [2.6.11] - 2026-09-10
 
 ### Performance
@@ -3355,7 +3383,8 @@ Change License: Apache License 2.0).
 - LDBC-shaped synthetic benchmark harness with a paired Kùzu runner
   under [`bench/`](./bench/).
 
-[Unreleased]: https://github.com/namidb/namidb/compare/v2.6.11...HEAD
+[Unreleased]: https://github.com/namidb/namidb/compare/v2.6.12...HEAD
+[2.6.12]: https://github.com/namidb/namidb/compare/v2.6.11...v2.6.12
 [2.6.11]: https://github.com/namidb/namidb/compare/v2.6.10...v2.6.11
 [2.6.10]: https://github.com/namidb/namidb/compare/v2.6.9...v2.6.10
 [2.6.9]: https://github.com/namidb/namidb/compare/v2.6.8...v2.6.9

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2199,7 +2199,7 @@ dependencies = [
 
 [[package]]
 name = "namidb"
-version = "2.6.11"
+version = "2.6.12"
 dependencies = [
  "namidb-core",
  "namidb-graph",
@@ -2209,7 +2209,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-ann"
-version = "2.6.11"
+version = "2.6.12"
 dependencies = [
  "namidb-core",
  "rand 0.8.6",
@@ -2222,7 +2222,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-bench"
-version = "2.6.11"
+version = "2.6.12"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2246,7 +2246,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-bolt"
-version = "2.6.11"
+version = "2.6.12"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2266,7 +2266,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-cli"
-version = "2.6.11"
+version = "2.6.12"
 dependencies = [
  "anyhow",
  "clap",
@@ -2286,7 +2286,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-core"
-version = "2.6.11"
+version = "2.6.12"
 dependencies = [
  "arrow-array",
  "arrow-schema",
@@ -2302,7 +2302,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-graph"
-version = "2.6.11"
+version = "2.6.12"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -2324,7 +2324,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-markdown"
-version = "2.6.11"
+version = "2.6.12"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2347,7 +2347,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-mcp"
-version = "2.6.11"
+version = "2.6.12"
 dependencies = [
  "anyhow",
  "clap",
@@ -2367,7 +2367,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-py"
-version = "2.6.11"
+version = "2.6.12"
 dependencies = [
  "bytes",
  "chrono",
@@ -2385,7 +2385,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-query"
-version = "2.6.11"
+version = "2.6.12"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2409,7 +2409,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-server"
-version = "2.6.11"
+version = "2.6.12"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2449,7 +2449,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-storage"
-version = "2.6.11"
+version = "2.6.12"
 dependencies = [
  "anyhow",
  "arrow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2.6.11"
+version = "2.6.12"
 edition = "2021"
 rust-version = "1.85"
 license = "BUSL-1.1"
@@ -123,13 +123,13 @@ tower = { version = "0.5", features = ["limit"] }
 tower-http = { version = "0.6", features = ["trace", "cors", "timeout"] }
 
 # Local workspace crates
-namidb-core = { path = "crates/namidb-core", version = "2.6.11" }
-namidb-storage = { path = "crates/namidb-storage", version = "2.6.11" }
-namidb-markdown = { path = "crates/namidb-markdown", version = "2.6.11" }
-namidb-graph = { path = "crates/namidb-graph", version = "2.6.11" }
-namidb-ann = { path = "crates/namidb-ann", version = "2.6.11" }
-namidb-query = { path = "crates/namidb-query", version = "2.6.11" }
-namidb-bolt = { path = "crates/namidb-bolt", version = "2.6.11" }
+namidb-core = { path = "crates/namidb-core", version = "2.6.12" }
+namidb-storage = { path = "crates/namidb-storage", version = "2.6.12" }
+namidb-markdown = { path = "crates/namidb-markdown", version = "2.6.12" }
+namidb-graph = { path = "crates/namidb-graph", version = "2.6.12" }
+namidb-ann = { path = "crates/namidb-ann", version = "2.6.12" }
+namidb-query = { path = "crates/namidb-query", version = "2.6.12" }
+namidb-bolt = { path = "crates/namidb-bolt", version = "2.6.12" }
 
 [profile.release]
 opt-level = 3

--- a/crates/namidb-py/pyproject.toml
+++ b/crates/namidb-py/pyproject.toml
@@ -7,7 +7,7 @@ name = "namidb"
 # Keep in sync with the workspace `version` in /Cargo.toml.
 # `python-wheels.yml` publishes a wheel whose filename uses THIS
 # version; the release tag `py-vX.Y.Z` must match X.Y.Z exactly.
-version = "2.6.11"
+version = "2.6.12"
 description = "Cloud-native graph database on object storage (Python bindings)"
 readme = "README.md"
 license = "BUSL-1.1"

--- a/crates/namidb-storage/src/sst/predicates.rs
+++ b/crates/namidb-storage/src/sst/predicates.rs
@@ -226,6 +226,18 @@ fn scalar_cmp(a: &StatScalar, b: &StatScalar) -> Option<Ordering> {
         (Int64(x), Int64(y)) => Some(x.cmp(y)),
         (Float32(x), Float32(y)) => Some(float_cmp_f32(*x, *y)),
         (Float64(x), Float64(y)) => Some(float_cmp_f64(*x, *y)),
+        // Mixed Int/Float, matching `value_cmp` above and the executor. A
+        // missing arm here is SAFE (the caller resolves `None` to
+        // `MaybePresent`, so it never prunes wrongly) but it means a mixed
+        // predicate skips no row groups at all.
+        (Int32(x), Float32(y)) => Some(float_cmp_f64(*x as f64, *y as f64)),
+        (Int32(x), Float64(y)) => Some(float_cmp_f64(*x as f64, *y)),
+        (Int64(x), Float32(y)) => Some(float_cmp_f64(*x as f64, *y as f64)),
+        (Int64(x), Float64(y)) => Some(float_cmp_f64(*x as f64, *y)),
+        (Float32(x), Int32(y)) => Some(float_cmp_f64(*x as f64, *y as f64)),
+        (Float32(x), Int64(y)) => Some(float_cmp_f64(*x as f64, *y as f64)),
+        (Float64(x), Int32(y)) => Some(float_cmp_f64(*x, *y as f64)),
+        (Float64(x), Int64(y)) => Some(float_cmp_f64(*x, *y as f64)),
         (Utf8(x), Utf8(y)) => Some(x.cmp(y)),
         (LargeUtf8(x), LargeUtf8(y)) => Some(x.cmp(y)),
         (Binary(x), Binary(y)) => Some(x.cmp(y)),
@@ -313,6 +325,19 @@ fn value_cmp(v: &Value, s: &StatScalar) -> Option<Ordering> {
         // determinism (writer canonicalises NaN during HLL hashing).
         (V::F64(a), S::Float32(b)) => Some(float_cmp_f64(*a, *b as f64)),
         (V::F64(a), S::Float64(b)) => Some(float_cmp_f64(*a, *b)),
+        // Cypher compares numbers ACROSS Int and Float: `5 = 5.0` is true,
+        // and the executor does exactly this — `is_equal` uses
+        // `(x as f64) == y` and `compare` uses `(x as f64).partial_cmp(y)`
+        // (exec/expr.rs). Without these arms a mixed comparison fell to
+        // `_ => None`, which every caller resolves as `false`, so
+        // `WHERE n.price > 0` over a float column returned NO ROWS while
+        // `RETURN n.price > 0` returned true — the same comparison
+        // disagreeing with itself depending on whether it was a filter or
+        // an expression.
+        (V::I64(a), S::Float32(b)) => Some(float_cmp_f64(*a as f64, *b as f64)),
+        (V::I64(a), S::Float64(b)) => Some(float_cmp_f64(*a as f64, *b)),
+        (V::F64(a), S::Int32(b)) => Some(float_cmp_f64(*a, *b as f64)),
+        (V::F64(a), S::Int64(b)) => Some(float_cmp_f64(*a, *b as f64)),
         (V::Str(a), S::Utf8(b)) => Some(a.as_str().cmp(b.as_str())),
         (V::Str(a), S::LargeUtf8(b)) => Some(a.as_str().cmp(b.as_str())),
         (V::Bytes(a), S::Binary(b)) => Some(a.as_slice().cmp(b.as_slice())),
@@ -790,5 +815,125 @@ mod tests {
         assert_eq!(p1.column(), "age");
         assert_eq!(p2.column(), "name");
         assert_eq!(p3.column(), "age");
+    }
+}
+
+#[cfg(test)]
+mod numeric_coercion_tests {
+    use super::*;
+    use namidb_core::value::Value;
+
+    /// A scan-side predicate must compare numbers the way the executor does:
+    /// `is_equal` uses `(x as f64) == y` and `compare` uses
+    /// `(x as f64).partial_cmp(y)` (namidb-query exec/expr.rs).
+    ///
+    /// Without cross-numeric arms every mixed comparison fell to `None`,
+    /// which the caller resolves to `false`, so `WHERE n.price > 0` over a
+    /// float column returned NO ROWS while `RETURN n.price > 0` returned
+    /// true — the same comparison disagreeing with itself.
+    #[test]
+    fn mixed_int_float_predicates_match_executor_semantics() {
+        let eq = |target: StatScalar| ScanPredicate::Eq {
+            column: "p".into(),
+            value: target,
+        };
+        let gt = |target: StatScalar| ScanPredicate::Gt {
+            column: "p".into(),
+            value: target,
+        };
+        let lt = |target: StatScalar| ScanPredicate::Lt {
+            column: "p".into(),
+            value: target,
+        };
+
+        // An integer-valued property against float predicates.
+        assert!(eval_against_value(
+            &eq(StatScalar::Float64(5.0)),
+            Some(&Value::I64(5))
+        ));
+        assert!(!eval_against_value(
+            &eq(StatScalar::Float64(5.5)),
+            Some(&Value::I64(5))
+        ));
+        assert!(eval_against_value(
+            &gt(StatScalar::Float64(4.5)),
+            Some(&Value::I64(5))
+        ));
+        assert!(eval_against_value(
+            &lt(StatScalar::Float64(5.5)),
+            Some(&Value::I64(5))
+        ));
+
+        // A float-valued property against integer predicates — the shape
+        // that silently emptied `WHERE amount > 0` over a money column.
+        assert!(eval_against_value(
+            &gt(StatScalar::Int64(0)),
+            Some(&Value::F64(12.5))
+        ));
+        assert!(eval_against_value(
+            &lt(StatScalar::Int64(13)),
+            Some(&Value::F64(12.5))
+        ));
+        assert!(!eval_against_value(
+            &gt(StatScalar::Int64(13)),
+            Some(&Value::F64(12.5))
+        ));
+        assert!(eval_against_value(
+            &eq(StatScalar::Int64(5)),
+            Some(&Value::F64(5.0))
+        ));
+        assert!(!eval_against_value(
+            &eq(StatScalar::Int64(5)),
+            Some(&Value::F64(5.5))
+        ));
+
+        // Same-type comparisons are unchanged.
+        assert!(eval_against_value(
+            &eq(StatScalar::Int64(5)),
+            Some(&Value::I64(5))
+        ));
+        assert!(eval_against_value(
+            &eq(StatScalar::Float64(5.5)),
+            Some(&Value::F64(5.5))
+        ));
+        // A genuinely incomparable pair still declines.
+        assert!(!eval_against_value(
+            &eq(StatScalar::Utf8("5".into())),
+            Some(&Value::I64(5))
+        ));
+    }
+
+    /// Row-group pruning must never exclude a group a mixed predicate could
+    /// match. `None` was already safe (`MaybePresent`); now the comparison
+    /// succeeds, so it can also prune correctly.
+    #[test]
+    fn mixed_row_group_bounds_prune_correctly_and_never_over_prune() {
+        let stats = PropertyColumnStats {
+            name: "p".into(),
+            null_count: 0,
+            min: Some(StatScalar::Int64(10)),
+            max: Some(StatScalar::Int64(20)),
+            ndv_estimate: None,
+        };
+        let eq = |v: StatScalar| ScanPredicate::Eq {
+            column: "p".into(),
+            value: v,
+        };
+        // Inside the integer range, expressed as a float: must be kept.
+        assert_eq!(
+            eval_row_group(&eq(StatScalar::Float64(15.0)), &stats),
+            RowGroupVerdict::MaybePresent
+        );
+        // On the boundary: kept.
+        assert_eq!(
+            eval_row_group(&eq(StatScalar::Float64(10.0)), &stats),
+            RowGroupVerdict::MaybePresent
+        );
+        // Outside: now provably absent, where before it was conservatively
+        // kept.
+        assert_eq!(
+            eval_row_group(&eq(StatScalar::Float64(25.0)), &stats),
+            RowGroupVerdict::Absent
+        );
     }
 }


### PR DESCRIPTION
## The bug

```cypher
MATCH (n:VENTA) WHERE n.neta > 0 RETURN count(*)     -- 0     (float column)
MATCH (n:VENTA) RETURN n.neta > 0                    -- true
```

The same comparison, in the same engine, disagreeing with itself depending on whether it is a **filter** or an **expression**.

Measured on one node `{neta: 12.5, unidades: 3}` — identical before and after flush:

| query | returned | correct |
|---|---|---|
| `WHERE n.neta > 0` | **0 rows** | 1 |
| `WHERE n.neta > 0.0` | 1 row | 1 |
| `WHERE n.unidades >= 1.0` | **0 rows** | 1 |
| `WHERE n.unidades >= 1` | 1 row | 1 |
| `RETURN n.neta > 0` | true | true |

Affects `=`, `<`, `<=`, `>`, `>=` and `IN`, on both the memtable and flushed-SST paths.

`WHERE amount > 0` over a money column, `WHERE quantity >= 1` over an integer column written against a float threshold — these are ordinary shapes, and they returned nothing.

## Cause

Cypher compares numbers across Int and Float, and the **executor already does**: `is_equal` uses `(x as f64) == y` and `compare` uses `(x as f64).partial_cmp(y)` (`exec/expr.rs`).

`value_cmp` in the scan-side evaluator had arms only for same-family pairs — `(I64, Int64)`, `(F64, Float64)` — so every mixed comparison fell to `_ => None`, and each caller resolves that with `.unwrap_or(false)`.

## It was already visible as a route divergence

`t.a = 30.0` against a stored `a: 30`:

- through a **composite** index → **matched** (TupleV1 canonicalises numeric members to f64 and confirms with coercing equality — a deliberate decision recorded in `25tb-readiness.md`)
- through the **single-property** path → **did not match**

So adding an unrelated `AND b = 'k'` conjunct changed the answer. The composite path had the semantics right; the single-property path was the outlier.

## Row-group pruning

`scalar_cmp` shared the gap, but it was already **fail-safe** there: the caller resolves an incomparable pair to `MaybePresent`, so it never over-pruned — it simply never pruned a mixed predicate at all. Both comparators now mirror the executor, so mixed predicates can prune too.

## Verification

- Two unit tests in `predicates.rs` covering both comparators, including negatives and a string-vs-number pair that must still **not** match.
- End to end across twelve shapes on memtable **and** on SST after flush: 12/12 correct on both, where 5 of 9 were wrong before.
- Suites: 685 storage lib, 560 query lib, `exec_writes` (99), `exec_match_expand` (66), `exec_rewrite_equivalence`.

## How it was found

Chasing item 80 (filtered scans prune nothing). The measurements ruled out row-group pruning as the answer — nodes are id-primary, so every row group spans the value range — which led to the index route note *"numeric equality is not posting-indexed; only String/Bool are"*, then to a string-vs-numeric contrast (0.001 s vs 1.603 s on identical data), and finally to the coercion asymmetry underneath it.