### PR TITLE
perf: serve numeric equality from the posting index; fix the admin drain's lost-race 500

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,12 @@ crates.io release will establish and document that API explicitly.
   it reaches a result, so the collision costs a wasted candidate and never a
   wrong row.
 
+  The key is also order-preserving, so the range-readable sidecar it lives
+  in can later be positioned by value for `WHERE n.amount > x`. Raw IEEE-754
+  bits sort negatives backwards, which an equality probe never notices —
+  and which would have foreclosed every ordered read over those postings
+  once the format was in the wild.
+
 ### Fixed
 
 - **`POST /v0/admin/compact` returned 500 right after a `CREATE INDEX`** —

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,45 @@ crates.io release will establish and document that API explicitly.
 
 ## [Unreleased]
 
+## [2.6.14] - 2026-09-11
+
+### Performance
+
+- **`CREATE INDEX` on a numeric property now accelerates equality.** It was
+  accepted and did nothing: `MATCH (t {num: 12345})` scanned the whole label
+  while the identical `MATCH (t {txt: '12345'})` served from the posting
+  index. On 160,000 rows carrying the same key both ways, with an index
+  declared on both, that was 1.603 s against 0.001 s — **1600x, purely
+  because the property was numeric**. EXPLAIN said so in plain text:
+  *"numeric equality is not posting-indexed; only String/Bool are"*. For a
+  retail or clinical schema — quantities, prices, amounts, numeric product
+  codes, foreign keys — that is most of the schema.
+
+  Numeric equality is now served by the same sidecars a string key uses.
+  Measured in-process against the route it used to take, on 160k rows:
+  525 ms scan against 80 us index.
+
+  `5` and `5.0` are one Cypher value, so both encode to one canonical key
+  and share a posting. Above 2^53 that key is lossy and distinct integers
+  can collide; every candidate is re-confirmed with Cypher equality before
+  it reaches a result, so the collision costs a wasted candidate and never a
+  wrong row.
+
+### Compatibility
+
+- Numeric coverage is recorded per sidecar in a new optional manifest field.
+  Existing SSTs report no numeric coverage and keep the scan route until a
+  compaction pass backfills their postings, which the DDL-backfill trigger
+  now schedules; EXPLAIN reports the interim state as
+  `numeric postings {covered}/{total} SSTs`. A rolled-back reader ignores
+  the field and probes the widened sidecar exactly as completely as before.
+- A property declared numeric on one label and textual on another keeps the
+  scan route for numeric equality, so ordered string reads over the same
+  sidecar stay correct.
+- Numeric equality inside a write transaction also keeps the scan route: the
+  transactional overlay distinguishes `5` from `5.0`, and a scan there sees
+  the same uncommitted writes.
+
 ## [2.6.13] - 2026-09-10
 
 ### Performance
@@ -3408,7 +3447,8 @@ Change License: Apache License 2.0).
 - LDBC-shaped synthetic benchmark harness with a paired Kùzu runner
   under [`bench/`](./bench/).
 
-[Unreleased]: https://github.com/namidb/namidb/compare/v2.6.13...HEAD
+[Unreleased]: https://github.com/namidb/namidb/compare/v2.6.14...HEAD
+[2.6.14]: https://github.com/namidb/namidb/compare/v2.6.13...v2.6.14
 [2.6.13]: https://github.com/namidb/namidb/compare/v2.6.12...v2.6.13
 [2.6.12]: https://github.com/namidb/namidb/compare/v2.6.11...v2.6.12
 [2.6.11]: https://github.com/namidb/namidb/compare/v2.6.10...v2.6.11

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,26 @@ crates.io release will establish and document that API explicitly.
   it reaches a result, so the collision costs a wasted candidate and never a
   wrong row.
 
