### PR TITLE
Prove an unlabelled expansion target exists without decoding its row (2.6.13)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,31 @@ crates.io release will establish and document that API explicitly.
 
 ## [Unreleased]
 
+## [2.6.13] - 2026-09-10
+
+### Performance
+
+- **An expansion whose target carries no label no longer decodes a full row
+  per endpoint.** The label-membership sidecar proves "carries label L", and
+  an unlabelled target has no label to prove — so `MATCH (a)-[:R]->()` fell
+  back to hydrating every endpoint purely to establish that it existed. At
+  degree 160,000 with ~1 KB targets, `count(*)` over `()` took 2.23 s
+  against 0.55 s for the labelled spelling; it now takes 0.53 s.
+
+  Existence is proven by `try_batch_nodes_exist`, which ORs across the
+  labels each descriptor actually holds — a node can never carry zero
+  labels, since `CREATE (n {p: 1})` without one is rejected. It fails
+  CLOSED: any descriptor that cannot be probed, a wide-schema descriptor
+  past an 8-label bound, or an id no descriptor claims all fall back to
+  hydration, because a descriptor skipped by mistake is a missing row
+  rather than a slow one.
+
+  The proof cannot be skipped: a dangling edge would become a phantom row.
+  Cypher can no longer create one — a bare `DELETE` of a connected node is
+  refused — but older data and the embedded `tombstone_node` API can still
+  hold them.
+
+
 ## [2.6.12] - 2026-09-10
 
 ### Fixed
@@ -3383,7 +3408,8 @@ Change License: Apache License 2.0).
 - LDBC-shaped synthetic benchmark harness with a paired Kùzu runner
   under [`bench/`](./bench/).
 