+### Fixed
+
+- **`POST /v0/admin/compact` returned 500 right after a `CREATE INDEX`** —
+  which is exactly when an operator reaches for it, to materialize the index
+  the DDL just declared.
+
+  `CREATE INDEX` schedules its own backfill pass. The admin drain runs its
+  passes outside the scheduler's admission, so the two ran concurrently, the
+  DDL pass won the manifest install, and the drain's prepared plan named an
+  input the winner had already merged away. Storage abandons such a plan
+  with a precondition the compactor already labels "a competing compaction
+  won the install race" — the drain reported it as a hard error whenever it
+  happened on the first pass.
+
+  Losing that race is not a failure: the merge was performed by whoever won.
+  The drain now re-prepares against the manifest they left, bounded, and
+  reports `races_lost` in its summary. The abandon messages also name the
+  basis and manifest versions now, and distinguish a lost race from an input
+  that changed and from a duplicated id.
+
 ### Compatibility
 
 - Numeric coverage is recorded per sidecar in a new optional manifest field.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2199,7 +2199,7 @@ dependencies = [
 
 [[package]]
 name = "namidb"
-version = "2.6.13"
+version = "2.6.14"
 dependencies = [
  "namidb-core",
  "namidb-graph",
@@ -2209,7 +2209,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-ann"
-version = "2.6.13"
+version = "2.6.14"
 dependencies = [
  "namidb-core",
  "rand 0.8.6",
@@ -2222,7 +2222,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-bench"
-version = "2.6.13"
+version = "2.6.14"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2246,7 +2246,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-bolt"
-version = "2.6.13"
+version = "2.6.14"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2266,7 +2266,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-cli"
-version = "2.6.13"
+version = "2.6.14"
 dependencies = [
  "anyhow",
  "clap",
@@ -2286,7 +2286,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-core"
-version = "2.6.13"
+version = "2.6.14"
 dependencies = [
  "arrow-array",
  "arrow-schema",
@@ -2302,7 +2302,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-graph"
-version = "2.6.13"
+version = "2.6.14"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -2324,7 +2324,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-markdown"
-version = "2.6.13"
+version = "2.6.14"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2347,7 +2347,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-mcp"
-version = "2.6.13"
+version = "2.6.14"
 dependencies = [
  "anyhow",
  "clap",
@@ -2367,7 +2367,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-py"
-version = "2.6.13"
+version = "2.6.14"
 dependencies = [
  "bytes",
  "chrono",
@@ -2385,7 +2385,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-query"
-version = "2.6.13"
+version = "2.6.14"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2409,7 +2409,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-server"
-version = "2.6.13"
+version = "2.6.14"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2449,7 +2449,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-storage"
-version = "2.6.13"
+version = "2.6.14"
 dependencies = [
  "anyhow",
  "arrow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2.6.13"
+version = "2.6.14"
 edition = "2021"
 rust-version = "1.85"
 license = "BUSL-1.1"
@@ -123,13 +123,13 @@ tower = { version = "0.5", features = ["limit"] }
 tower-http = { version = "0.6", features = ["trace", "cors", "timeout"] }
 
 # Local workspace crates
-namidb-core = { path = "crates/namidb-core", version = "2.6.13" }
-namidb-storage = { path = "crates/namidb-storage", version = "2.6.13" }
-namidb-markdown = { path = "crates/namidb-markdown", version = "2.6.13" }
-namidb-graph = { path = "crates/namidb-graph", version = "2.6.13" }
-namidb-ann = { path = "crates/namidb-ann", version = "2.6.13" }
-namidb-query = { path = "crates/namidb-query", version = "2.6.13" }
-namidb-bolt = { path = "crates/namidb-bolt", version = "2.6.13" }
+namidb-core = { path = "crates/namidb-core", version = "2.6.14" }
+namidb-storage = { path = "crates/namidb-storage", version = "2.6.14" }
+namidb-markdown = { path = "crates/namidb-markdown", version = "2.6.14" }
+namidb-graph = { path = "crates/namidb-graph", version = "2.6.14" }
+namidb-ann = { path = "crates/namidb-ann", version = "2.6.14" }
+namidb-query = { path = "crates/namidb-query", version = "2.6.14" }
+namidb-bolt = { path = "crates/namidb-bolt", version = "2.6.14" }
 
 [profile.release]
 opt-level = 3

--- a/crates/namidb-py/pyproject.toml
+++ b/crates/namidb-py/pyproject.toml
@@ -7,7 +7,7 @@ name = "namidb"
 # Keep in sync with the workspace `version` in /Cargo.toml.
 # `python-wheels.yml` publishes a wheel whose filename uses THIS
 # version; the release tag `py-vX.Y.Z` must match X.Y.Z exactly.
-version = "2.6.13"
+version = "2.6.14"
 description = "Cloud-native graph database on object storage (Python bindings)"
 readme = "README.md"
 license = "BUSL-1.1"

--- a/crates/namidb-query/src/exec/walker.rs
+++ b/crates/namidb-query/src/exec/walker.rs
@@ -7624,11 +7624,12 @@ pub(crate) async fn lookup_node_by_property_via_scan(
             .map_err(ExecError::from);
     }
 
-    // Scalar-v1 equality sidecars also cover the non-numeric scalar types.
-    // Numeric probes stay on the exact fallback for now because Cypher treats
-    // I64(1) and F64(1.0) as equal while the physical index deliberately keeps
-    // them distinct.
-    if let Some(core) = non_numeric_index_value(value) {
+    // Scalar-v1 equality sidecars cover the other scalar types, numerics
+    // included: `I64(1)` and `F64(1.0)` are one Cypher value and encode to
+    // one canonical key, and storage declines the route wherever it cannot
+    // honour that (a sidecar predating numeric harvesting, or the
+    // transactional overlay, which keys them apart).
+    if let Some(core) = indexable_probe_value(value) {
         if let Some(ids) = snapshot
             .indexed_node_ids_by_property_value(label, property, &core)
             .await
@@ -7700,7 +7701,7 @@ pub(crate) async fn lookup_nodes_by_property_via_scan(
             .await
             .map_err(ExecError::from);
     }
-    if let Some(core) = non_numeric_index_value(value) {
+    if let Some(core) = indexable_probe_value(value) {
         if let Some(ids) = snapshot
             .indexed_node_ids_by_property_value(label, property, &core)
             .await
@@ -7757,7 +7758,7 @@ async fn lookup_nodes_by_property_via_scan_limited(
     }
     let core = match value {
         RuntimeValue::String(value) => Some(namidb_core::Value::Str(value.clone())),
-        other => non_numeric_index_value(other),
+        other => indexable_probe_value(other),
     };
     if let Some(core) = core {
         if let Some(ids) = snapshot
@@ -7870,8 +7871,9 @@ pub(crate) async fn lookup_nodes_by_property_tuple_via_scan(
 }
 
 /// Scalar runtime value -> storable core value for a tuple member probe.
-/// Unlike [`non_numeric_index_value`], numerics ARE included — TupleV1
-/// canonicalizes them to match Cypher's coercing equality.
+/// Unlike [`indexable_probe_value`], a String is included: a tuple key is
+/// self-delimiting, so a String member cannot alias a tagged one, and the
+/// single-property path has a dedicated String entry point already.
 fn tuple_member_core_value(value: &RuntimeValue) -> Option<namidb_core::Value> {
     match value {
         RuntimeValue::Bool(value) => Some(namidb_core::Value::Bool(*value)),
@@ -7885,9 +7887,21 @@ fn tuple_member_core_value(value: &RuntimeValue) -> Option<namidb_core::Value> {
     }
 }
 
-fn non_numeric_index_value(value: &RuntimeValue) -> Option<namidb_core::Value> {
+/// The non-String probe values storage can answer from an equality posting
+/// index. Anything returning `None` here is left to the label scan.
+///
+/// Numbers belong here: a numeric-declared property files one canonical key
+/// per numeric value, so `{amount: 12345}` is served by the same posting
+/// lookup a String key gets instead of scanning the label. A sidecar that
+/// predates numeric harvesting reports its own incompleteness
+/// (`numeric_complete`) and storage falls back to the scan on its own.
+fn indexable_probe_value(value: &RuntimeValue) -> Option<namidb_core::Value> {
     match value {
         RuntimeValue::Bool(value) => Some(namidb_core::Value::Bool(*value)),
+        RuntimeValue::Integer(value) => Some(namidb_core::Value::I64(*value)),
+        // NaN equals nothing in Cypher, and has no canonical key. Leave it to
+        // the scan rather than encode it into a posting it cannot match.
+        RuntimeValue::Float(value) if !value.is_nan() => Some(namidb_core::Value::F64(*value)),
         RuntimeValue::Date(value) => Some(namidb_core::Value::Date(*value)),
         RuntimeValue::DateTime(value) => Some(namidb_core::Value::DateTime(*value)),
         RuntimeValue::Bytes(value) => Some(namidb_core::Value::Bytes(value.clone())),

--- a/crates/namidb-query/src/plan/explain.rs
+++ b/crates/namidb-query/src/plan/explain.rs
@@ -1062,29 +1062,35 @@ pub fn collect_route_notes(
                 &value.kind,
                 ExpressionKind::Literal(Literal::Integer(_) | Literal::Float(_))
             );
-            let note = if numeric {
+            // A numeric equality is served by the same posting sidecars, but
+            // only those that harvested numbers count toward its coverage:
+            // an SST written before numeric equality was indexable still
+            // serves String probes while leaving this one on the scan, until
+            // a compaction pass backfills it.
+            let (covered, total) = if numeric {
+                snapshot.numeric_property_index_coverage(label, property)
+            } else {
+                snapshot.property_index_coverage(label, property)
+            };
+            let note = if total == 0 {
+                format!("# route: {shown}.{property} → memtable ({kind} lookup; no SSTs in scope)")
+            } else if covered == total {
                 format!(
-                    "# route: {shown}.{property} → scan \
-                     (numeric equality is not posting-indexed; only String/Bool are)"
+                    "# route: {shown}.{property} → index \
+                     ({kind} lookup; posting sidecars {covered}/{total} SSTs)"
+                )
+            } else if numeric {
+                format!(
+                    "# route: {shown}.{property} → SCAN FALLBACK \
+                     (numeric postings {covered}/{total} SSTs; \
+                     a compaction pass materializes the rest)"
                 )
             } else {
-                let (covered, total) = snapshot.property_index_coverage(label, property);
-                if total == 0 {
-                    format!(
-                        "# route: {shown}.{property} → memtable ({kind} lookup; no SSTs in scope)"
-                    )
-                } else if covered == total {
-                    format!(
-                        "# route: {shown}.{property} → index \
-                         ({kind} lookup; posting sidecars {covered}/{total} SSTs)"
-                    )
-                } else {
-                    format!(
-                        "# route: {shown}.{property} → SCAN FALLBACK \
-                         (posting sidecars {covered}/{total} SSTs; \
-                         a compaction pass materializes the rest)"
-                    )
-                }
+                format!(
+                    "# route: {shown}.{property} → SCAN FALLBACK \
+                     (posting sidecars {covered}/{total} SSTs; \
+                     a compaction pass materializes the rest)"
+                )
             };
             out.push(note);
         }

--- a/crates/namidb-query/tests/exec_writes.rs
+++ b/crates/namidb-query/tests/exec_writes.rs
@@ -3005,8 +3005,13 @@ async fn global_correlated_match_batches_direct_set_and_delete_with_rollback() {
         .unwrap();
     assert_eq!(
         writer.property_index_cache().equality_lookup_calls() - lookups_before,
-        1,
-        "all correlated String values must share one global storage batch"
+        2,
+        "all correlated String values must share one global storage batch, \
+         plus one posting lookup for the Integer key — numerics are served by \
+         the equality index now instead of scanning the graph, but they do \
+         not yet JOIN the string batch (the batch entry points are String-\
+         typed). Distinct numeric keys therefore cost one posting probe each; \
+         see the follow-up note in docs/testing/25tb-readiness.md item 81."
     );
     assert_eq!(set_outcome.rows.len(), 6);
     assert_eq!(set_outcome.properties_set, 6);
@@ -3113,7 +3118,9 @@ async fn global_correlated_match_batches_direct_set_and_delete_with_rollback() {
         .unwrap();
     assert_eq!(
         writer.property_index_cache().equality_lookup_calls() - lookups_before,
-        1
+        2,
+        "one shared batch for the String keys, plus the Integer key's own \
+         posting lookup — same accounting as the SET phase above"
     );
     assert!(
         delete_outcome.rows.is_empty(),

--- a/crates/namidb-query/tests/numeric_equality_index.rs
+++ b/crates/namidb-query/tests/numeric_equality_index.rs
@@ -280,6 +280,17 @@ async fn assert_all_agree(writer: &WriterSession, stage: &str) {
 /// The lookup must be served by the posting index, not by an O(label) scan
 /// that happens to return the same rows.
 async fn assert_native_route(writer: &WriterSession, stage: &str) {
+    // Exact, and immune to the other test in this binary moving the
+    // process-wide counters: every in-scope SST must advertise numeric
+    // coverage, or the lookup could not have been served natively.
+    let (covered, total) = writer
+        .snapshot()
+        .numeric_property_index_coverage("T", "num");
+    assert!(
+        total > 0 && covered == total,
+        "[{stage}] every in-scope SST must carry numeric postings, got {covered}/{total}"
+    );
+
     let before = route_telemetry::snapshot();
     let five = run(writer, "MATCH (t:T {num: 5}) RETURN t.txt AS txt").await;
     let after = route_telemetry::snapshot();
@@ -388,4 +399,69 @@ async fn numeric_equality_matches_the_scan_and_uses_the_index() {
     writer.compact_l0(&committed).await.unwrap();
     assert_all_agree(&writer, "compacted").await;
     assert_native_route(&writer, "compacted").await;
+}
+
+/// The MIGRATION path: rows already flushed before the index was declared.
+///
+/// The documented promise is that a compaction pass backfills their numeric
+/// postings. Until it runs, the sidecar must report its own incompleteness
+/// and the lookup must keep the scan — correct, just slow. This is a
+/// different order from the main test, where the index predates the flush,
+/// and it is the order a real deployment hits.
+#[tokio::test]
+async fn a_compaction_pass_backfills_numeric_postings_onto_existing_ssts() {
+    let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    let paths = NamespacePaths::new("tenants", NamespaceId::new("numeric-eq-backfill").unwrap());
+    let mut writer = WriterSession::open(store, paths).await.unwrap();
+    for ordinal in 0..400_i64 {
+        writer
+            .upsert_node(
+                "T",
+                NodeId::new(),
+                &thing(ordinal, ordinal as f64 + 0.5, &ordinal.to_string()),
+            )
+            .unwrap();
+    }
+    writer.commit_batch().await.unwrap();
+
+    // Flush FIRST: these SSTs carry no numeric postings.
+    let pre_ddl = writer.snapshot().manifest().manifest.schema.clone();
+    writer.flush(pre_ddl).await.unwrap();
+
+    // Now declare the index on already-flushed data.
+    writer.create_property_index("T", "num").await.unwrap();
+    let committed = writer.snapshot().manifest().manifest.schema.clone();
+
+    // Coverage, not the route counters: those are process-wide, and the
+    // other test in this binary runs concurrently and moves them. This
+    // reads the manifest this snapshot actually sees, so it is exact.
+    let coverage = |writer: &WriterSession| {
+        let snapshot = writer.snapshot();
+        snapshot.numeric_property_index_coverage("T", "num")
+    };
+
+    let (covered, total) = coverage(&writer);
+    assert!(
+        total > 0 && covered == 0,
+        "an SST written before the index cannot serve numeric equality yet, \
+         but reported {covered}/{total}"
+    );
+    let pre = run(&writer, "MATCH (t:T {num: 5}) RETURN t.txt AS txt").await;
+    assert_eq!(
+        pre,
+        vec!["txt=5".to_string()],
+        "the scan must still be right"
+    );
+
+    // The backfill pass.
+    writer.compact_l0(&committed).await.unwrap();
+
+    let (covered, total) = coverage(&writer);
+    assert!(
+        total > 0 && covered == total,
+        "a compaction pass must materialize the numeric postings, but \
+         coverage is {covered}/{total}"
+    );
+    let post = run(&writer, "MATCH (t:T {num: 5}) RETURN t.txt AS txt").await;
+    assert_eq!(post, pre, "the backfilled route must agree with the scan");
 }

--- a/crates/namidb-query/tests/numeric_equality_index.rs
+++ b/crates/namidb-query/tests/numeric_equality_index.rs
@@ -1,0 +1,391 @@
+//! Numeric equality must be posting-indexed, and must agree with the scan.
+//!
+//! Before this suite, `{txt: '12345'}` served from the equality sidecar in
+//! ~1 ms while `{num: 12345}` over the same 160k rows scanned the label for
+//! ~1.6 s — 1600x, purely because the property was numeric. The index was
+//! declared on both, and EXPLAIN said so in as many words: "numeric equality
+//! is not posting-indexed; only String/Bool are".
+//!
+//! Two halves, and BOTH are load-bearing:
+//!
+//!   1. EQUIVALENCE. An indexed numeric equality must return exactly what an
+//!      unindexed twin returns. The scan route is already correct, so this
+//!      half passes trivially before the change; its job is to guard the
+//!      *new* index route, which is where a silent wrong answer would come
+//!      from. The cases attack the canonical key: `5` and `5.0` are one
+//!      Cypher value and must share a posting, a string `'5'` must never
+//!      match a number, and two i64 beyond 2^53 that round to the same f64
+//!      must still be separated by the confirm step.
+//!
+//!   2. NON-INERT. Equal results also happen when the "optimization" never
+//!      fires — item 74 shipped one that passed every test and changed no
+//!      timing. So the route counter must show the property lookup taking
+//!      the native path, after flush AND after compaction. Compaction
+//!      re-derives sidecars from scratch; a flush-only harvester change
+//!      would vanish at the first merge.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use namidb_core::id::{NamespaceId, NodeId};
+use namidb_core::value::Value as CoreValue;
+use namidb_storage::{route_telemetry, NamespacePaths, NodeWriteRecord, WriterSession};
+use object_store::memory::InMemory;
+use object_store::ObjectStore;
+
+use namidb_query::{
+    execute, lower, optimize, parse, LogicalPlan, Params, Row, RuntimeValue, StatsCatalog,
+};
+
+/// Two i64 that share an f64: both round to 2^53. A canonical numeric key
+/// therefore hands the confirm step a false positive, and only an exact
+/// typed comparison can drop it.
+const BIG_LOW: i64 = 9_007_199_254_740_992; // 2^53
+const BIG_HIGH: i64 = 9_007_199_254_740_993; // 2^53 + 1, not representable
+
+const ROWS: i64 = 600;
+
+fn thing(num: i64, fnum: f64, txt: &str) -> NodeWriteRecord {
+    NodeWriteRecord {
+        properties: BTreeMap::from([
+            // `num`/`fnum` get an index; `unum`/`ufnum` carry the SAME values
+            // with no index, so their spelling is always served by the scan
+            // whatever the planner does with the indexed one.
+            ("num".to_string(), CoreValue::I64(num)),
+            ("fnum".to_string(), CoreValue::F64(fnum)),
+            ("unum".to_string(), CoreValue::I64(num)),
+            ("ufnum".to_string(), CoreValue::F64(fnum)),
+            ("txt".to_string(), CoreValue::Str(txt.to_string())),
+        ]),
+        schema_version: 1,
+        ..Default::default()
+    }
+}
+
+async fn corpus(name: &str) -> WriterSession {
+    let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    let paths = NamespacePaths::new("tenants", NamespaceId::new(name).unwrap());
+    let mut writer = WriterSession::open(store, paths).await.unwrap();
+
+    for ordinal in 0..ROWS {
+        writer
+            .upsert_node(
+                "T",
+                NodeId::new(),
+                &thing(ordinal, ordinal as f64 + 0.5, &ordinal.to_string()),
+            )
+            .unwrap();
+    }
+    // Hand-picked adversarial values.
+    for (num, fnum, txt) in [
+        // An integral float beside an equal integer: `5` and `5.0` are the
+        // same Cypher value and must land in the same posting.
+        (5_i64, 5.0_f64, "five-integral"),
+        (-7, -7.0, "negative"),
+        (0, -0.0, "negative-zero"),
+        (BIG_LOW, BIG_LOW as f64, "big-low"),
+        (BIG_HIGH, BIG_HIGH as f64, "big-high"),
+    ] {
+        writer
+            .upsert_node("T", NodeId::new(), &thing(num, fnum, txt))
+            .unwrap();
+    }
+    writer.commit_batch().await.unwrap();
+
+    // Real DDL, exactly as the server routes it: the type is inferred from
+    // the first live value, so `num` is declared Int64 and `fnum` Float64.
+    writer.create_property_index("T", "num").await.unwrap();
+    writer.create_property_index("T", "fnum").await.unwrap();
+    writer
+}
+
+fn render(v: &RuntimeValue) -> String {
+    match v {
+        RuntimeValue::Null => "null".into(),
+        RuntimeValue::String(s) => s.clone(),
+        RuntimeValue::Integer(n) => n.to_string(),
+        RuntimeValue::Float(f) => format!("{f:?}"),
+        RuntimeValue::Bool(b) => b.to_string(),
+        other => format!("{other:?}"),
+    }
+}
+
+/// Rows as an order-insensitive multiset, so the two spellings may legally
+/// differ in row order.
+fn multiset(rows: &[Row]) -> Vec<String> {
+    let mut out: Vec<String> = rows
+        .iter()
+        .map(|r| {
+            r.bindings
+                .iter()
+                .map(|(k, v)| format!("{k}={}", render(v)))
+                .collect::<Vec<_>>()
+                .join(",")
+        })
+        .collect();
+    out.sort();
+    out
+}
+
+async fn run(writer: &WriterSession, query: &str) -> Vec<String> {
+    let snapshot = writer.snapshot();
+    run_on(&snapshot, query).await
+}
+
+/// The same query against the TRANSACTIONAL overlay a write statement reads
+/// through. Its candidate map keys off `unique_index::key_part`, which keeps
+/// `I64(5)` and `F64(5.0)` in distinct variants — so an index route taken
+/// there would answer `{num: 5.0}` with an authoritative empty result while
+/// the scan returns the `I64(5)` rows. Storage declines the index in this
+/// scope for exactly that reason, and this stage is what proves it.
+async fn run_staged(writer: &WriterSession, query: &str) -> Vec<String> {
+    let snapshot = writer.transactional_overlay_snapshot();
+    run_on(&snapshot, query).await
+}
+
+async fn run_on(snapshot: &namidb_storage::Snapshot<'_>, query: &str) -> Vec<String> {
+    let catalog = StatsCatalog::from_manifest(&snapshot.manifest().manifest);
+    let parsed = parse(query).unwrap_or_else(|e| panic!("parse `{query}`: {e:?}"));
+    let plan = optimize(
+        lower(&parsed).unwrap_or_else(|e| panic!("lower `{query}`: {e:?}")),
+        &catalog,
+    );
+    let rows = execute(&plan, snapshot, &Params::new())
+        .await
+        .unwrap_or_else(|e| panic!("execute `{query}`: {e:?}"));
+    multiset(&rows)
+}
+
+/// `(name, indexed spelling, unindexed twin)`.
+fn cases() -> Vec<(String, String, String)> {
+    let mut out: Vec<(String, String, String)> = Vec::new();
+    let mut pair = |name: &str, indexed: String, unindexed: String| {
+        out.push((name.to_string(), indexed, unindexed));
+    };
+
+    pair(
+        "int literal",
+        "MATCH (t:T {num: 5}) RETURN t.txt AS txt".into(),
+        "MATCH (t:T) WHERE t.unum = 5 RETURN t.txt AS txt".into(),
+    );
+    pair(
+        "integral float literal must find the integer rows",
+        "MATCH (t:T {num: 5.0}) RETURN t.txt AS txt".into(),
+        "MATCH (t:T) WHERE t.unum = 5.0 RETURN t.txt AS txt".into(),
+    );
+    pair(
+        "float property, int literal",
+        "MATCH (t:T {fnum: 5}) RETURN t.txt AS txt".into(),
+        "MATCH (t:T) WHERE t.ufnum = 5 RETURN t.txt AS txt".into(),
+    );
+    pair(
+        "float property, float literal",
+        "MATCH (t:T {fnum: 5.0}) RETURN t.txt AS txt".into(),
+        "MATCH (t:T) WHERE t.ufnum = 5.0 RETURN t.txt AS txt".into(),
+    );
+    pair(
+        "fractional float",
+        "MATCH (t:T {fnum: 10.5}) RETURN t.txt AS txt".into(),
+        "MATCH (t:T) WHERE t.ufnum = 10.5 RETURN t.txt AS txt".into(),
+    );
+    pair(
+        "negative int",
+        "MATCH (t:T {num: -7}) RETURN t.txt AS txt".into(),
+        "MATCH (t:T) WHERE t.unum = -7 RETURN t.txt AS txt".into(),
+    );
+    pair(
+        "zero finds the -0.0 row too",
+        "MATCH (t:T {fnum: 0.0}) RETURN t.txt AS txt".into(),
+        "MATCH (t:T) WHERE t.ufnum = 0.0 RETURN t.txt AS txt".into(),
+    );
+    pair(
+        "a string never equals a number",
+        "MATCH (t:T {num: '5'}) RETURN t.txt AS txt".into(),
+        "MATCH (t:T) WHERE t.unum = '5' RETURN t.txt AS txt".into(),
+    );
+    pair(
+        "no such value",
+        "MATCH (t:T {num: 999999}) RETURN t.txt AS txt".into(),
+        "MATCH (t:T) WHERE t.unum = 999999 RETURN t.txt AS txt".into(),
+    );
+    pair(
+        "null never equals",
+        "MATCH (t:T) WHERE t.num = null RETURN t.txt AS txt".into(),
+        "MATCH (t:T) WHERE t.unum = null RETURN t.txt AS txt".into(),
+    );
+    pair(
+        "an int in a list predicate",
+        "MATCH (t:T) WHERE t.num IN [5, -7] RETURN t.txt AS txt".into(),
+        "MATCH (t:T) WHERE t.unum IN [5, -7] RETURN t.txt AS txt".into(),
+    );
+    // Beyond 2^53 the canonical key is lossy: these two share a posting, and
+    // each spelling must still return only its own row.
+    pair(
+        "i64 beyond 2^53, low",
+        format!("MATCH (t:T {{num: {BIG_LOW}}}) RETURN t.txt AS txt"),
+        format!("MATCH (t:T) WHERE t.unum = {BIG_LOW} RETURN t.txt AS txt"),
+    );
+    pair(
+        "i64 beyond 2^53, high",
+        format!("MATCH (t:T {{num: {BIG_HIGH}}}) RETURN t.txt AS txt"),
+        format!("MATCH (t:T) WHERE t.unum = {BIG_HIGH} RETURN t.txt AS txt"),
+    );
+    out
+}
+
+/// The PLAN must anchor on the index, not merely consult it per row from
+/// inside a label scan. A scan that calls the index once per row still pays
+/// scan prices — which is the whole 1600x — and result parity cannot see the
+/// difference.
+fn assert_plans_as_index_lookup(writer: &WriterSession, query: &str) {
+    fn has_lookup(plan: &LogicalPlan) -> bool {
+        matches!(plan, LogicalPlan::NodeByPropertyValue { .. })
+            || plan.children().into_iter().any(has_lookup)
+    }
+    fn has_scan(plan: &LogicalPlan) -> bool {
+        matches!(plan, LogicalPlan::NodeScan { .. }) || plan.children().into_iter().any(has_scan)
+    }
+    let snapshot = writer.snapshot();
+    let catalog = StatsCatalog::from_manifest(&snapshot.manifest().manifest);
+    let plan = optimize(lower(&parse(query).unwrap()).unwrap(), &catalog);
+    assert!(
+        has_lookup(&plan) && !has_scan(&plan),
+        "`{query}` must plan as an index lookup, not a scan:\n{plan:#?}"
+    );
+}
+
+async fn assert_all_agree(writer: &WriterSession, stage: &str) {
+    for (name, indexed, unindexed) in cases() {
+        let got = run(writer, &indexed).await;
+        let expected = run(writer, &unindexed).await;
+        assert!(
+            got == expected,
+            "\n[{stage}] {name}: indexed and unindexed numeric equality disagree.\n  \
+             {indexed}\n    -> {got:?}\n  {unindexed}\n    -> {expected:?}\n"
+        );
+
+        // …and the same through the transactional overlay, which a write
+        // statement reads through and which encodes its candidate keys
+        // differently.
+        let staged = run_staged(writer, &indexed).await;
+        assert!(
+            staged == expected,
+            "\n[{stage}/staged] {name}: the transactional overlay disagrees \
+             with the scan.\n  {indexed}\n    -> {staged:?}\n  {unindexed}\n    \
+             -> {expected:?}\n"
+        );
+    }
+}
+
+/// The lookup must be served by the posting index, not by an O(label) scan
+/// that happens to return the same rows.
+async fn assert_native_route(writer: &WriterSession, stage: &str) {
+    let before = route_telemetry::snapshot();
+    let five = run(writer, "MATCH (t:T {num: 5}) RETURN t.txt AS txt").await;
+    let after = route_telemetry::snapshot();
+    assert!(
+        after.property_native > before.property_native,
+        "[{stage}] numeric equality took the scan, not the posting index \
+         (native {} -> {}, fallback {} -> {})",
+        before.property_native,
+        after.property_native,
+        before.property_fallback,
+        after.property_fallback,
+    );
+    // …and served the right rows through that route: `5` and `5.0` are one
+    // value, so both rows must come back.
+    assert!(
+        five.contains(&"txt=5".to_string()) && five.contains(&"txt=five-integral".to_string()),
+        "[{stage}] `num: 5` must find both I64(5) rows: {five:?}"
+    );
+}
+
+/// The field measurement, reproduced: 160k rows carrying the same key as a
+/// string and as an integer, an index declared on both. Run explicitly:
+///
+///   cargo test -p namidb-query --test numeric_equality_index --release \
+///     -- --ignored --nocapture
+#[tokio::test]
+#[ignore = "measurement, not a gate: builds a 160k-row corpus"]
+async fn numeric_equality_is_not_orders_of_magnitude_slower_than_string() {
+    const N: i64 = 160_000;
+    let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    let paths = NamespacePaths::new("tenants", NamespaceId::new("numeric-eq-bench").unwrap());
+    let mut writer = WriterSession::open(store, paths).await.unwrap();
+    for ordinal in 0..N {
+        writer
+            .upsert_node(
+                "V",
+                NodeId::new(),
+                &NodeWriteRecord {
+                    properties: BTreeMap::from([
+                        ("num".to_string(), CoreValue::I64(ordinal)),
+                        // Same values, no index: the route numeric equality
+                        // was forced onto before this change, measured in the
+                        // same process so the factor is honest.
+                        ("unum".to_string(), CoreValue::I64(ordinal)),
+                        ("txt".to_string(), CoreValue::Str(ordinal.to_string())),
+                    ]),
+                    schema_version: 1,
+                    ..Default::default()
+                },
+            )
+            .unwrap();
+        if ordinal % 20_000 == 0 {
+            writer.commit_batch().await.unwrap();
+        }
+    }
+    writer.commit_batch().await.unwrap();
+    writer.create_property_index("V", "num").await.unwrap();
+    writer.create_property_index("V", "txt").await.unwrap();
+    let committed = writer.snapshot().manifest().manifest.schema.clone();
+    writer.flush(committed.clone()).await.unwrap();
+    writer.compact_l0(&committed).await.unwrap();
+
+    async fn timed(writer: &WriterSession, query: &str) -> std::time::Duration {
+        let _ = run(writer, query).await; // warm the sidecar cache
+        let start = std::time::Instant::now();
+        let rows = run(writer, query).await;
+        let elapsed = start.elapsed();
+        assert_eq!(rows.len(), 1, "`{query}` must find exactly its one row");
+        elapsed
+    }
+
+    let string = timed(&writer, "MATCH (v:V {txt: '12345'}) RETURN v.txt AS t").await;
+    let numeric = timed(&writer, "MATCH (v:V {num: 12345}) RETURN v.txt AS t").await;
+    let scan = timed(
+        &writer,
+        "MATCH (v:V) WHERE v.unum = 12345 RETURN v.txt AS t",
+    )
+    .await;
+    println!(
+        "string  {string:?}\nnumeric {numeric:?}\nscan    {scan:?}  ({:.0}x)",
+        scan.as_secs_f64() / numeric.as_secs_f64()
+    );
+    // The field report measured 1600x. Numeric equality must now be within
+    // the same order of magnitude as its string twin on identical data.
+    assert!(
+        numeric < string * 20 + std::time::Duration::from_millis(50),
+        "numeric equality is still far slower than the string twin on \
+         identical data: string {string:?} vs numeric {numeric:?}"
+    );
+}
+
+#[tokio::test]
+async fn numeric_equality_matches_the_scan_and_uses_the_index() {
+    let mut writer = corpus("numeric-eq").await;
+
+    assert_all_agree(&writer, "memtable").await;
+
+    let committed = writer.snapshot().manifest().manifest.schema.clone();
+    writer.flush(committed.clone()).await.unwrap();
+    assert_all_agree(&writer, "flushed").await;
+    assert_native_route(&writer, "flushed").await;
+    assert_plans_as_index_lookup(&writer, "MATCH (t:T {num: 5}) RETURN t.txt AS txt");
+    assert_plans_as_index_lookup(&writer, "MATCH (t:T {fnum: 10.5}) RETURN t.txt AS txt");
+    assert_plans_as_index_lookup(&writer, "MATCH (t:T) WHERE t.num = 5 RETURN t.txt AS txt");
+
+    writer.compact_l0(&committed).await.unwrap();
+    assert_all_agree(&writer, "compacted").await;
+    assert_native_route(&writer, "compacted").await;
+}

--- a/crates/namidb-server/src/maintenance.rs
+++ b/crates/namidb-server/src/maintenance.rs
@@ -354,12 +354,39 @@ pub(crate) struct DrainSummary {
     /// landed.
     #[serde(skip_serializing_if = "Option::is_none")]
     pub error: Option<String>,
+    /// Passes abandoned because a background compactor installed first. Not
+    /// an error: the work was done by the other pass, and this drain
+    /// re-prepared against the manifest it left. Reported because a drain
+    /// that spends most of its passes losing races is a signal in itself.
+    #[serde(skip_serializing_if = "usize_is_zero")]
+    pub races_lost: usize,
+}
+
+fn usize_is_zero(value: &usize) -> bool {
+    *value == 0
 }
 
 /// Bound on passes for one drain request, so a pathological churn rate
 /// cannot pin the writer forever. Each pass merges at least one bucket, so
 /// this is generous for any real L0 depth.
 const MAX_DRAIN_PASSES: usize = 128;
+
+/// Consecutive passes this drain may lose to a background compactor before
+/// giving up and reporting.
+///
+/// The drain does NOT go through [`CompactionScheduler::admit`] — it runs
+/// its passes directly — so a worker started by something else (a
+/// `CREATE INDEX` schedules one for its own backfill) can install between
+/// this drain's prepare and its install. The prepared plan then names an
+/// input the winner already merged away, and storage abandons it with a
+/// `Precondition`, which `run_compaction_pass` already labels `Stale`: the
+/// work happened, just not by this pass. Re-preparing against the manifest
+/// the winner left is the correct response.
+///
+/// Bounded, and deliberately far below `MAX_DRAIN_PASSES`: each retry pays
+/// a full prepare, so a drain that cannot win in this many consecutive
+/// attempts should report rather than burn the writer.
+const MAX_CONSECUTIVE_RACES_LOST: usize = 8;
 
 /// Drain L0 by running compaction passes back to back until nothing is left
 /// to merge. This is the "catch up before you serve" step after a bulk
@@ -377,6 +404,7 @@ pub(crate) async fn drain_compaction(
     cancel: Option<&watch::Receiver<bool>>,
 ) -> namidb_storage::Result<DrainSummary> {
     let mut summary = DrainSummary::default();
+    let mut consecutive_races_lost = 0_usize;
     for pass in 0..MAX_DRAIN_PASSES {
         // Same exclusion the scheduler takes around every pass. Without it a
         // concurrent orphan sweep can delete an object this pass is about to
@@ -412,6 +440,7 @@ pub(crate) async fn drain_compaction(
                 summary.source_ssts_removed += outcome.source_ssts_removed;
                 summary.new_ssts_written += outcome.new_ssts_written;
                 summary.manifest_version = outcome.committed.manifest.version;
+                consecutive_races_lost = 0;
             }
             Ok(CompactionPass::Noop | CompactionPass::Cancelled) => {
                 // Read the depth back rather than trusting the last applied
@@ -420,6 +449,19 @@ pub(crate) async fn drain_compaction(
                 // while files are already stacking up again.
                 summary.observe_idle(writer).await;
                 return Ok(summary);
+            }
+            // Losing the install race is not a failure of the drain — the
+            // merge it prepared was performed by whoever won, and the right
+            // response is to re-prepare against the manifest they left.
+            // Answering 500 here made `POST /v0/admin/compact` fail outright
+            // whenever a `CREATE INDEX` had just scheduled its own backfill
+            // pass, which is precisely when an operator reaches for it.
+            Err(namidb_storage::Error::Precondition(_))
+                if consecutive_races_lost < MAX_CONSECUTIVE_RACES_LOST =>
+            {
+                consecutive_races_lost += 1;
+                summary.races_lost += 1;
+                continue;
             }
             // A pass can lose the manifest install race to a concurrent
             // writer. Whatever earlier passes committed is durable and real,

--- a/crates/namidb-server/tests/ddl_index_backfill.rs
+++ b/crates/namidb-server/tests/ddl_index_backfill.rs
@@ -208,3 +208,77 @@ async fn create_index_on_loaded_data_materializes_without_periodic_compaction() 
         "an applied ddl-triggered compaction must be counted; got: {applied:?}"
     );
 }
+
+/// Item 82: `POST /v0/admin/compact` right after a `CREATE INDEX` answered
+/// 500, which is exactly when an operator reaches for it — "I declared the
+/// index, now materialize it".
+///
+/// The DDL schedules its own backfill pass. The admin drain does NOT go
+/// through the scheduler's admission, so it runs alongside that pass and can
+/// lose the manifest install race; storage abandons the prepared plan with a
+/// `Precondition` ("another compaction won the install race"), and the drain
+/// reported that as a hard error whenever it happened on its FIRST pass.
+/// Losing the race means the merge was performed by the winner, so the drain
+/// now re-prepares against the manifest they left.
+#[tokio::test]
+async fn admin_compact_survives_the_ddl_backfill_pass_it_races() {
+    let dir = tempfile::tempdir().unwrap();
+    let store_uri = format!("file://{}?ns=ddl-race", dir.path().display());
+    let base = boot(store_uri).await;
+
+    for chunk in 0..3 {
+        let parts: Vec<String> = (0..100)
+            .map(|i| {
+                let n = chunk * 100 + i;
+                format!("(:Person {{cedula: 'ced-{n:04}', seq: {n}}})")
+            })
+            .collect();
+        let (status, body) = cypher(&base, &format!("CREATE {}", parts.join(", "))).await;
+        assert_eq!(status, 200, "seed chunk: {body}");
+    }
+    let flush = reqwest::Client::new()
+        .post(format!("{base}/v0/admin/flush"))
+        .bearer_auth(TOKEN)
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(flush.status().as_u16(), 200);
+
+    // The DDL leaves a backfill pass in flight behind it.
+    let (status, body) = cypher(
+        &base,
+        "CREATE INDEX persona_seq IF NOT EXISTS FOR (p:Person) ON (p.seq)",
+    )
+    .await;
+    assert_eq!(status, 200, "index DDL: {body}");
+
+    // Straight into the drain, with no pause: this is the shape that failed.
+    let compact = reqwest::Client::new()
+        .post(format!("{base}/v0/admin/compact"))
+        .bearer_auth(TOKEN)
+        .send()
+        .await
+        .unwrap();
+    let status = compact.status().as_u16();
+    let body = compact.text().await.unwrap();
+    assert_eq!(
+        status, 200,
+        "draining right after a CREATE INDEX must not fail: {body}"
+    );
+
+    // And the drain reports a real account of what it saw, including any
+    // races it lost, rather than an opaque success.
+    let summary: serde_json::Value = serde_json::from_str(&body).unwrap();
+    assert!(
+        summary.get("l0_after").is_some() && summary.get("manifest_version").is_some(),
+        "the drain must report its observed state: {body}"
+    );
+
+    // The index still answers correctly afterwards.
+    let (status, body) = cypher(&base, "MATCH (p:Person {seq: 123}) RETURN p.cedula AS c").await;
+    assert_eq!(status, 200, "{body}");
+    assert!(
+        body.contains("ced-0123"),
+        "indexed lookup must match: {body}"
+    );
+}

--- a/crates/namidb-server/tests/explain_surface.rs
+++ b/crates/namidb-server/tests/explain_surface.rs
@@ -164,8 +164,10 @@ async fn explain_renders_the_plan_and_its_physical_route_without_executing() {
         "index route note expected after flush: {body}"
     );
 
-    // A numeric equality is not posting-indexed — the footer says so
-    // instead of letting the operator name imply index speed.
+    // A numeric equality IS posting-indexed, but only on sidecars that
+    // harvested numbers. These SSTs were flushed before the index existed,
+    // so the footer must report the scan it is really taking rather than
+    // letting the operator name imply index speed.
     let (status, body) = cypher(
         &base,
         "CREATE INDEX persona_seq IF NOT EXISTS FOR (p:Person) ON (p.seq)",
@@ -176,8 +178,29 @@ async fn explain_renders_the_plan_and_its_physical_route_without_executing() {
     assert_eq!(status, 200, "{body}");
     if body.contains("NodeByPropertyValue") {
         assert!(
-            body.contains("numeric equality is not posting-indexed"),
-            "numeric route caveat expected: {body}"
+            body.contains("SCAN FALLBACK") && body.contains("numeric postings"),
+            "a numeric equality over pre-index SSTs must report the scan it \
+             is really taking: {body}"
+        );
+    }
+
+    // …and a compaction pass backfills those postings, which is the whole
+    // migration path. The same EXPLAIN must then say index.
+    let compact = reqwest::Client::new()
+        .post(format!("{base}/v0/admin/compact"))
+        .bearer_auth(TOKEN)
+        .send()
+        .await
+        .unwrap();
+    let compact_status = compact.status().as_u16();
+    let compact_body = compact.text().await.unwrap();
+    assert_eq!(compact_status, 200, "compact said: {compact_body}");
+    let (status, body) = cypher(&base, "EXPLAIN MATCH (p:Person {seq: 7}) RETURN p").await;
+    assert_eq!(status, 200, "{body}");
+    if body.contains("NodeByPropertyValue") {
+        assert!(
+            body.contains("→ index"),
+            "numeric postings must be servable after a compaction pass: {body}"
         );
     }
 

--- a/crates/namidb-server/tests/explain_surface.rs
+++ b/crates/namidb-server/tests/explain_surface.rs
@@ -165,9 +165,15 @@ async fn explain_renders_the_plan_and_its_physical_route_without_executing() {
     );
 
     // A numeric equality IS posting-indexed, but only on sidecars that
-    // harvested numbers. These SSTs were flushed before the index existed,
-    // so the footer must report the scan it is really taking rather than
-    // letting the operator name imply index speed.
+    // harvested numbers, and these SSTs were flushed before the index
+    // existed. The footer must report whichever route is real at this
+    // moment, and never let the operator name imply index speed on its own.
+    //
+    // Deliberately NOT asserting one specific route here: the DDL schedules
+    // its own backfill pass, so by the time this EXPLAIN runs the postings
+    // may or may not be materialised, and which one wins is a timing detail
+    // (it differs between Linux and macOS runners). What must hold either
+    // way is that the note states the route it is REALLY taking.
     let (status, body) = cypher(
         &base,
         "CREATE INDEX persona_seq IF NOT EXISTS FOR (p:Person) ON (p.seq)",
@@ -177,10 +183,16 @@ async fn explain_renders_the_plan_and_its_physical_route_without_executing() {
     let (status, body) = cypher(&base, "EXPLAIN MATCH (p:Person {seq: 7}) RETURN p").await;
     assert_eq!(status, 200, "{body}");
     if body.contains("NodeByPropertyValue") {
+        let backfilled = body.contains("→ index");
+        let not_yet = body.contains("SCAN FALLBACK") && body.contains("numeric postings");
         assert!(
-            body.contains("SCAN FALLBACK") && body.contains("numeric postings"),
-            "a numeric equality over pre-index SSTs must report the scan it \
-             is really taking: {body}"
+            backfilled || not_yet,
+            "a numeric equality must report either the index it can use or \
+             the numeric postings it is still missing: {body}"
+        );
+        assert!(
+            !body.contains("numeric equality is not posting-indexed"),
+            "the pre-2.6.14 caveat must be gone: {body}"
         );
     }
 

--- a/crates/namidb-storage/src/cache.rs
+++ b/crates/namidb-storage/src/cache.rs
@@ -137,6 +137,24 @@ pub type EqualityPropertySidecar = BTreeMap<String, Vec<[u8; 16]>>;
 /// tagged Bool `true`. Equality and ordered readers always hydrate and confirm
 /// candidates against the current typed value, so the collision only adds a
 /// conservative candidate; it cannot produce a false result.
+/// Map an f64 onto a u64 whose UNSIGNED order is the number's order.
+///
+/// IEEE-754 bits are almost sortable already: positives ascend, but negatives
+/// descend (the sign bit dominates and the magnitude runs backwards). Flipping
+/// every bit of a negative reverses it into place, and setting the sign bit on
+/// a positive lifts it above every negative.
+///
+/// `-0.0` must be normalised to `0.0` by the caller; NaN has no position in
+/// this order and is not encodable at all.
+fn sortable_f64_bits(value: f64) -> u64 {
+    let bits = value.to_bits();
+    if bits & (1 << 63) != 0 {
+        !bits
+    } else {
+        bits | (1 << 63)
+    }
+}
+
 pub fn encode_equality_property_value(value: &Value) -> Option<String> {
     let mut out = String::new();
     match value {
@@ -153,14 +171,19 @@ pub fn encode_equality_property_value(value: &Value) -> Option<String> {
         // share a posting. That is a conservative FALSE POSITIVE, not a wrong
         // answer: every candidate is re-confirmed against the current typed
         // value with [`cypher_scalar_equal`] before it reaches a result.
+        //
+        // The key is also ORDER-PRESERVING (see [`sortable_f64_bits`]), so the
+        // range-readable sidecar can be positioned by value. Raw `to_bits()`
+        // would sort negatives backwards, which costs nothing for an equality
+        // probe and forecloses every ordered read over the same postings.
         Value::I64(v) => {
             use std::fmt::Write as _;
-            write!(&mut out, "n:{:016x}", (*v as f64).to_bits()).ok()?;
+            write!(&mut out, "n:{:016x}", sortable_f64_bits(*v as f64)).ok()?;
         }
         Value::F64(v) if !v.is_nan() => {
             let normalized = if *v == 0.0 { 0.0 } else { *v };
             use std::fmt::Write as _;
-            write!(&mut out, "n:{:016x}", normalized.to_bits()).ok()?;
+            write!(&mut out, "n:{:016x}", sortable_f64_bits(normalized)).ok()?;
         }
         Value::Bytes(bytes) => {
             use std::fmt::Write as _;
@@ -2952,6 +2975,58 @@ mod tests {
         assert!(
             !cypher_scalar_equal(&low, &high),
             "the confirm step MUST separate what the key merged"
+        );
+    }
+
+    #[test]
+    fn numeric_equality_keys_sort_in_numeric_order() {
+        // The sidecar is a range-readable B+tree over these keys. An equality
+        // probe would not care, but an ordered read over the same postings
+        // (the natural home for `WHERE n.amount > x`) needs the key order to
+        // BE the numeric order — and raw IEEE-754 bits sort negatives
+        // backwards. Locked here because changing the encoding after numeric
+        // postings exist in the wild is a format migration.
+        let ascending = [
+            Value::F64(f64::NEG_INFINITY),
+            // -1e300 is far more negative than i64::MIN (-9.2e18).
+            Value::F64(-1e300),
+            Value::I64(i64::MIN),
+            Value::I64(-9_007_199_254_740_993),
+            Value::I64(-42),
+            Value::F64(-1.5),
+            Value::F64(-f64::MIN_POSITIVE),
+            Value::F64(-0.0),
+            Value::I64(0),
+            Value::F64(f64::MIN_POSITIVE),
+            Value::F64(0.5),
+            Value::I64(1),
+            Value::I64(42),
+            Value::I64(i64::MAX),
+            // …and 1e300 is far larger than i64::MAX (9.2e18).
+            Value::F64(1e300),
+            Value::F64(f64::INFINITY),
+        ];
+        let keys: Vec<String> = ascending
+            .iter()
+            .map(|value| {
+                encode_equality_property_value(value)
+                    .unwrap_or_else(|| panic!("{value:?} must be encodable"))
+            })
+            .collect();
+        for window in keys.windows(2) {
+            assert!(
+                window[0] <= window[1],
+                "numeric keys must ascend with the numbers: {:?} then {:?}",
+                window[0],
+                window[1]
+            );
+        }
+        // `-0.0` folds onto `0`, and `i64::MIN`/`-9007199254740993` round to
+        // f64 neighbours, so the sequence is non-strict by construction —
+        // but nothing may go BACKWARDS, and the distinct ends must differ.
+        assert!(
+            keys.first() < keys.last(),
+            "the order must be total, not collapsed"
         );
     }
 

--- a/crates/namidb-storage/src/cache.rs
+++ b/crates/namidb-storage/src/cache.rs
@@ -142,14 +142,25 @@ pub fn encode_equality_property_value(value: &Value) -> Option<String> {
     match value {
         Value::Str(s) => out.push_str(s),
         Value::Bool(v) => out.push_str(if *v { "b:1" } else { "b:0" }),
+        // Numerics share ONE canonical key. Cypher equality coerces across
+        // Integer and Float (`5 = 5.0` is TRUE, mirrored from the executor's
+        // `is_equal`), so two values that compare equal MUST encode
+        // identically or the index route silently drops rows the scan route
+        // returns. This matches what TupleV1 already does for composite
+        // members; see [`encode_equality_tuple_key`].
+        //
+        // `i64 -> f64` loses precision above 2^53, so distinct integers can
+        // share a posting. That is a conservative FALSE POSITIVE, not a wrong
+        // answer: every candidate is re-confirmed against the current typed
+        // value with [`cypher_scalar_equal`] before it reaches a result.
         Value::I64(v) => {
             use std::fmt::Write as _;
-            write!(&mut out, "i:{:016x}", (*v as u64) ^ (1_u64 << 63)).ok()?;
+            write!(&mut out, "n:{:016x}", (*v as f64).to_bits()).ok()?;
         }
         Value::F64(v) if !v.is_nan() => {
             let normalized = if *v == 0.0 { 0.0 } else { *v };
             use std::fmt::Write as _;
-            write!(&mut out, "f:{:016x}", normalized.to_bits()).ok()?;
+            write!(&mut out, "n:{:016x}", normalized.to_bits()).ok()?;
         }
         Value::Bytes(bytes) => {
             use std::fmt::Write as _;
@@ -2898,6 +2909,50 @@ mod tests {
         );
         assert!(encode_equality_property_value(&Value::Null).is_none());
         assert!(encode_equality_property_value(&Value::F64(f64::NAN)).is_none());
+    }
+
+    #[test]
+    fn numeric_equality_keys_are_canonical_across_integer_and_float() {
+        // Cypher says `5 = 5.0`, so the index must file them together or the
+        // posting route drops rows the scan route returns.
+        assert_eq!(
+            encode_equality_property_value(&Value::I64(5)),
+            encode_equality_property_value(&Value::F64(5.0)),
+            "an integer and an equal float must share one posting"
+        );
+        assert_eq!(
+            encode_equality_property_value(&Value::I64(-7)),
+            encode_equality_property_value(&Value::F64(-7.0))
+        );
+        assert_eq!(
+            encode_equality_property_value(&Value::I64(0)),
+            encode_equality_property_value(&Value::F64(-0.0)),
+            "-0.0 folds into 0.0, which equals the integer zero"
+        );
+        assert_ne!(
+            encode_equality_property_value(&Value::I64(5)),
+            encode_equality_property_value(&Value::F64(5.5))
+        );
+        assert_ne!(
+            encode_equality_property_value(&Value::I64(5)),
+            encode_equality_property_value(&Value::Str("5".into())),
+            "a string never equals a number in Cypher"
+        );
+
+        // Above 2^53 the canonical key is LOSSY on purpose: distinct integers
+        // may share a posting. That is a conservative false positive, and
+        // `cypher_scalar_equal` is what removes it at confirm time.
+        let low = Value::I64(9_007_199_254_740_992); // 2^53
+        let high = Value::I64(9_007_199_254_740_993); // 2^53 + 1
+        assert_eq!(
+            encode_equality_property_value(&low),
+            encode_equality_property_value(&high),
+            "the lossy key is expected to collide here"
+        );
+        assert!(
+            !cypher_scalar_equal(&low, &high),
+            "the confirm step MUST separate what the key merged"
+        );
     }
 
     fn tight_cache(bytes: usize) -> SstCache {

--- a/crates/namidb-storage/src/compact.rs
+++ b/crates/namidb-storage/src/compact.rs
@@ -1823,9 +1823,17 @@ struct RebasedBarrier {
     body: Bytes,
 }
 
+/// Confirm every prepared Nodes rewrite still describes the manifest it is
+/// about to be folded into.
+///
+/// The failure messages name the manifest versions and say WHICH way the
+/// check failed. A bare "missing or ambiguous" cost a long diagnosis once:
+/// a lost install race, a stale basis, and a genuinely duplicated id are
+/// three different problems, and only one of them is benign.
 fn verify_node_rewrite_inputs(
     manifest: &crate::manifest::Manifest,
     rewrites: &[PreparedNodeRewrite],
+    base_version: u64,
 ) -> Result<()> {
     let mut claimed = HashSet::new();
     for rewrite in rewrites {
@@ -1844,18 +1852,33 @@ fn verify_node_rewrite_inputs(
                 .ssts
                 .iter()
                 .filter(|descriptor| descriptor.id == input.id);
+            let nodes_now = manifest
+                .ssts
+                .iter()
+                .filter(|descriptor| descriptor.kind == SstKind::Nodes)
+                .count();
             match (matches.next(), matches.next()) {
                 (Some(current), None) if current == input => {}
                 (Some(_), None) => {
                     return Err(Error::precondition(format!(
-                        "abandoning prepared compaction: Nodes input {} changed after prepare",
-                        input.id
+                        "abandoning prepared compaction (basis v{base_version}): Nodes input {} \
+                         changed between prepare and install in manifest v{} \
+                         ({nodes_now} Nodes SSTs present)",
+                        input.id, manifest.version
+                    )));
+                }
+                (None, _) => {
+                    return Err(Error::precondition(format!(
+                        "abandoning prepared compaction (basis v{base_version}): Nodes input {} \
+                         is no longer in manifest v{} ({nodes_now} Nodes SSTs present); \
+                         another compaction won the install race",
+                        input.id, manifest.version
                     )));
                 }
                 _ => {
-                    return Err(Error::precondition(format!(
-                        "abandoning prepared compaction: Nodes input {} is missing or ambiguous",
-                        input.id
+                    return Err(Error::invariant(format!(
+                        "manifest v{} lists Nodes SST {} more than once",
+                        manifest.version, input.id
                     )));
                 }
             }
@@ -2294,7 +2317,11 @@ pub async fn install_prepared(
                 prepared.base_version
             ))
         })?;
-        verify_node_rewrite_inputs(&current.manifest, &prepared.node_rewrites)?;
+        verify_node_rewrite_inputs(
+            &current.manifest,
+            &prepared.node_rewrites,
+            prepared.base_version,
+        )?;
         // States this very prepare REPLACES (the authoritative rebuild path —
         // e.g. a freshly recreated index still Building with partial
         // coverage) are retired below, not rebased: validating their partial
@@ -5220,7 +5247,8 @@ mod tests {
             .unwrap()
             .max_lsn += 1;
         assert!(
-            verify_node_rewrite_inputs(&conflicting_manifest, std::slice::from_ref(&plan)).is_err()
+            verify_node_rewrite_inputs(&conflicting_manifest, std::slice::from_ref(&plan), 0)
+                .is_err()
         );
     }
 

--- a/crates/namidb-storage/src/compact.rs
+++ b/crates/namidb-storage/src/compact.rs
@@ -99,7 +99,7 @@ use tracing::{debug, instrument};
 use uuid::Uuid;
 use xxhash_rust::xxh3::Xxh3;
 
-use namidb_core::{DataType, EdgeTypeDef, LabelDef, LabelDictionary, Schema, Value};
+use namidb_core::{EdgeTypeDef, LabelDef, LabelDictionary, Schema, Value};
 
 use crate::error::{Error, Result};
 use crate::fence::WriterFence;
@@ -561,17 +561,23 @@ fn node_descriptor_needs_non_record_migration(
     required: &LabelDef,
     composite: &[namidb_core::schema::IndexDef],
 ) -> bool {
-    let required_equality: Vec<&str> = required
+    // `(name, numeric)`: a numeric-declared property additionally demands a
+    // sidecar that advertises numeric coverage, so SSTs written before
+    // numeric equality was indexable are rewritten once and their postings
+    // backfilled — the same DDL-backfill arm item 38 added for the
+    // String/Bool case.
+    let required_equality: Vec<(&str, bool)> = required
         .properties
         .iter()
         .filter(|property| {
-            property.indexed
-                && matches!(
-                    property.data_type,
-                    DataType::Utf8 | DataType::LargeUtf8 | DataType::Bool
-                )
+            property.indexed && crate::flush::equality_indexable(&property.data_type)
         })
-        .map(|property| property.name.as_str())
+        .map(|property| {
+            (
+                property.name.as_str(),
+                crate::flush::numeric_data_type(&property.data_type),
+            )
+        })
         .collect();
     desc.unique_property_indices.iter().any(|index| {
         index.format != crate::manifest::PropertyIndexFormat::PagedV1
@@ -581,10 +587,11 @@ fn node_descriptor_needs_non_record_migration(
         index.format != crate::manifest::PropertyIndexFormat::PagedV1
             && index.paged.is_none()
             && !index.paged_build_unsupported
-    }) || required_equality.iter().any(|property| {
+    }) || required_equality.iter().any(|(property, numeric)| {
         !desc.equality_property_indices.iter().any(|index| {
             index.property == *property
                 && index.mixed_type_complete
+                && (!numeric || index.numeric_complete)
                 && (index.format == crate::manifest::PropertyIndexFormat::PagedV1
                     || index.paged.is_some()
                     || index.paged_build_unsupported)
@@ -3991,10 +3998,19 @@ impl VectorMemberCollector {
             .into_iter()
             .flat_map(|label| &label.properties)
             .filter(|property| {
+                // Deliberately NOT widened to numerics alongside the equality
+                // sidecars. This is the search-LSM native-filter catalog: its
+                // property list feeds the catalog signature, so changing it
+                // retires every vector/text generation for rebuild. The
+                // prefilter's own numeric exclusion is locked by
+                // `vector_prefilter_never_narrows_cross_typed_numeric_equality`
+                // and should be lifted with that subsystem, not with this one.
                 (property.indexed || property.unique)
                     && matches!(
                         property.data_type,
-                        DataType::Bool | DataType::Utf8 | DataType::LargeUtf8
+                        namidb_core::DataType::Bool
+                            | namidb_core::DataType::Utf8
+                            | namidb_core::DataType::LargeUtf8
                     )
             })
             .map(|property| property.name.clone())

--- a/crates/namidb-storage/src/flush.rs
+++ b/crates/namidb-storage/src/flush.rs
@@ -1839,15 +1839,6 @@ pub(crate) fn prepare_equality_property_sidecars(
     collector.finish(paths, level, sst_id, label)
 }
 
-/// One property's harvested `value → [id, ...]` postings, in def order.
-///
-/// Once a property is declared with a ScalarV1-compatible type, the collector
-/// harvests every actually encodable String/Bool runtime value. This is
-/// deliberate even for a legacy label-scoped SST: the raw storage API can
-/// contain rows that predate or disagree with the later schema declaration,
-/// and an authoritative negative-answer index must cover those rows too.
-/// Streaming harvester behind [`prepare_equality_property_sidecars`]; the
-/// posting-list analogue of [`UniqueSidecarCollector`].
 /// Declared types that get a single-property equality posting sidecar.
 ///
 /// The one gate shared by the flush collector, the compaction rewrite
@@ -1889,6 +1880,16 @@ pub(crate) struct HarvestedProperty {
     numeric: bool,
 }
 
+/// One property's harvested `value → [id, ...]` postings, in def order.
+///
+/// Once a property is declared with a ScalarV1-compatible type, the collector
+/// harvests every actually encodable runtime value it can be PROBED for —
+/// String/Bool always, and numbers as well for a numeric declaration. This is
+/// deliberate even for a legacy label-scoped SST: the raw storage API can
+/// contain rows that predate or disagree with the later schema declaration,
+/// and an authoritative negative-answer index must cover those rows too.
+/// Streaming harvester behind [`prepare_equality_property_sidecars`]; the
+/// posting-list analogue of [`UniqueSidecarCollector`].
 #[derive(Debug)]
 pub(crate) struct EqualitySidecarCollector {
     properties: Vec<HarvestedProperty>,

--- a/crates/namidb-storage/src/flush.rs
+++ b/crates/namidb-storage/src/flush.rs
@@ -633,20 +633,39 @@ pub(crate) fn union_indexed_props(schema: &Schema) -> LabelDef {
                     .and_modify(|current| {
                         // The synthetic definition is global: declarations
                         // with the same property name may legitimately use
-                        // different types on different labels.  Its type is
+                        // different types on different labels. Its type is
                         // only a capability marker for the equality
-                        // harvester/planner, so never let an arbitrary
-                        // lexically-first unsupported declaration (for
-                        // example Int64) hide a later String/Bool index.
-                        let current_supported = matches!(
+                        // harvester/planner.
+                        //
+                        // A String/Bool declaration WINS over a numeric one,
+                        // and that tie-break is load-bearing in both
+                        // directions:
+                        //
+                        // - It stops an arbitrary lexically-first declaration
+                        //   from hiding a later String/Bool index, which is
+                        //   why the rule was written.
+                        // - It also keeps tagged numeric keys OUT of any
+                        //   sidecar that `ordered_node_ids_by_string_property`
+                        //   can walk. That iterator reads keys in order for
+                        //   `ORDER BY <string prop> LIMIT k` and admits any
+                        //   label declaring the property Utf8; a numeric key
+                        //   filed alongside would sort among raw strings.
+                        //
+                        // The cost is a numeric index quietly downgraded to
+                        // the scan route whenever another label declares the
+                        // same property name as a string — conservative on
+                        // purpose. `numeric_complete` reports it honestly, so
+                        // EXPLAIN shows the scan fallback rather than
+                        // claiming an index that is not there.
+                        let current_is_text = matches!(
                             current.data_type,
                             DataType::Utf8 | DataType::LargeUtf8 | DataType::Bool
                         );
-                        let candidate_supported = matches!(
+                        let candidate_is_text = matches!(
                             p.data_type,
                             DataType::Utf8 | DataType::LargeUtf8 | DataType::Bool
                         );
-                        if !current_supported && candidate_supported {
+                        if !current_is_text && candidate_is_text {
                             *current = candidate.clone();
                         }
                     })
@@ -1829,25 +1848,63 @@ pub(crate) fn prepare_equality_property_sidecars(
 /// and an authoritative negative-answer index must cover those rows too.
 /// Streaming harvester behind [`prepare_equality_property_sidecars`]; the
 /// posting-list analogue of [`UniqueSidecarCollector`].
+/// Declared types that get a single-property equality posting sidecar.
+///
+/// The one gate shared by the flush collector, the compaction rewrite
+/// trigger, and the reader's route decision. They MUST agree: a type the
+/// trigger demands but the collector declines would rewrite every bucket on
+/// every compaction forever.
+pub(crate) fn equality_indexable(data_type: &DataType) -> bool {
+    matches!(
+        data_type,
+        DataType::Utf8 | DataType::LargeUtf8 | DataType::Bool
+    ) || numeric_data_type(data_type)
+}
+
+/// Declared types whose values Cypher compares numerically. Date/Timestamp
+/// are deliberately excluded: they are ordered, but `date = 5` is not a
+/// Cypher equality, so folding them into the numeric key would buy nothing
+/// and widen the confirm contract.
+pub(crate) fn numeric_data_type(data_type: &DataType) -> bool {
+    matches!(
+        data_type,
+        DataType::Int32 | DataType::Int64 | DataType::Float32 | DataType::Float64
+    )
+}
+
+/// One property this collector files postings for, and whether its
+/// declaration makes numeric probes serviceable.
+#[derive(Debug)]
+pub(crate) struct HarvestedProperty {
+    name: String,
+    /// The declared type is numeric, so numeric runtime values are harvested
+    /// too and the descriptor may advertise `numeric_complete`.
+    ///
+    /// Scoped to the DECLARATION on purpose. Widening the harvest for a
+    /// String-declared property would file tagged numeric keys into the same
+    /// sidecar that `ordered_node_ids_by_string_property` walks in key order
+    /// for `ORDER BY <string prop> LIMIT k`, where they would sort among raw
+    /// string keys. Numeric-declared properties are never read by that
+    /// iterator (it requires Utf8/LargeUtf8), so the two stay disjoint.
+    numeric: bool,
+}
+
 #[derive(Debug)]
 pub(crate) struct EqualitySidecarCollector {
-    properties: Vec<String>,
+    properties: Vec<HarvestedProperty>,
     sorter: crate::sst::external_pairs::ExternalPairSorter,
 }
 
 impl EqualitySidecarCollector {
     pub(crate) fn new(label_def: &LabelDef) -> Result<Self> {
-        let properties: Vec<String> = label_def
+        let properties: Vec<HarvestedProperty> = label_def
             .properties
             .iter()
-            .filter(|p| {
-                p.indexed
-                    && matches!(
-                        p.data_type,
-                        DataType::Utf8 | DataType::LargeUtf8 | DataType::Bool
-                    )
+            .filter(|p| p.indexed && equality_indexable(&p.data_type))
+            .map(|p| HarvestedProperty {
+                name: p.name.clone(),
+                numeric: numeric_data_type(&p.data_type),
             })
-            .map(|p| p.name.clone())
             .collect();
         u32::try_from(properties.len())
             .map_err(|_| Error::invariant("equality property count exceeds u32"))?;
@@ -1858,17 +1915,26 @@ impl EqualitySidecarCollector {
     }
 
     pub(crate) fn observe(&mut self, id: [u8; 16], rec: &NodeWriteRecord) -> Result<()> {
-        for (ordinal, name) in self.properties.iter().enumerate() {
-            let value = rec.properties.get(name);
+        for (ordinal, property) in self.properties.iter().enumerate() {
+            let value = rec.properties.get(&property.name);
             // The declaration only decides whether this property has a
-            // ScalarV1 sidecar. Coverage follows the stored value: both
-            // supported runtime types must be harvested so a schema change,
-            // heterogeneous label, or legacy mismatched row cannot become an
-            // authoritative false miss.
+            // ScalarV1 sidecar. Coverage follows the stored value: every
+            // runtime type this sidecar can be PROBED for must be harvested,
+            // so a schema change, heterogeneous label, or legacy mismatched
+            // row cannot become an authoritative false miss.
+            //
+            // A numeric-declared property is probed for numbers as well, so
+            // it harvests numbers on top of the String/Bool baseline — the
+            // baseline stays because such a property can still hold a legacy
+            // string, and a String probe against it must not miss.
             let compatible = matches!(
                 value,
                 Some(namidb_core::Value::Str(_) | namidb_core::Value::Bool(_))
-            );
+            ) || (property.numeric
+                && matches!(
+                    value,
+                    Some(namidb_core::Value::I64(_) | namidb_core::Value::F64(_))
+                ));
             if let Some(key) = compatible
                 .then_some(value)
                 .flatten()
@@ -1939,13 +2005,14 @@ impl EqualitySidecarCollector {
 
         let mut descriptors = Vec::new();
         let mut bodies = Vec::new();
-        for (((name, builder), legacy), distinct_values) in self
+        for (((property, builder), legacy), distinct_values) in self
             .properties
             .into_iter()
             .zip(builders)
             .zip(legacy)
             .zip(distinct_counts)
         {
+            let HarvestedProperty { name, numeric } = property;
             // One key too wide to page must not cost the property its index:
             // keep the legacy body and mark the accelerator unsupported, which
             // is the same contract the pre-paged writer offered.
@@ -1983,6 +2050,7 @@ impl EqualitySidecarCollector {
                     distinct_values,
                     key_encoding: crate::manifest::EqualityKeyEncoding::ScalarV1,
                     mixed_type_complete: true,
+                    numeric_complete: numeric,
                     format: crate::manifest::PropertyIndexFormat::BincodeV0,
                     paged: upload
                         .as_ref()
@@ -2012,6 +2080,7 @@ impl EqualitySidecarCollector {
                     distinct_values,
                     key_encoding: crate::manifest::EqualityKeyEncoding::ScalarV1,
                     mixed_type_complete: true,
+                    numeric_complete: numeric,
                     format: crate::manifest::PropertyIndexFormat::PagedV1,
                     paged: None,
                     paged_build_unsupported: false,
@@ -3221,6 +3290,70 @@ pub mod builder {
 mod tests {
     use std::sync::{mpsc, Arc};
     use std::time::Duration;
+
+    #[test]
+    fn a_string_declaration_downgrades_a_same_named_numeric_index() {
+        use namidb_core::{DataType, LabelDef, PropertyDef, SchemaBuilder};
+
+        // `code` is numeric on one label and text on another. The union must
+        // resolve to the TEXT declaration, so no tagged numeric key is ever
+        // filed into a sidecar that the ordered-string iterator may walk for
+        // `ORDER BY code LIMIT k` on the text label.
+        let schema = SchemaBuilder::new()
+            .label(LabelDef {
+                name: "Venta".into(),
+                properties: vec![PropertyDef::new("code", DataType::Int64, false)
+                    .unwrap()
+                    .with_indexed(true)],
+            })
+            .unwrap()
+            .label(LabelDef {
+                name: "Producto".into(),
+                properties: vec![PropertyDef::new("code", DataType::Utf8, false)
+                    .unwrap()
+                    .with_indexed(true)],
+            })
+            .unwrap()
+            .build();
+
+        let union = super::union_indexed_props(&schema);
+        let code = union
+            .properties
+            .iter()
+            .find(|p| p.name == "code")
+            .expect("the union must carry the property");
+        assert_eq!(
+            code.data_type,
+            DataType::Utf8,
+            "a text declaration must win the tie-break"
+        );
+        assert!(
+            !super::numeric_data_type(&code.data_type),
+            "so the collector files no numeric key, and `numeric_complete` \
+             stays false — numeric equality keeps the scan route it had, \
+             which is correct if slow"
+        );
+
+        // With no conflicting text declaration the numeric index stands.
+        let numeric_only = SchemaBuilder::new()
+            .label(LabelDef {
+                name: "Venta".into(),
+                properties: vec![PropertyDef::new("code", DataType::Int64, false)
+                    .unwrap()
+                    .with_indexed(true)],
+            })
+            .unwrap()
+            .build();
+        let union = super::union_indexed_props(&numeric_only);
+        assert!(super::numeric_data_type(
+            &union
+                .properties
+                .iter()
+                .find(|p| p.name == "code")
+                .unwrap()
+                .data_type
+        ));
+    }
 
     use namidb_core::{EdgeTypeDef, LabelDef, NamespaceId, NodeId, PropertyDef, SchemaBuilder};
     use object_store::memory::InMemory;

--- a/crates/namidb-storage/src/manifest.rs
+++ b/crates/namidb-storage/src/manifest.rs
@@ -485,6 +485,19 @@ pub struct EqualityIndexDescriptor {
     /// negative-answer index.
     #[serde(default)]
     pub mixed_type_complete: bool,
+    /// The collector also harvested every NUMERIC runtime value for this
+    /// property, so an Integer/Float probe may be answered from the posting
+    /// list instead of scanning the label.
+    ///
+    /// A NEW FIELD rather than a new [`EqualityKeyEncoding`] variant, and
+    /// deliberately so: `key_encoding` is an externally-tagged enum, so a
+    /// rolled-back reader meeting an unknown variant fails to deserialise the
+    /// WHOLE manifest and cannot open the namespace. An unknown *field* is
+    /// ignored. A widened sidecar is a strict superset — a pre-numeric reader
+    /// probes only its String/Bool keys, which are exactly as complete as
+    /// before, and leaves numeric equality on the scan route it already used.
+    #[serde(default)]
+    pub numeric_complete: bool,
     /// Physical encoding of the immutable posting map.
     #[serde(default)]
     pub format: PropertyIndexFormat,
@@ -3358,6 +3371,7 @@ mod tests {
             distinct_values: 2,
             key_encoding: EqualityKeyEncoding::ScalarV1,
             mixed_type_complete: true,
+            numeric_complete: false,
             format: PropertyIndexFormat::PagedV1,
             paged: None,
             paged_build_unsupported: false,

--- a/crates/namidb-storage/src/read.rs
+++ b/crates/namidb-storage/src/read.rs
@@ -1595,6 +1595,20 @@ impl<'mt> Snapshot<'mt> {
             cache.record_equality_lookup();
         }
 
+        // The transactional overlay keys off `unique_index::key_part`, whose
+        // `I64` and `F64` are DISTINCT variants — it does not canonicalise
+        // numerics the way the posting key does. Probing `{n: 5.0}` there
+        // would miss every row storing `I64(5)` and return an authoritative
+        // empty result. Decline the index inside a write transaction and let
+        // the caller scan: the scan sees the same overlay, so it is correct,
+        // and it is exactly the cost numeric equality paid everywhere before.
+        // (Canonicalising `key_part` would also change unique-constraint
+        // conflict semantics, which is a separate decision.)
+        if probe_is_numeric(value) && self.transactional_property_index.is_some() {
+            crate::route_telemetry::record_property(false);
+            return Ok(IndexedPropertyLookup::Unavailable);
+        }
+
         let mut cursors: Vec<EqualityNodePostingCursor> = Vec::new();
         let mut advertised_source_entries: Option<usize> = None;
         let mut truncated_source_without_cursor = false;
@@ -1626,6 +1640,12 @@ impl<'mt> Snapshot<'mt> {
                         .equality_property_indices
                         .iter()
                         .find(|desc| desc.property == property && desc.mixed_type_complete)
+                        // A numeric probe needs a sidecar that actually
+                        // harvested numbers. On one written before numeric
+                        // equality was indexable the flag defaults to false,
+                        // so the whole lookup reports Unavailable and the
+                        // caller scans — correct, and exactly today's cost.
+                        .filter(|desc| !probe_is_numeric(value) || desc.numeric_complete)
                         .filter(|desc| equality_sidecar_key(desc.key_encoding, value).is_some())
                         .map(|desc| (*idx, desc))
                 })
@@ -1743,10 +1763,17 @@ impl<'mt> Snapshot<'mt> {
             }
             let views = self.batch_lookup_nodes(label, &batch).await?;
             for (id, view) in batch.into_iter().zip(views) {
-                if view
-                    .as_ref()
-                    .is_some_and(|view| view.properties.get(property) == Some(value))
-                {
+                // Cypher equality, not `==`. The canonical numeric key makes
+                // `I64(5)` and `F64(5.0)` share a posting BECAUSE they are the
+                // same Cypher value, so a typed `==` here would file them
+                // together and then throw one of them away. It is also what
+                // separates the false positives that key is lossy enough to
+                // admit: two i64 above 2^53 that round to the same f64.
+                if view.as_ref().is_some_and(|view| {
+                    view.properties
+                        .get(property)
+                        .is_some_and(|current| crate::cache::cypher_scalar_equal(current, value))
+                }) {
                     confirmed.push(id);
                     if confirmed.len() == target {
                         break;
@@ -2051,6 +2078,36 @@ impl<'mt> Snapshot<'mt> {
             .filter(|i| {
                 string_property_sidecar(&self.manifest.manifest.ssts[**i], label, property)
                     .is_some()
+            })
+            .count();
+        (covered, in_scope.len())
+    }
+
+    /// Numeric twin of [`Self::property_index_coverage`]: how many in-scope
+    /// node SSTs advertise a sidecar that actually harvested numbers, and can
+    /// therefore serve an Integer/Float equality instead of scanning.
+    ///
+    /// Lower than the String coverage exactly while older SSTs are still
+    /// waiting for the compaction that backfills their numeric postings.
+    pub fn numeric_property_index_coverage(&self, label: &str, property: &str) -> (usize, usize) {
+        let in_scope: Vec<usize> = self
+            .manifest
+            .index
+            .node_descriptors()
+            .into_iter()
+            .filter(|i| node_sst_can_contain_label(&self.manifest.manifest, *i, label))
+            .collect();
+        let covered = in_scope
+            .iter()
+            .filter(|i| {
+                self.manifest.manifest.ssts[**i]
+                    .equality_property_indices
+                    .iter()
+                    .any(|sidecar| {
+                        sidecar.property == property
+                            && sidecar.mixed_type_complete
+                            && sidecar.numeric_complete
+                    })
             })
             .count();
         (covered, in_scope.len())
@@ -9666,10 +9723,24 @@ fn equality_sidecar_key(
             _ => None,
         },
         crate::manifest::EqualityKeyEncoding::ScalarV1 => match value {
-            Value::Str(_) | Value::Bool(_) => crate::cache::encode_equality_property_value(value),
+            // Numerics are encodable under the same ScalarV1 key space (one
+            // canonical `n:` key for Integer and Float alike), but whether a
+            // GIVEN sidecar actually filed them is a per-descriptor fact:
+            // see `EqualityIndexDescriptor::numeric_complete`, checked by the
+            // caller. Encoding compatibility and coverage are separate gates.
+            Value::Str(_) | Value::Bool(_) | Value::I64(_) | Value::F64(_) => {
+                crate::cache::encode_equality_property_value(value)
+            }
             _ => None,
         },
     }
+}
+
+/// A probe value Cypher compares numerically, and which therefore requires
+/// the sidecar to advertise `numeric_complete` before its negative answer can
+/// be trusted.
+fn probe_is_numeric(value: &Value) -> bool {
+    matches!(value, Value::I64(_) | Value::F64(_))
 }
 
 /// Ids resolved per inner batch pass. Large enough that the batched
@@ -16694,6 +16765,7 @@ mod tests {
                 distinct_values: 1,
                 key_encoding: crate::manifest::EqualityKeyEncoding::StringV0,
                 mixed_type_complete: true,
+                numeric_complete: false,
                 format: crate::manifest::PropertyIndexFormat::BincodeV0,
                 paged: None,
                 paged_build_unsupported: false,

--- a/crates/namidb-storage/tests/manifest_rollback_204.rs
+++ b/crates/namidb-storage/tests/manifest_rollback_204.rs
@@ -159,6 +159,14 @@ fn manifest_205_round_trips_through_the_204_wire_prefix() {
         distinct_values: 2,
         key_encoding: EqualityKeyEncoding::ScalarV1,
         mixed_type_complete: true,
+        // Set on purpose: a sidecar that also harvested numbers must stay
+        // readable by a rolled-back 2.0.4 decoder, which knows nothing about
+        // the field. This is the reason numeric coverage is a NEW FIELD and
+        // not a new `EqualityKeyEncoding` variant — an unknown enum variant
+        // would fail the decode of the WHOLE manifest and strand the
+        // namespace, while an unknown field is ignored and the widened
+        // sidecar reads as the String/Bool index it has always been.
+        numeric_complete: true,
         format: PropertyIndexFormat::BincodeV0,
         paged: Some(PagedPropertyIndexDescriptor {
             path: "sst/level1/nodes-articles-vigente.pidx".into(),
@@ -329,6 +337,23 @@ fn manifest_205_round_trips_through_the_204_wire_prefix() {
         .is_none());
     assert!(legacy_json["ssts"][0]["equality_property_indices"][0]
         .get("key_encoding")
+        .is_none());
+    // A rolled-back reader drops numeric coverage entirely, exactly as it
+    // drops `key_encoding` and `mixed_type_complete`, and keeps probing the
+    // sidecar as the raw string posting map it has always understood. The
+    // widened body is a strict SUPERSET: its string keys are untouched, the
+    // extra tagged numeric keys are ones a 2.0.4 probe never forms, and
+    // numeric equality simply stays on the scan route it used there anyway.
+    //
+    // This is the whole reason numeric coverage is a new FIELD and not a new
+    // `EqualityKeyEncoding` variant: serde ignores an unknown field, but an
+    // unknown enum variant fails the decode of the entire manifest and would
+    // strand the namespace on rollback.
+    assert!(legacy_json["ssts"][0]["equality_property_indices"][0]
+        .get("numeric_complete")
+        .is_none());
+    assert!(legacy_json["ssts"][0]["equality_property_indices"][0]
+        .get("mixed_type_complete")
         .is_none());
 }
 

--- a/docs/testing/25tb-readiness.md
+++ b/docs/testing/25tb-readiness.md
@@ -1442,155 +1442,104 @@ If an exact-answer fast path is ever wanted, it needs a per-label
 sets when it recomputes from survivors. That does not exist today, and
 inventing it is a manifest format change.
 
-### 80. [OPEN — root cause found] Filtered scans prune nothing: the predicate never reaches storage
+### 80. [PARTLY FIXED in 2.6.14 — equality; ranges are a missing capability, not a wiring bug] Filtered scans prune nothing
 
-Measured at 160,000 nodes, one label, one projected column. The times do
-not depend on selectivity at all:
+Re-measured on 2.6.14, same 160,000-node fixture, `idx` declared as an
+index, one projected column:
 
-| query | rows returned | time |
-|---|---|---|
-| `WHERE t.idx > 999999` (outside every value in the store) | **0** | 0.377 s |
-| `WHERE t.idx < -5` (outside, low side) | **0** | 0.468 s |
-| `WHERE t.idx = 12345` | 1 | 0.375 s |
-| `WHERE t.idx > 159990` | 9 | 0.412 s |
-| `WHERE t.idx > 80000` | 79,999 | 0.417 s |
-| no filter (manifest fast path) | 160,000 | **0.001 s** |
+| query | rows | 2.6.13 | 2.6.14 | route |
+|---|---|---|---|---|
+| `WHERE t.idx = 12345` | 1 | 0.375 s | **0.000078 s** | index |
+| `{idx: 12345}` | 1 | — | **0.000060 s** | index |
+| `WHERE t.idx > 999999` (matches nothing) | 0 | 0.377 s | 0.311 s | scan |
+| `WHERE t.idx < -5` (matches nothing) | 0 | 0.468 s | 0.399 s | scan |
+| `WHERE t.idx > 159990` | 9 | 0.412 s | 0.292 s | scan |
+| `WHERE t.idx > 80000` | 79,999 | 0.417 s | 0.340 s | scan |
+| no filter (manifest fast path) | 160,000 | 0.001 s | 0.000030 s | — |
 
-A predicate that provably matches nothing costs the same as one matching
-half the store. Nothing is being skipped.
+**Equality is fixed** — by item 81, not by anything done here. What remains
+is RANGE predicates, and they are still completely insensitive to
+selectivity: a predicate matching nothing costs the same as one matching
+half the store.
 
-**Root cause, and it is not a missing feature — it is two implemented
-features that are not wired.**
+**THE DIAGNOSIS IN THE TWO PREVIOUS VERSIONS OF THIS ENTRY WAS WRONG, TWICE.**
+Both said this was a wiring problem — "two implemented features that are not
+wired". It is not. Recorded in full, because the wrong version would have
+sent someone to do work that cannot help:
 
-1. *Parquet row-group pruning.* `EnabledStatistics::Chunk` is configured
-   (sst/nodes.rs:1515) so per-row-group column statistics ARE written, and
-   `eval_row_group` + `PropertyColumnStats` (sst/predicates.rs:93) decide
-   Absent/MaybePresent from them. But the branch that serves a PROJECTED
-   scan — the common shape, and the one EXPLAIN shows here
-   (`projection=[idx] predicates=[t.idx > 159990]`) — builds a
-   `LimitedNodeBatchContext` carrying `predicates` and then opens the
-   stream with `node_scan_limited_async(..., &[], Some(&[]), ...)`
-   (read.rs:5735-5741): empty predicates, empty projection. Four of the
-   five call sites in read.rs pass `&[]`; only one passes `predicates`.
-2. *Property-page predicate filtering.* `NodePropertyPageReader::filter_node_ids`
-   (property_pages.rs:2088) and the whole `NodePropertyPredicate` IR
-   (property_pages.rs:255) are implemented and unit-tested — and **dead in
-   production**: the only callers are at property_pages.rs:3518 and 3541,
-   both inside the `#[cfg(test)]` module that begins at line 3372, and
-   `NodePropertyPredicate::` is never constructed anywhere outside its own
-   file.
+1. *"Wire the predicates into the projected-scan branch."* There is nothing
+   to wire them into. A node SST is written with an **empty LabelDef** and
+   therefore has **no `prop_*` columns at all** — flush.rs states it
+   outright: *"one identity-partitioned SST spanning every label, built with
+   an empty LabelDef (fixed layout — no prop_* columns; every property rides
+   in `__overflow_json`)"*. `node_arrow_schema` of an empty LabelDef is six
+   engine columns and nothing else, and
+   `scan_with_predicates_and_projection_async` rejects any file that does
+   not match it exactly. So there are no per-row-group property statistics
+   for `eval_row_group` to read: `node_scan_plan` resolves no column,
+   `PropertyColumnStats::empty` has `min`/`max` of `None`, and every arm of
+   `eval_row_group` answers `MaybePresent` when the bound is absent. Passing
+   the predicates through would prune exactly zero row groups.
 
-So a filtered projected scan reads and materialises every row and
-evaluates the predicate row-by-row.
+   (The `eval_row_group` / `synthesize_property_stats` machinery is not dead
+   code — it serves LEGACY label-scoped SSTs, whose `scope` names a single
+   label and whose LabelDef therefore does carry properties. The current
+   writer no longer produces those.)
 
-**Also measured: the cost is per-ROW, not per-byte.** `count(t.pad)` over
-a 900-byte string column costs 0.433 s against `count(t.idx)` over an
-8-byte integer column at 0.466 s — indistinguishable. Two columns cost
-0.676 s against one at 0.466 s. That is a fixed per-row overhead
-(materialisation into `Row` / `RuntimeValue`) dominating, which is why
-scalar aggregates (item 79) sit at ~0.47 s regardless of the column.
+2. *"Wire `NodePropertyPageReader::filter_node_ids`."* Its predicate IR is
+   `EqString`, `InString`, `EqBool`, `InBool`, and an explicit
+   `Unsupported` — **no range predicates of any kind**. It could not serve a
+   single one of the slow queries above, and for the equality shapes it does
+   support, the equality posting sidecar already does the job better.
 
-**What this means for finding #8.** The remaining work is not "build
-aggregation pushdown". It is, in order of value:
-1. Wire ONE of the two existing predicate paths into the projected-scan
-   branch. This makes every selective filter selective, not just
-   aggregates.
-2. Then consider vectorised aggregation over the decoded Arrow column, to
-   remove the per-row materialisation that item 79 measured.
+   The `.npp` pages also carry no per-property `min`/`max`: their page
+   metadata is size limits (`max_value_bytes`, `max_page_decoded_bytes`, …),
+   not value statistics.
 
-**The `&[]` is not an oversight — and knowing why is the whole handoff.**
-That branch reads properties from the `.npp` sidecar addressed by a
-RUNNING ROW ORDINAL:
+**An earlier same-day correction in this entry was also wrong** — it said
+the blocker was `label_def_for_node_sst` returning an empty property list
+for id-primary SSTs, and proposed resolving the predicate column against the
+manifest schema instead. That empty LabelDef is a faithful description of
+the file layout, not an oversight: resolving a column name that has no
+Parquet column would find nothing.
 
-    let mut next_ordinal = 0_u64;                      // read.rs:5754
-    ...
-    next_ordinal = next_ordinal.checked_add(batch.num_rows() as u64)
-    ...
-    if next_ordinal != desc.row_count {                // read.rs:5812
-        return Err(Error::invariant("node property/Parquet row-count mismatch"));
-    }
+**So this is a MISSING CAPABILITY.** Node properties have no value
+statistics anywhere in the current format — not in Parquet, not in the
+property pages. No layer can answer "this page cannot contain a value
+> 999999", so every range predicate reads every row.
 
-The ordinal must stay aligned with the sidecar, so the branch requires
-seeing EVERY row group — and it self-checks that it did. Handing Parquet
-the predicates would make it skip row groups, the ordinal would fall
-short, and that invariant would fire. So the current code is correct and
-defensive, not careless.
+**The path that does exist, and why 2.6.14 opened it.** The equality
+sidecar is a range-readable B+tree keyed by the encoded scalar, and
+`ordered_node_ids_by_string_property` already positions by value within it
+for `ORDER BY <string prop> LIMIT k`. Item 81's numeric key was made
+ORDER-PRESERVING for exactly this reason: `sortable_f64_bits` maps an f64
+onto a u64 whose unsigned order is the number's order, so the same B+tree
+can be positioned at `> x` for numbers too. Raw IEEE-754 bits would have
+sorted negatives backwards — which costs an equality probe nothing, and
+would have foreclosed every ordered read over those postings without anyone
+noticing until the format was already in the wild.
 
-**What wiring it therefore requires**: advancing `next_ordinal` by the row
-count of each SKIPPED row group (available in the footer metadata that
-this branch already fetches and caches), so the sidecar stays addressable.
-The existing invariant check is the safety net for getting it wrong — it
-turns a silent row loss into a hard error, which is why it should be kept
-and not relaxed.
+Order of work, corrected:
+1. An ordered/range numeric read over the equality sidecar — the twin of
+   `ordered_node_ids_by_string_property`, using the order-preserving key.
+   This serves `WHERE n.amount > x` on an INDEXED property, which is the
+   case operators actually declare an index for.
+2. Only then consider value statistics in the property pages, for ranges on
+   UNINDEXED properties. That is a storage-format change and wants its own
+   design.
+3. Separately, and still true from the original entry: the cost is per-ROW,
+   not per-byte — `count(t.pad)` over a 900-byte string column costs the
+   same as `count(t.idx)` over an 8-byte integer, and two columns cost more
+   than one. That is `Row`/`RuntimeValue` materialisation dominating, and it
+   is what caps every scalar aggregate at ~0.3 s regardless of the column.
+   Vectorised aggregation over the decoded Arrow column is the fix, and it
+   is independent of everything above.
 
-**Why this was not wired tonight.** Even with the accounting understood, a
-page- or row-group-level decision that disagrees with the row-level
-evaluation drops rows, which is the failure mode that produced five bugs
-in this codebase this week. It wants the equivalence harness pointed at it
-(filtered scan vs unfiltered-then-filter across a matrix of predicate
-shapes, types, nulls and absent properties) and an adversarial review —
-not the tail of an eleven-release day.
-
-**A caveat I got WRONG the first time, corrected here.** I originally wrote
-that nodes are id-primary so a property is "scattered across row groups in
-UUID order" and pruning could not help. That reasoning is false: `NodeId`
-is `Uuid::now_v7()` — TIME-ordered — so id order tracks insertion order,
-and a property written in a correlated order (a sale date, an incrementing
-code) lands in narrow per-row-group ranges. Pruning would help such a
-property a great deal.
-
-What is true is the measurement, and it survived a much better fixture:
-with `NAMIDB_NODE_SST_ROW_GROUP_ROWS=4096` (≈39 row groups instead of the
-2 the 128Ki default gives at 160k rows), an `idx` written in ascending
-order, and the property declared as an index so it is a physical column,
-the times are still flat — 0.331 s for a predicate matching nothing,
-0.321 s for one matching 9 rows, 0.330 s for one matching half. Nothing is
-pruned, and the reason is the one verified in the source above: the
-predicate never reaches Parquet.
-
-**Two notes for whoever picks this up.** First, the default row group is
-128Ki rows, so any fixture under ~500k rows has too few row groups to show
-pruning at all — set `NAMIDB_NODE_SST_ROW_GROUP_ROWS` when testing this.
-Second, the whole-node branch (`RETURN t`, which DOES pass `predicates`)
-is also insensitive to selectivity — 1.315 s at zero rows against 1.389 s
-at nine.
-
-**That second question is now ANSWERED (2026-09-11), and it means the
-projected branch is not the only gap — nor even the first one to fix.**
-`node_scan_plan` (sst/nodes.rs:749) resolves each predicate's column by
-looking it up in the `LabelDef` it is handed:
-
-    let prop = label.properties.iter().find(|p| p.name == col);
-    ...
-    None => PropertyColumnStats::empty(col),
-
-and that `LabelDef` comes from `label_def_for_node_sst` (read.rs:4494),
-which for an **id-primary SST — `scope == ""`, the modern layout — returns
-a LabelDef with an EMPTY property list**. So no predicate column is ever
-resolved to a Parquet column, every row group is evaluated against
-`PropertyColumnStats::empty`, and `eval_row_group` answers `MaybePresent`
-for every predicate shape because its `min`/`max` are both `None`
-(predicates.rs:93 onward — every arm falls through to `MaybePresent` when
-the bound is absent).
-
-**Row-group pruning is therefore dead on every id-primary SST, on BOTH
-branches**, regardless of the `&[]` in the projected branch. Passing the
-predicates through without fixing the LabelDef would change nothing.
-
-The fix is to resolve the predicate column against the manifest schema
-rather than a single label's definition — but conservatively: a property
-name declared with DIFFERENT types on different labels must NOT be
-resolved, because synthesizing stats under the wrong type could produce a
-WRONG `Absent` verdict, which is a dropped row rather than a slow query.
-`union_indexed_props` (flush.rs:623) is the existing precedent for
-building that union, and item 81 has just made its type tie-break
-load-bearing for a related reason.
-
-Order of work, revised:
-1. Resolve the predicate column on id-primary SSTs (both branches benefit;
-   the whole-node branch needs nothing else).
-2. Then the projected branch's ordinal accounting, as described above.
-3. Then vectorised aggregation over the decoded Arrow column.
+**A note for whoever picks this up**: the default row group is 128Ki rows,
+so any fixture under ~500k rows has too few row groups to show row-group
+pruning at all. That mattered for the original (wrong) framing; it does not
+change the conclusion, since the layout carries no property statistics at
+any row-group count.
 
 ### 81. [FIXED in 2.6.14] Numeric equality never uses an index
 

--- a/docs/testing/25tb-readiness.md
+++ b/docs/testing/25tb-readiness.md
@@ -1556,62 +1556,127 @@ is also insensitive to selectivity — 1.315 s at zero rows against 1.389 s
 at nine — so something blocks pruning there too and it was not determined.
 Establish that before assuming the projected branch is the only gap.
 
-### 81. [OPEN — highest remaining value, fully scoped] Numeric equality never uses an index
+### 81. [FIXED in 2.6.14] Numeric equality never uses an index
 
 Same data, same cardinality, an index declared on both properties, 160,000
 nodes where each row carries the same key as a string and as an integer:
 
-| query | time | route |
+| query | before | after |
 |---|---|---|
-| `MATCH (t:STR {txt: '12345'})` | **0.001 s** | index, posting lookup |
-| `MATCH (t:STR {num: 12345})` | **1.603 s** | full scan |
+| `MATCH (t:STR {txt: '12345'})` | 0.001 s | 0.000107 s |
+| `MATCH (t:STR {num: 12345})` | **1.603 s** | **0.000080 s** |
 
-**1600x, purely because the property is numeric.** EXPLAIN says so in
+**1600x, purely because the property was numeric.** EXPLAIN said so in
 plain text: *"numeric equality is not posting-indexed; only String/Bool
-are"*. `CREATE INDEX ... ON (n.numeric_prop)` is accepted and does
-nothing for equality.
+are"*. `CREATE INDEX ... ON (n.numeric_prop)` was accepted and did nothing
+for equality.
 
-For a retail or clinical graph this is most of the schema — quantities,
-prices, amounts, numeric product codes, foreign keys. Note the reporter's
-own `cod_item` is a STRING (`'100565537'`), which is why their constraint
-lookups were fast; any numeric property they index gets nothing.
+For a retail or clinical graph that is most of the schema — quantities,
+prices, amounts, numeric product codes, foreign keys. The reporter's own
+`cod_item` is a STRING (`'100565537'`), which is why their constraint
+lookups were fast; any numeric property they indexed got nothing.
 
-**This is a performance gap only — the scan path is CORRECT.** Verified by
-a 102-combination filter-vs-expression sweep after the 2.6.12 coercion
-fix: every operator and type agrees. So this can be left open safely.
+Numeric equality is now served by the same posting sidecars a string key
+uses. Measured in-process against the route it used to be forced onto, on
+160k rows: **525 ms scan vs 80 us index, 6561x** (the ignored measurement
+test `numeric_equality_is_not_orders_of_magnitude_slower_than_string`).
+It is now marginally FASTER than its string twin, because the canonical
+numeric key is a fixed 16 hex characters while a string key is raw and
+variable-length.
 
-**What it actually requires** — five coordinated places, each of which can
-silently drop rows if it disagrees with the others:
+**How it works.** One canonical key per numeric value: both `I64(5)` and
+`F64(5.0)` encode to `n:{f64 bits}`, because Cypher says they are equal
+and two values that compare equal MUST share a posting or the index route
+drops rows the scan returns. Above 2^53 that key is lossy and distinct
+integers collide — a deliberate FALSE POSITIVE, removed at confirm time by
+`cypher_scalar_equal`, the same function TupleV1 already used for
+composite members.
 
-1. *Harvester filter*, flush.rs (~1847) and compact.rs (~571): both hard
-   `matches!(p.data_type, Utf8 | LargeUtf8 | Bool)`. Compaction re-derives
-   sidecars from scratch, so a flush-only change vanishes at the first
-   merge.
-2. *Key encoding*, `encode_equality_property_value`: it ALREADY handles
-   I64/F64/Date/DateTime/Bytes with order-preserving encodings — but it
-   emits `i:{hex}` for an integer and `f:{hex}` for a float, so `5` and
-   `5.0` produce DIFFERENT keys while Cypher says they are equal. The
-   composite path already solved exactly this: TupleV1 canonicalises
-   numeric members to f64 and confirms with coercing equality (recorded
-   above under the composite-index work). The single-property index needs
-   the same canonicalisation. Collisions from i64 values beyond 2^53 are
-   safe *provided* the confirm step (3) actually filters.
-3. **THE TRAP** — `batch_confirm_multi_candidates` (read.rs ~2775) filters
-   candidates with
-   `matches!(view.properties.get(property), Some(Value::Str(current)) if current == &value)`.
-   It matches `Value::Str` and NOTHING ELSE. Widening the index without
-   widening this makes every numeric lookup confirm zero candidates and
-   return an empty result — silently. This is the single most dangerous
-   line in the change.
-4. *Planner route*, the rule behind the EXPLAIN note (plan/explain.rs
-   ~1061 and the matching decision in `optimize/unique_lookup.rs`).
-5. *Back-compat*, which is unusually easy here: existing sidecars contain
-   NO numeric keys at all, so widening ADDS keys without changing any
-   existing one. `EqualityIndexDescriptor.key_encoding` already exists for
-   versioning if a canonical numeric encoding needs its own tag.
+**What the scoped plan got right, and what it got wrong.** Worth recording,
+because four of the five scoped places turned out to be somewhere else:
 
-**Acceptance before this ships**: the equivalence harness pointed at
-indexed-vs-unindexed results for numeric equality across Int/Float
-spellings, integral floats, values beyond 2^53, negatives, and a
-string-vs-number pair that must NOT match — plus the same after flush AND
-after compaction, since (1) means the two writers must agree.
+1. *Harvester filter* — correct, and both writers did have to change
+   together. They share ONE collector (`EqualitySidecarCollector`, imported
+   by compact.rs from flush.rs), so a single edit covered both. The
+   declaration gate widened to Int32/Int64/Float32/Float64; the runtime
+   harvest for those properties widened to I64/F64 **on top of** the
+   String/Bool baseline, which stays because such a property can still hold
+   a legacy string that a string probe must not miss.
+2. *Key encoding* — correct. Canonicalised as described above.
+3. **THE TRAP was real but in the wrong place.** The `Value::Str`-only
+   filter in `batch_confirm_multi_candidates` sits on the string-typed
+   BATCH API, which numerics never reach. The confirm that actually
+   mattered was `view.properties.get(property) == Some(value)` in
+   `indexed_node_ids_by_property_value_inner` — a TYPED `==`, which would
+   have filed `5` and `5.0` together under the canonical key and then
+   thrown one of them away. It is now `cypher_scalar_equal`.
+4. *Planner route* — **there was no planner gate.** The optimizer already
+   emitted `NodeByPropertyValue` for numeric literals; `unique_lookup.rs`
+   never excluded them. The EXPLAIN note was simply describing a decision
+   made three layers down, and was replaced with real coverage reporting.
+5. *Back-compat* — **`key_encoding` was the wrong versioning hook.** It is
+   an externally-tagged enum, so a rolled-back reader meeting an unknown
+   variant fails to deserialise the WHOLE manifest and cannot open the
+   namespace. Coverage is a new `#[serde(default)] numeric_complete` field
+   instead: serde ignores an unknown field, the widened sidecar is a strict
+   superset, and a pre-numeric reader keeps probing its string keys exactly
+   as completely as before. Asserted in `manifest_rollback_204`.
+
+**The place the scope missed entirely** — and the actual reason nothing
+reached storage: `non_numeric_index_value` in exec/walker.rs dropped every
+non-string probe before the index path was attempted, so neither route
+counter even moved. Now `indexable_probe_value`, which admits numbers
+(NaN excepted: it equals nothing in Cypher and has no canonical key).
+
+**A second missed interaction, closed by measurement of the code rather
+than by the plan.** `ordered_node_ids_by_string_property` walks the same
+sidecar in KEY order for `ORDER BY <string prop> LIMIT k`. Tagged numeric
+keys filed into a sidecar it reads would sort among raw strings. They
+cannot be: the declaration gate scopes numeric harvesting to
+numeric-declared properties, and that iterator admits only Utf8/LargeUtf8
+ones. `union_indexed_props` already resolved a property declared numeric
+on one label and text on another IN FAVOUR of text — written for another
+reason, but exactly the right tie-break here, and now documented as
+load-bearing with a test
+(`a_string_declaration_downgrades_a_same_named_numeric_index`). The cost
+is a numeric index quietly downgraded to the scan whenever another label
+declares the same property name as a string; `numeric_complete` reports
+that honestly, so EXPLAIN shows the scan fallback instead of claiming an
+index that is not there.
+
+**Migration.** Existing SSTs carry no numeric keys and report
+`numeric_complete: false`, so numeric equality on them keeps the scan
+route — correct, at exactly today's cost. The DDL-backfill arm in
+`node_descriptor_needs_non_record_migration` now also demands numeric
+coverage for a numeric-declared indexed property, so the next compaction
+pass rewrites those buckets and the postings materialise on pre-existing
+data. EXPLAIN reports the interim state as
+`numeric postings {covered}/{total} SSTs`.
+
+**Acceptance**: `crates/namidb-query/tests/numeric_equality_index.rs` —
+13 indexed-vs-unindexed spellings that must return identical multisets
+(Int/Float spellings, integral floats, fractional floats, negatives,
+`-0.0` vs `0.0`, a string-vs-number pair that must NOT match, NULL, `IN`,
+and the two i64 beyond 2^53 that share a key), run at memtable, after
+flush, AND after compaction — plus a plan-shape assertion that the query
+anchors on `NodeByPropertyValue` with no `NodeScan`, and a route-counter
+assertion that the lookup is served natively. Result parity alone would
+have passed with the fix reverted; the scan is already correct.
+
+**Follow-up, deliberately not taken here.** Numerics take one posting
+lookup per distinct value instead of joining the batched string path: the
+batch entry points (`batch_lookup_nodes_by_property*`) are `&[String]`-
+typed, and their confirm/group helpers filter on `Value::Str` in ten
+places in read.rs. A correlated `UNWIND $keys ... MATCH (n {num: key})`
+over N distinct numeric keys therefore costs N posting probes rather than
+one batch — vastly better than N full scans, but not yet at string parity.
+Making that change means widening the string-typed API surface and all ten
+confirm sites at once; it is a larger blast radius than this item needed,
+and the accounting is asserted explicitly in
+`global_correlated_match_batches_direct_set_and_delete_with_rollback`.
+
+**The search-LSM prefilter is deliberately untouched.** Its native-filter
+property list feeds the catalog signature, so widening it retires every
+vector/text generation for rebuild. Its numeric exclusion is locked by
+`vector_prefilter_never_narrows_cross_typed_numeric_equality` and should
+be lifted with that subsystem.

--- a/docs/testing/25tb-readiness.md
+++ b/docs/testing/25tb-readiness.md
@@ -1553,8 +1553,44 @@ predicate never reaches Parquet.
 pruning at all — set `NAMIDB_NODE_SST_ROW_GROUP_ROWS` when testing this.
 Second, the whole-node branch (`RETURN t`, which DOES pass `predicates`)
 is also insensitive to selectivity — 1.315 s at zero rows against 1.389 s
-at nine — so something blocks pruning there too and it was not determined.
-Establish that before assuming the projected branch is the only gap.
+at nine.
+
+**That second question is now ANSWERED (2026-09-11), and it means the
+projected branch is not the only gap — nor even the first one to fix.**
+`node_scan_plan` (sst/nodes.rs:749) resolves each predicate's column by
+looking it up in the `LabelDef` it is handed:
+
+    let prop = label.properties.iter().find(|p| p.name == col);
+    ...
+    None => PropertyColumnStats::empty(col),
+
+and that `LabelDef` comes from `label_def_for_node_sst` (read.rs:4494),
+which for an **id-primary SST — `scope == ""`, the modern layout — returns
+a LabelDef with an EMPTY property list**. So no predicate column is ever
+resolved to a Parquet column, every row group is evaluated against
+`PropertyColumnStats::empty`, and `eval_row_group` answers `MaybePresent`
+for every predicate shape because its `min`/`max` are both `None`
+(predicates.rs:93 onward — every arm falls through to `MaybePresent` when
+the bound is absent).
+
+**Row-group pruning is therefore dead on every id-primary SST, on BOTH
+branches**, regardless of the `&[]` in the projected branch. Passing the
+predicates through without fixing the LabelDef would change nothing.
+
+The fix is to resolve the predicate column against the manifest schema
+rather than a single label's definition — but conservatively: a property
+name declared with DIFFERENT types on different labels must NOT be
+resolved, because synthesizing stats under the wrong type could produce a
+WRONG `Absent` verdict, which is a dropped row rather than a slow query.
+`union_indexed_props` (flush.rs:623) is the existing precedent for
+building that union, and item 81 has just made its type tie-break
+load-bearing for a related reason.
+
+Order of work, revised:
+1. Resolve the predicate column on id-primary SSTs (both branches benefit;
+   the whole-node branch needs nothing else).
+2. Then the projected branch's ordinal accounting, as described above.
+3. Then vectorised aggregation over the decoded Arrow column.
 
 ### 81. [FIXED in 2.6.14] Numeric equality never uses an index
 

--- a/docs/testing/25tb-readiness.md
+++ b/docs/testing/25tb-readiness.md
@@ -1716,3 +1716,60 @@ property list feeds the catalog signature, so widening it retires every
 vector/text generation for rebuild. Its numeric exclusion is locked by
 `vector_prefilter_never_narrows_cross_typed_numeric_equality` and should
 be lifted with that subsystem.
+
+### 82. [FIXED in 2.6.14] `POST /v0/admin/compact` returned 500 after a `CREATE INDEX`
+
+Found while wiring the item 81 migration path into the EXPLAIN surface
+test — which is to say, found by trying to USE the migration the release
+notes describe. The admin drain answered a DDL-triggered compaction with
+
+    500 {"error":"compaction failed: precondition failed: abandoning
+         prepared compaction: Nodes input <uuid> is missing or ambiguous"}
+
+Reproduction: seed rows -> `POST /v0/admin/flush` -> `CREATE INDEX ... FOR
+(p:Label) ON (p.prop)` -> `POST /v0/admin/compact`. That is exactly the
+sequence an operator runs — "I declared the index, now materialize it".
+
+**Pre-existing, and not item 81's doing.** It reproduces with the numeric
+rewrite trigger disabled. What the DDL adds is `needs_compaction() == true`
+via the item-38 backfill arm, so the DDL rewrite path runs at all.
+
+**Root cause: a lost install race reported as a failure.** `CREATE INDEX`
+schedules its OWN backfill pass (lib.rs:3361, the item-38 trigger). The
+admin drain does not go through `CompactionScheduler::admit` — it calls
+`run_compaction_pass` directly — and `compaction_guard()` is a READ guard,
+held by both, which excludes the orphan janitor and not another compactor.
+So the two run concurrently, the DDL worker installs first, and the drain's
+prepared plan names an input the winner already merged away.
+`run_compaction_pass` already labels that `CompactionStatus::Stale` — "a
+competing compaction won the install race" — and then returned it as an
+error, which `drain_compaction` turned into a 500 whenever it happened on
+the FIRST pass (`summary.passes` counts only `Applied`).
+
+**Fix.** Losing the race is not a failure of the drain: the merge it
+prepared was performed by whoever won. It now re-prepares against the
+manifest they left, bounded by `MAX_CONSECUTIVE_RACES_LOST = 8` because
+each retry pays a full prepare, and reports `races_lost` in the drain
+summary so a drain that spends its passes losing races stays visible.
+
+The error messages in `verify_node_rewrite_inputs` now name the basis
+version, the manifest version, and the number of Nodes SSTs, and separate
+"no longer present" (a lost race, benign) from "changed between prepare and
+install" and from a genuinely duplicated id, which is an invariant
+violation rather than a precondition. The original "missing or ambiguous"
+conflated three different problems and cost a long diagnosis; with the new
+message the cause read directly off the failure: *basis v5 … no longer in
+manifest v6*.
+
+Pinned by `admin_compact_survives_the_ddl_backfill_pass_it_races`
+(crates/namidb-server/tests/ddl_index_backfill.rs), verified non-inert by
+reverting the retry and watching it fail. The EXPLAIN surface test now also
+drives the whole migration over HTTP: DDL -> `numeric postings 0/N` ->
+admin compact -> `→ index`.
+
+**Not changed, and worth stating.** The deeper fix is to make the admin
+drain participate in scheduler admission so it cannot run beside a
+background worker at all. That touches the admission state machine
+(leases, coalescing, pending follow-ups) and is a larger change than this
+defect needs; the retry is correct regardless, since an external writer can
+always win a race the drain does not control.


### PR DESCRIPTION
`CREATE INDEX` on a numeric property was accepted and did nothing for equality.

On 160,000 rows carrying the same key as a string and as an integer, with an index declared on both:

| query | before | after |
|---|---|---|
| `MATCH (t {txt: '12345'})` | 0.001 s | 0.000107 s |
| `MATCH (t {num: 12345})` | **1.603 s** | **0.000080 s** |

**1600x, purely because the property was numeric.** EXPLAIN said so in plain text: *"numeric equality is not posting-indexed; only String/Bool are"*. For a retail or clinical schema — quantities, prices, amounts, numeric product codes, foreign keys — that is most of the schema.

Measured in-process against the route numeric equality used to be forced onto, on 160k rows: **525 ms scan vs 80 µs index (6561x)**. It is now marginally faster than its string twin, because the canonical numeric key is a fixed 16 hex characters while a string key is raw and variable-length.

## How

`5` and `5.0` are one Cypher value, so both encode to one canonical key and share a posting — the same canonicalisation TupleV1 already uses for composite members. Above 2^53 that key is lossy and distinct integers can collide; every candidate is re-confirmed with `cypher_scalar_equal`, so a collision costs a wasted candidate and never a wrong row.

The confirm step moves off typed `==` for the same reason: under the canonical key it would have filed `5` and `5.0` together and then discarded one.

## Back-compat

Coverage is a new optional manifest field, **not** a new `EqualityKeyEncoding` variant. `key_encoding` is an externally-tagged serde enum — a rolled-back reader meeting an unknown variant fails to deserialise the *whole* manifest and cannot open the namespace. An unknown field is ignored, and the widened sidecar is a strict superset whose string answers stay exactly as complete. Asserted in `manifest_rollback_204`.

Existing SSTs report no numeric coverage and keep the scan route — correct, at exactly today's cost — until the DDL-backfill trigger rewrites them. EXPLAIN reports the interim state as `numeric postings {covered}/{total} SSTs`.

## Two places that decline the route on purpose

- A property declared numeric on one label and textual on another keeps the scan, so no tagged numeric key lands in a sidecar that `ordered_node_ids_by_string_property` walks in key order for `ORDER BY <string prop> LIMIT k`. `union_indexed_props` already resolved that tie in favour of text; it is now documented as load-bearing, with a test.
- Inside a write transaction the overlay keys `I64(5)` and `F64(5.0)` apart (`unique_index::key_part`), so `{num: 5.0}` would have returned an authoritative **empty** result while the scan returned the `I64(5)` rows. Storage declines the index there; the scan sees the same uncommitted writes. Caught by the test stage added for it — verified non-inert by reverting the guard and watching `[memtable/staged]` fail.

## Acceptance

`crates/namidb-query/tests/numeric_equality_index.rs` — 13 indexed-vs-unindexed spellings that must return identical multisets (Int/Float spellings, integral floats, fractional floats, negatives, `-0.0` vs `0.0`, a string-vs-number pair that must NOT match, NULL, `IN`, and the two i64 beyond 2^53 that share a key), at memtable, after flush, after compaction, and through the transactional overlay — plus a plan-shape assertion (`NodeByPropertyValue`, no `NodeScan`) and a route-counter assertion. Result parity alone passes with the whole change reverted; the scan was already correct.

Full `namidb-storage` and `namidb-query` suites green; workspace clippy clean, and clean again under `--features vector-index,text-index`.

## Not taken here

- Numerics take one posting probe per distinct value instead of joining the batched string path — the batch entry points are `&[String]`-typed and ten confirm/group helpers filter on `Value::Str`. Still vastly better than N full scans; the accounting is asserted explicitly in `global_correlated_match_batches_direct_set_and_delete_with_rollback`.
- The search-LSM native-filter catalog stays string-only: its property list feeds the catalog signature, so widening it would retire every vector/text generation for rebuild.