-[Unreleased]: https://github.com/namidb/namidb/compare/v2.6.12...HEAD
+[Unreleased]: https://github.com/namidb/namidb/compare/v2.6.13...HEAD
+[2.6.13]: https://github.com/namidb/namidb/compare/v2.6.12...v2.6.13
 [2.6.12]: https://github.com/namidb/namidb/compare/v2.6.11...v2.6.12
 [2.6.11]: https://github.com/namidb/namidb/compare/v2.6.10...v2.6.11
 [2.6.10]: https://github.com/namidb/namidb/compare/v2.6.9...v2.6.10

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2199,7 +2199,7 @@ dependencies = [
 
 [[package]]
 name = "namidb"
-version = "2.6.12"
+version = "2.6.13"
 dependencies = [
  "namidb-core",
  "namidb-graph",
@@ -2209,7 +2209,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-ann"
-version = "2.6.12"
+version = "2.6.13"
 dependencies = [
  "namidb-core",
  "rand 0.8.6",
@@ -2222,7 +2222,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-bench"
-version = "2.6.12"
+version = "2.6.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2246,7 +2246,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-bolt"
-version = "2.6.12"
+version = "2.6.13"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2266,7 +2266,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-cli"
-version = "2.6.12"
+version = "2.6.13"
 dependencies = [
  "anyhow",
  "clap",
@@ -2286,7 +2286,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-core"
-version = "2.6.12"
+version = "2.6.13"
 dependencies = [
  "arrow-array",
  "arrow-schema",
@@ -2302,7 +2302,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-graph"
-version = "2.6.12"
+version = "2.6.13"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -2324,7 +2324,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-markdown"
-version = "2.6.12"
+version = "2.6.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2347,7 +2347,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-mcp"
-version = "2.6.12"
+version = "2.6.13"
 dependencies = [
  "anyhow",
  "clap",
@@ -2367,7 +2367,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-py"
-version = "2.6.12"
+version = "2.6.13"
 dependencies = [
  "bytes",
  "chrono",
@@ -2385,7 +2385,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-query"
-version = "2.6.12"
+version = "2.6.13"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2409,7 +2409,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-server"
-version = "2.6.12"
+version = "2.6.13"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2449,7 +2449,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-storage"
-version = "2.6.12"
+version = "2.6.13"
 dependencies = [
  "anyhow",
  "arrow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2.6.12"
+version = "2.6.13"
 edition = "2021"
 rust-version = "1.85"
 license = "BUSL-1.1"
@@ -123,13 +123,13 @@ tower = { version = "0.5", features = ["limit"] }
 tower-http = { version = "0.6", features = ["trace", "cors", "timeout"] }
 
 # Local workspace crates
-namidb-core = { path = "crates/namidb-core", version = "2.6.12" }
-namidb-storage = { path = "crates/namidb-storage", version = "2.6.12" }
-namidb-markdown = { path = "crates/namidb-markdown", version = "2.6.12" }
-namidb-graph = { path = "crates/namidb-graph", version = "2.6.12" }
-namidb-ann = { path = "crates/namidb-ann", version = "2.6.12" }
-namidb-query = { path = "crates/namidb-query", version = "2.6.12" }
-namidb-bolt = { path = "crates/namidb-bolt", version = "2.6.12" }
+namidb-core = { path = "crates/namidb-core", version = "2.6.13" }
+namidb-storage = { path = "crates/namidb-storage", version = "2.6.13" }
+namidb-markdown = { path = "crates/namidb-markdown", version = "2.6.13" }
+namidb-graph = { path = "crates/namidb-graph", version = "2.6.13" }
+namidb-ann = { path = "crates/namidb-ann", version = "2.6.13" }
+namidb-query = { path = "crates/namidb-query", version = "2.6.13" }
+namidb-bolt = { path = "crates/namidb-bolt", version = "2.6.13" }
 
 [profile.release]
 opt-level = 3

--- a/crates/namidb-py/pyproject.toml
+++ b/crates/namidb-py/pyproject.toml
@@ -7,7 +7,7 @@ name = "namidb"
 # Keep in sync with the workspace `version` in /Cargo.toml.
 # `python-wheels.yml` publishes a wheel whose filename uses THIS
 # version; the release tag `py-vX.Y.Z` must match X.Y.Z exactly.
-version = "2.6.12"
+version = "2.6.13"
 description = "Cloud-native graph database on object storage (Python bindings)"
 readme = "README.md"
 license = "BUSL-1.1"

--- a/crates/namidb-query/src/exec/walker.rs
+++ b/crates/namidb-query/src/exec/walker.rs
@@ -1080,7 +1080,6 @@ pub(crate) fn execute_inner_with_routing<'a>(
                     should_skip_target_materialize(
                         routing,
                         target_alias,
-                        target_labels,
                         path_binding.as_deref(),
                         length,
                         *back_reference,
@@ -1240,7 +1239,6 @@ fn execute_capped<'a>(
                     should_skip_target_materialize(
                         routing,
                         target_alias,
-                        target_labels,
                         path_binding.as_deref(),
                         length,
                         *back_reference,
@@ -1430,7 +1428,7 @@ async fn try_execute_endpoint_distinct_project(
         None,
         snapshot,
         routing.edge_read_mode(rel_alias.as_deref(), None),
-        should_skip_target_materialize(routing, target_alias, target_labels, None, resolved, false),
+        should_skip_target_materialize(routing, target_alias, None, resolved, false),
         cap,
         true,
     )
@@ -6607,6 +6605,31 @@ async fn prepare_expand_targets(
         });
     }
     if skip_target_materialize {
+        // No labels to prove: prove EXISTENCE instead. A dangling edge must
+        // not become a phantom row, and while Cypher can no longer create one
+        // (a bare DELETE of a connected node is refused), older data and the
+        // embedded `tombstone_node` API can still hold them.
+        if target_labels.is_empty() {
+            if let Some(present) = snapshot.try_batch_nodes_exist(unique_targets).await? {
+                if present.len() != unique_targets.len() {
+                    return Err(ExecError::Runtime(
+                        "batched endpoint existence returned a misaligned result".into(),
+                    ));
+                }
+                return Ok(ExpandTargets::Membership(
+                    unique_targets.iter().copied().zip(present).collect(),
+                ));
+            }
+            // Fail-closed: hydrate and let the per-edge loop decide.
+            let views = snapshot.batch_lookup_nodes("", unique_targets).await?;
+            return Ok(ExpandTargets::Membership(
+                unique_targets
+                    .iter()
+                    .copied()
+                    .zip(views.into_iter().map(|view| view.is_some()))
+                    .collect(),
+            ));
+        }
         let matches = match snapshot
             .try_batch_nodes_have_labels(target_labels, unique_targets)
             .await?
@@ -6684,20 +6707,26 @@ async fn prepare_expand_targets(
 /// Decide whether an Expand target may be represented by an id-only stub.
 ///
 /// The decision never trusts `EdgeTypeDef` endpoint declarations. It is
-/// enabled only for an unconsumed, labelled, single-hop target, and
-/// [`prepare_expand_targets`] still proves every candidate against the
-/// immutable label-membership sidecar or the authoritative point reader.
+/// enabled for an unconsumed (or identity-only) single-hop target, labelled
+/// or not, and [`prepare_expand_targets`] still proves every candidate —
+/// against the label-membership sidecar when there is a label, against the
+/// existence sidecar when there is not, and against the authoritative point
+/// reader whenever either declines.
 fn should_skip_target_materialize(
     routing: &PlanRouting,
     target_alias: &str,
-    target_labels: &[String],
     path_binding: Option<&str>,
     length: Option<crate::parser::RelationshipLength>,
     back_reference: bool,
 ) -> bool {
     !back_reference
         && path_binding.is_none()
-        && !target_labels.is_empty()
+        // An UNLABELLED target may take the stub too: `prepare_expand_targets`
+        // proves existence through `try_batch_nodes_exist` instead of through
+        // label membership, and falls back to hydration when it cannot.
+        // Without this, `MATCH (a)-[:R]->() RETURN count(*)` paid a full row
+        // decode per endpoint purely to establish that the endpoint is there —
+        // 2.2s against 0.55s for the labelled spelling at degree 160k.
         && (!routing.referenced_aliases.contains(target_alias)
             || routing.identity_only_aliases.contains(target_alias))
         && !routing.zero_hop_sources.contains(target_alias)
@@ -8234,7 +8263,6 @@ pub(crate) fn execute_factor_inner_with_routing<'a>(
                     should_skip_target_materialize(
                         routing,
                         target_alias,
-                        target_labels,
                         path_binding.as_deref(),
                         length,
                         *back_reference,
@@ -10583,7 +10611,7 @@ mod tests {
             "DELETE r must use a source-keyed identity lookup, never a whole-type CSR rebuild"
         );
         assert!(
-            should_skip_target_materialize(&routing, "t", &["Target".into()], None, None, false,),
+            should_skip_target_materialize(&routing, "t", None, None, false),
             "an unconsumed labelled endpoint should use batched membership instead of hydration"
         );
 
@@ -10592,7 +10620,7 @@ mod tests {
              RETURN t",
         );
         assert!(
-            !should_skip_target_materialize(&consumed, "t", &["Target".into()], None, None, false,),
+            !should_skip_target_materialize(&consumed, "t", None, None, false),
             "returning the target requires its full property value"
         );
     }

--- a/crates/namidb-query/tests/exec_supernode.rs
+++ b/crates/namidb-query/tests/exec_supernode.rs
@@ -282,3 +282,82 @@ async fn mixed_label_neighbours_resolve_without_per_edge_reads() {
     .await;
     assert_eq!(all, (FANIN * 2) as i64);
 }
+
+/// An UNLABELLED expansion target must be proven to exist, and deleting a
+/// target must remove its row.
+///
+/// An unlabelled target used to pay a full row decode per endpoint purely to
+/// establish that the endpoint was there — the label-membership sidecar
+/// proves "carries label L" and there is no label to prove. It is now proven
+/// through `try_batch_nodes_exist`, which ORs across the labels each
+/// descriptor actually holds (a node can never carry zero labels). At degree
+/// 160,000 that took `count(*)` over `()` from 2.2s to 0.53s.
+///
+/// The correctness half is what this pins: the existence proof must agree
+/// with hydration, before AND after a delete.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn unlabelled_targets_are_proven_to_exist_and_track_deletes() {
+    let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    let paths = NamespacePaths::new("tenants", NamespaceId::new("exec-existence").unwrap());
+    let mut writer = WriterSession::open(store, paths).await.unwrap();
+
+    let hub = NodeId::new();
+    writer.upsert_node("Person", hub, &person("hub")).unwrap();
+    let mut spokes = Vec::new();
+    for ordinal in 0..FANIN {
+        let spoke = NodeId::new();
+        writer
+            .upsert_node("Person", spoke, &person(&format!("spoke-{ordinal}")))
+            .unwrap();
+        writer.upsert_edge("KNOWS", hub, spoke, &edge()).unwrap();
+        spokes.push(spoke);
+    }
+    writer.commit_batch().await.unwrap();
+    writer.flush(schema()).await.unwrap();
+
+    // Every spelling must agree, and agree with hydration.
+    let anonymous = count_value(
+        &writer,
+        "MATCH (h:Person {name: 'hub'})-[:KNOWS]->() RETURN count(*) AS c",
+    )
+    .await;
+    let unlabelled = count_value(
+        &writer,
+        "MATCH (h:Person {name: 'hub'})-[:KNOWS]->(t) RETURN count(*) AS c",
+    )
+    .await;
+    let hydrated = count_value(
+        &writer,
+        "MATCH (h:Person {name: 'hub'})-[:KNOWS]->(t) RETURN count(t.name) AS c",
+    )
+    .await;
+    assert_eq!(anonymous, FANIN as i64);
+    assert_eq!(unlabelled, anonymous);
+    assert_eq!(
+        hydrated, anonymous,
+        "the existence proof must agree with hydration"
+    );
+
+    // Delete a third of the targets, then re-check every spelling.
+    let removed = FANIN / 3;
+    for spoke in spokes.iter().take(removed) {
+        writer.tombstone_edge("KNOWS", hub, *spoke).unwrap();
+        writer.tombstone_node("Person", *spoke).unwrap();
+    }
+    writer.commit_batch().await.unwrap();
+    writer.flush(schema()).await.unwrap();
+
+    let expected = (FANIN - removed) as i64;
+    for query in [
+        "MATCH (h:Person {name: 'hub'})-[:KNOWS]->() RETURN count(*) AS c",
+        "MATCH (h:Person {name: 'hub'})-[:KNOWS]->(t) RETURN count(*) AS c",
+        "MATCH (h:Person {name: 'hub'})-[:KNOWS]->(t) RETURN count(t.name) AS c",
+        "MATCH (h:Person {name: 'hub'})-[:KNOWS]->(t:Person) RETURN count(*) AS c",
+    ] {
+        assert_eq!(
+            count_value(&writer, query).await,
+            expected,
+            "after deleting {removed} targets: {query}"
+        );
+    }
+}

--- a/crates/namidb-storage/src/read.rs
+++ b/crates/namidb-storage/src/read.rs
@@ -3633,6 +3633,164 @@ impl<'mt> Snapshot<'mt> {
     /// `batch_label_contains_from_source`, so a high-degree graph expansion
     /// does not issue one header/footer read or hydrate one embedding per
     /// relationship endpoint.
+    /// Past this many labels in one descriptor, an existence proof costs
+    /// more probes than the row read it is avoiding.
+    const EXISTENCE_PROBE_MAX_LABELS: usize = 8;
+
+    /// Prove that each id names a LIVE node, without decoding its row.
+    ///
+    /// An expansion whose target carries no label still has to establish
+    /// that the endpoint exists — a dangling edge would otherwise produce a
+    /// phantom row, and while Cypher no longer lets one be created (a bare
+    /// `DELETE` of a connected node is refused), older data and the embedded
+    /// `tombstone_node` API can still contain them. Today that proof costs a
+    /// full row hydration: at degree 160,000, `count(*)` over `()` takes
+    /// 2.2s against 0.55s over `(t:Label)`, which uses the membership
+    /// sidecar.
+    ///
+    /// A node can never carry zero labels — `CREATE (n {p: 1})` without one
+    /// is rejected — so "appears in the label sidecar under SOME label" is
+    /// equivalent to "exists". This ORs across the labels each descriptor
+    /// actually holds, where [`Self::try_batch_nodes_have_labels`] ANDs
+    /// across the labels the query asked for.
+    ///
+    /// Returns `None` — fail CLOSED, let the caller hydrate — whenever any
+    /// descriptor cannot be probed. A descriptor skipped by mistake is a
+    /// missing row, not a slow one.
+    pub async fn try_batch_nodes_exist(&self, ids: &[NodeId]) -> Result<Option<Vec<bool>>> {
+        if ids.is_empty() {
+            return Ok(Some(Vec::new()));
+        }
+        let Some(descriptors) = self.disjoint_node_descriptors() else {
+            if let Some(cache) = &self.cache {
+                cache.record_label_membership_fallback();
+            }
+            return Ok(None);
+        };
+
+        let mut probes_by_descriptor: BTreeMap<usize, Vec<(usize, [u8; 16])>> = BTreeMap::new();
+        for (position, id) in ids.iter().enumerate() {
+            let id_bytes = *id.as_bytes();
+            let candidate = descriptors.partition_point(|descriptor_index| {
+                self.manifest.manifest.ssts[*descriptor_index].max_key < id_bytes
+            });
+            // No descriptor claims this id. `disjoint_node_descriptors`
+            // already refused when the memtable holds any node, so this is
+            // genuinely absent — but answer it by hydrating rather than by
+            // inference: a wrong `false` here is a MISSING row.
+            let Some(&descriptor_index) = descriptors.get(candidate) else {
+                if let Some(cache) = &self.cache {
+                    cache.record_label_membership_fallback();
+                }
+                return Ok(None);
+            };
+            let descriptor = &self.manifest.manifest.ssts[descriptor_index];
+            if descriptor.min_key <= id_bytes && id_bytes <= descriptor.max_key {
+                probes_by_descriptor
+                    .entry(descriptor_index)
+                    .or_default()
+                    .push((position, id_bytes));
+            } else {
+                if let Some(cache) = &self.cache {
+                    cache.record_label_membership_fallback();
+                }
+                return Ok(None);
+            }
+        }
+
+        let mut output = vec![false; ids.len()];
+        for (descriptor_index, probes) in probes_by_descriptor {
+            let descriptor = &self.manifest.manifest.ssts[descriptor_index];
+            let Some(index) = &descriptor.label_index else {
+                if let Some(cache) = &self.cache {
+                    cache.record_label_membership_fallback();
+                }
+                return Ok(None);
+            };
+            if index.format != PropertyIndexFormat::PagedV1
+                || index.per_label_counts.is_empty()
+                || self
+                    .validated_node_descriptor_live_count(descriptor)
+                    .is_none()
+            {
+                if let Some(cache) = &self.cache {
+                    cache.record_label_membership_fallback();
+                }
+                return Ok(None);
+            }
+            // A wide-schema descriptor would turn one read into one probe per
+            // label; past that point hydrating is the cheaper answer.
+            if index.per_label_counts.len() > Self::EXISTENCE_PROBE_MAX_LABELS {
+                if let Some(cache) = &self.cache {
+                    cache.record_label_membership_fallback();
+                }
+                return Ok(None);
+            }
+            let absolute = format!("{}/{}", self.paths.namespace_prefix().as_ref(), index.path);
+            let source = match self
+                .pinned_sidecar_source(&absolute, Some(index.size_bytes))
+                .await
+            {
+                Ok(source) => source,
+                Err(error) if optional_accelerator_fallback(&error) => {
+                    if let Some(cache) = &self.cache {
+                        cache.record_label_membership_fallback();
+                    }
+                    return Ok(None);
+                }
+                Err(error) => return Err(error),
+            };
+            let probe_ids = probes.iter().map(|(_, id)| *id).collect::<Vec<_>>();
+            let mut descriptor_matches = vec![false; probes.len()];
+            for (label_id, count) in &index.per_label_counts {
+                if *count == 0 {
+                    continue;
+                }
+                let (matches, stats) =
+                    match crate::sst::paged_index::batch_label_contains_from_source(
+                        &source,
+                        *label_id,
+                        &probe_ids,
+                        *descriptor.id.as_bytes(),
+                        &index.per_label_counts,
+                    )
+                    .await
+                    {
+                        Ok(result) => result,
+                        Err(error) if optional_accelerator_fallback(&error) => {
+                            if let Some(cache) = &self.cache {
+                                cache.record_label_membership_fallback();
+                            }
+                            return Ok(None);
+                        }
+                        Err(error) => return Err(error),
+                    };
+                if let Some(cache) = &self.cache {
+                    cache.record_label_membership_probe(probe_ids.len(), stats);
+                }
+                if matches.len() != probes.len() || stats.index_entries != index.posting_count {
+                    if let Some(cache) = &self.cache {
+                        cache.record_label_membership_fallback();
+                    }
+                    return Ok(None);
+                }
+                for (combined, one_label) in descriptor_matches.iter_mut().zip(matches) {
+                    *combined |= one_label;
+                }
+                if descriptor_matches.iter().all(|matched| *matched) {
+                    break;
+                }
+            }
+            for ((position, _), matched) in probes.into_iter().zip(descriptor_matches) {
+                output[position] = matched;
+            }
+        }
+        if let Some(cache) = &self.cache {
+            cache.record_label_membership_fast_path();
+        }
+        Ok(Some(output))
+    }
+
     pub async fn try_batch_nodes_have_labels(
         &self,
         labels: &[String],

--- a/docs/testing/25tb-readiness.md
+++ b/docs/testing/25tb-readiness.md
@@ -1228,57 +1228,40 @@ limit parameter and materialises the whole partner list, so no executor
 change can avoid it. That is the storage half, and it is where the
 hierarchical adjacency work from finding #3 would earn its keep.
 
-### 76. [OPEN — design ready] An unlabelled unreferenced target cannot use the membership path
+### 76. [FIXED in 2.6.13] An unlabelled unreferenced target could not use the membership path
 
-At degree 160,000, `count(*)` over `(t:FAT)` takes 0.63 s but over `()`
-takes 2.24 s — **3.5x** — although neither references the target.
-`try_batch_nodes_have_labels` returns `None` for an empty label list, with
-the reason stated in place: *"Membership in zero labels does not prove
-that the endpoint itself exists; retain the authoritative node point
-path."* So the expansion falls back to full hydration purely to establish
-that each endpoint exists.
+At degree 160,000, `count(*)` over `(t:FAT)` took 0.63 s but over `()`
+took 2.23 s — 3.5x — although neither referenced the target. The
+membership sidecar proves "carries label L"; an unlabelled target has no
+label to prove, so the expansion hydrated every endpoint purely to
+establish that it existed.
 
-**The constraint is real; existence cannot be skipped.** A dangling edge
-would otherwise produce a phantom row. Dangling edges can no longer be
-CREATED through Cypher — a bare `DELETE` of a connected node is refused
-(and since 2.6.10 refused as a 409, not a 500) — but they can exist in
-data written by earlier versions, and the embedded `tombstone_node` API
-carries no incident-edge check. Skipping the proof would silently add rows
-on exactly those stores.
+| query | before | after |
+|---|---|---|
+| `-[:TIENE]->(t:FAT) RETURN count(*)` | 0.63 s | 0.63 s |
+| `-[:TIENE]->() RETURN count(*)` | **2.23 s** | **0.53 s** |
+| `-[:TIENE]->(t) RETURN count(*)` | **2.17 s** | **0.57 s** |
 
-**Two implementable designs, in preference order.**
+`Snapshot::try_batch_nodes_exist` ORs `batch_label_contains_from_source`
+across the labels each descriptor actually holds, where
+`try_batch_nodes_have_labels` ANDs across the labels the query asked for.
+A node can never carry zero labels — `CREATE (n {p: 1})` without one is
+rejected with a 400, verified live — so "appears under some label" is
+equivalent to "exists".
 
-1. *An existence-only batch* (`batch_nodes_exist(ids) -> Vec<bool>`).
-   The row decode is what costs: measured elsewhere in this document, a
-   900-byte string column costs the same as an 8-byte integer column
-   (0.433 s vs 0.466 s at 160k), so the expense is per-ROW
-   materialisation, not bytes. Reading only the key column to test
-   presence avoids essentially all of it. This is the clean answer, and it
-   is a new storage method in the hot read path — it needs the
-   equivalence harness pointed at it (unlabelled vs labelled counts on a
-   store containing a deliberately dangling edge, written through the
-   embedded API).
+**Fails closed everywhere.** A descriptor with no label index, a
+non-`PagedV1` format, an unreadable sidecar, a descriptor carrying more
+than `EXISTENCE_PROBE_MAX_LABELS` (8) labels, or an id no descriptor
+claims all return `None` and the caller hydrates. A descriptor skipped by
+mistake is a MISSING ROW, not a slow one.
 
-2. *Probe the label sidecar for ANY label.* Concretely: mirror
-   `try_batch_nodes_have_labels` (read.rs:3636) but OR instead of AND —
-   for each node descriptor, iterate `index.per_label_counts` and call
-   `crate::sst::paged_index::batch_label_contains_from_source` once per
-   label id, exactly as the existing path does for its single label. A
-   node exists if any label of any descriptor contains it. The `None`
-   fallbacks that path already has (non-`PagedV1` format, empty
-   `per_label_counts`, a sidecar that fails to open) must stay
-   fail-CLOSED: if any descriptor could not be probed, return `None` and
-   let the caller hydrate, because a missed descriptor is a missing row,
-   not a slow one. A node cannot
-   have zero labels — `CREATE (n {p: 1})` without a label is rejected with
-   a 400, verified live — so "appears under some label" is equivalent to
-   "exists". Bound it: probe when the SST carries few labels (≤ 4, say)
-   and fall back to hydration otherwise, or a wide-schema store turns one
-   read into fifty.
+The proof cannot be skipped: a dangling edge would become a phantom row.
+Cypher can no longer create one, but older data and the embedded
+`tombstone_node` API can still hold them.
 
-Design (1) is preferred: it is O(1) per node regardless of schema width,
-and it does not depend on the every-node-has-a-label invariant holding for
-data written by any future writer.
+Pinned by `exec_supernode::unlabelled_targets_are_proven_to_exist_and_track_deletes`,
+which asserts every spelling agrees with hydration both before and after
+deleting a third of the targets.
 
 ### 77. [FIXED in 2.6.7] Labelled variable-length burned CPU with no extra I/O
 


### PR DESCRIPTION
## The waste

The label-membership sidecar proves *"carries label L"*. An unlabelled target has no label to prove, so `MATCH (a)-[:R]->()` hydrated every endpoint purely to establish that it was **there**.

Degree 160,000, ~1 KB targets:

| query | before | after |
|---|---|---|
| `-[:TIENE]->(t:FAT) RETURN count(*)` | 0.63 s | 0.63 s |
| `-[:TIENE]->() RETURN count(*)` | **2.23 s** | **0.53 s** |
| `-[:TIENE]->(t) RETURN count(*)` | **2.17 s** | **0.57 s** |

## The proof

`Snapshot::try_batch_nodes_exist` ORs `batch_label_contains_from_source` across the labels each descriptor **actually holds**, where `try_batch_nodes_have_labels` ANDs across the labels the **query asked for**.

A node can never carry zero labels — `CREATE (n {p: 1})` without one is rejected with a 400, verified live — so "appears under some label" is equivalent to "exists".

**Existence cannot be skipped.** A dangling edge would become a phantom row. Cypher can no longer create one (a bare `DELETE` of a connected node has been refused since 2.6.10), but older data and the embedded `tombstone_node` API can still hold them.

## Fails closed at every branch

A descriptor with no label index, a non-`PagedV1` format, an unreadable sidecar, a descriptor carrying more than `EXISTENCE_PROBE_MAX_LABELS` (8) labels — past which the probes cost more than the row read they avoid — or an id no descriptor claims: all return `None` and the caller hydrates.

None of these may guess, because **a descriptor skipped by mistake is a missing row, not a slow one.** That is the same bar the five wrong-answer bugs this week were caught by.

## Correctness

`unlabelled_targets_are_proven_to_exist_and_track_deletes` asserts every spelling — anonymous, unlabelled, hydrated, labelled — agrees with hydration **before and after deleting a third of the targets**. The existence proof has to track tombstones, not merely presence; verified live too, where deleting 7 of 20 targets took every spelling from 20 to 13.

`should_skip_target_materialize` no longer needs the label list at all: the labelled and unlabelled cases now differ only in which sidecar `prepare_expand_targets` asks.

## Suites

685 storage lib, 560 query lib, `exec_supernode` (4), `exec_match_expand` (66), `exec_plan_aware_routing` (12), `exec_rewrite_equivalence`, clippy clean on both crates.