### PR TITLE
perf: serve indexed numeric ranges from the posting index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,54 @@ crates.io release will establish and document that API explicitly.
 
 ## [Unreleased]
 
+## [2.6.15] - 2026-09-11
+
+### Performance
+
+- **A range predicate on an indexed numeric property is now served by the
+  index instead of reading every row.** `WHERE n.amount > 1000`,
+  `WHERE n.fecha >= ... AND n.fecha < ...`, `WHERE n.stock < 5` — the shapes
+  a retail or clinical schema is built on — were completely insensitive to
+  selectivity: on 160,000 rows, a predicate matching NOTHING cost 0.311 s and
+  one matching half cost 0.340 s.
+
+  | query | before | after |
+  |---|---|---|
+  | `WHERE t.idx > 999999` (0 rows) | 0.311 s | 0.000068 s |
+  | `WHERE t.idx < -5` (0 rows) | 0.399 s | 0.000053 s |
+  | `WHERE t.idx > 159990` (9 rows) | 0.292 s | 0.000109 s |
+  | `WHERE t.idx > 1000 AND t.idx < 1100` (99 rows) | ~0.4 s | 0.000527 s |
+  | `WHERE t.idx > 80000` (79,999 rows) | 0.340 s | scan, declined |
+
+  The equality sidecar is a range-readable B+tree and its numeric key is
+  order-preserving, so a key window is a value window: the reader descends
+  once to the lower bound and walks the leaf level forward, reading the
+  matching keys rather than the corpus.
+
+  Candidates are confirmed with the same evaluator the scan uses, so the two
+  routes cannot disagree — necessary, because the candidate set is
+  deliberately a superset (the key is lossy above 2^53, a posting can name a
+  stale version, and a raw string key can fall inside the numeric window).
+
+  The route declines, and the scan runs as before, whenever it cannot be
+  authoritative or cannot win: an unindexed property, a sidecar without
+  numeric coverage, an open write transaction, or a window too wide relative
+  to the label. That threshold scales with the label's live row count, which
+  the manifest already carries.
+
+  A range on an UNINDEXED property is unchanged and still reads every row.
+  Node SSTs carry no per-property columns and the property pages carry no
+  value statistics, so there is nothing to prune on; closing that is a
+  storage-format change.
+
+### Fixed
+
+- **A negative literal bound never reached storage as a predicate.**
+  `WHERE n.amount < -5` parses the sign as a unary operator, and predicate
+  pushdown accepted only bare literals, so every negative bound — a
+  temperature, a delta, a debit — was left entirely to the residual filter.
+  `-i64::MIN` still is, rather than wrapping into a positive bound.
+
 ## [2.6.14] - 2026-09-11
 
 ### Performance
@@ -3473,7 +3521,8 @@ Change License: Apache License 2.0).
 - LDBC-shaped synthetic benchmark harness with a paired Kùzu runner
   under [`bench/`](./bench/).
 
-[Unreleased]: https://github.com/namidb/namidb/compare/v2.6.14...HEAD
+[Unreleased]: https://github.com/namidb/namidb/compare/v2.6.15...HEAD
+[2.6.15]: https://github.com/namidb/namidb/compare/v2.6.14...v2.6.15
 [2.6.14]: https://github.com/namidb/namidb/compare/v2.6.13...v2.6.14
 [2.6.13]: https://github.com/namidb/namidb/compare/v2.6.12...v2.6.13
 [2.6.12]: https://github.com/namidb/namidb/compare/v2.6.11...v2.6.12

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2199,7 +2199,7 @@ dependencies = [
 
 [[package]]
 name = "namidb"
-version = "2.6.14"
+version = "2.6.15"
 dependencies = [
  "namidb-core",
  "namidb-graph",
@@ -2209,7 +2209,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-ann"
-version = "2.6.14"
+version = "2.6.15"
 dependencies = [
  "namidb-core",
  "rand 0.8.6",
@@ -2222,7 +2222,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-bench"
-version = "2.6.14"
+version = "2.6.15"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2246,7 +2246,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-bolt"
-version = "2.6.14"
+version = "2.6.15"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2266,7 +2266,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-cli"
-version = "2.6.14"
+version = "2.6.15"
 dependencies = [
  "anyhow",
  "clap",
@@ -2286,7 +2286,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-core"
-version = "2.6.14"
+version = "2.6.15"
 dependencies = [
  "arrow-array",
  "arrow-schema",
@@ -2302,7 +2302,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-graph"
-version = "2.6.14"
+version = "2.6.15"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -2324,7 +2324,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-markdown"
-version = "2.6.14"
+version = "2.6.15"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2347,7 +2347,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-mcp"
-version = "2.6.14"
+version = "2.6.15"
 dependencies = [
  "anyhow",
  "clap",
@@ -2367,7 +2367,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-py"
-version = "2.6.14"
+version = "2.6.15"
 dependencies = [
  "bytes",
  "chrono",
@@ -2385,7 +2385,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-query"
-version = "2.6.14"
+version = "2.6.15"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2409,7 +2409,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-server"
-version = "2.6.14"
+version = "2.6.15"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2449,7 +2449,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-storage"
-version = "2.6.14"
+version = "2.6.15"
 dependencies = [
  "anyhow",
  "arrow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2.6.14"
+version = "2.6.15"
 edition = "2021"
 rust-version = "1.85"
 license = "BUSL-1.1"
@@ -123,13 +123,13 @@ tower = { version = "0.5", features = ["limit"] }
 tower-http = { version = "0.6", features = ["trace", "cors", "timeout"] }
 
 # Local workspace crates
-namidb-core = { path = "crates/namidb-core", version = "2.6.14" }
-namidb-storage = { path = "crates/namidb-storage", version = "2.6.14" }
-namidb-markdown = { path = "crates/namidb-markdown", version = "2.6.14" }
-namidb-graph = { path = "crates/namidb-graph", version = "2.6.14" }
-namidb-ann = { path = "crates/namidb-ann", version = "2.6.14" }
-namidb-query = { path = "crates/namidb-query", version = "2.6.14" }
-namidb-bolt = { path = "crates/namidb-bolt", version = "2.6.14" }
+namidb-core = { path = "crates/namidb-core", version = "2.6.15" }
+namidb-storage = { path = "crates/namidb-storage", version = "2.6.15" }
+namidb-markdown = { path = "crates/namidb-markdown", version = "2.6.15" }
+namidb-graph = { path = "crates/namidb-graph", version = "2.6.15" }
+namidb-ann = { path = "crates/namidb-ann", version = "2.6.15" }
+namidb-query = { path = "crates/namidb-query", version = "2.6.15" }
+namidb-bolt = { path = "crates/namidb-bolt", version = "2.6.15" }
 
 [profile.release]
 opt-level = 3

--- a/crates/namidb-py/pyproject.toml
+++ b/crates/namidb-py/pyproject.toml
@@ -7,7 +7,7 @@ name = "namidb"
 # Keep in sync with the workspace `version` in /Cargo.toml.
 # `python-wheels.yml` publishes a wheel whose filename uses THIS
 # version; the release tag `py-vX.Y.Z` must match X.Y.Z exactly.
-version = "2.6.14"
+version = "2.6.15"
 description = "Cloud-native graph database on object storage (Python bindings)"
 readme = "README.md"
 license = "BUSL-1.1"

--- a/crates/namidb-query/src/optimize/parquet_pushdown.rs
+++ b/crates/namidb-query/src/optimize/parquet_pushdown.rs
@@ -17,7 +17,7 @@
 use namidb_storage::sst::predicates::ScanPredicate;
 use namidb_storage::sst::stats::StatScalar;
 
-use crate::parser::ast::{BinaryOp, Expression, ExpressionKind, Literal};
+use crate::parser::ast::{BinaryOp, Expression, ExpressionKind, Literal, UnaryOp};
 
 /// Split `pending` into (a) conjuncts that translate to `ScanPredicate`
 /// against `alias` and (b) the residual that must remain as a Filter.
@@ -79,12 +79,16 @@ fn try_binary_to_predicate(
     alias: &str,
 ) -> Option<ScanPredicate> {
     // Try (Property OP Literal). Then try mirror (Literal OP Property).
-    if let (Some(column), Some(lit)) = (property_column_for_alias(left, alias), literal_of(right)) {
-        let value = literal_to_stat_scalar(lit)?;
+    if let (Some(column), Some(value)) = (
+        property_column_for_alias(left, alias),
+        scalar_bound_of(right),
+    ) {
         return predicate_for_binary(op, column, value, /*literal_on_right=*/ true);
     }
-    if let (Some(column), Some(lit)) = (property_column_for_alias(right, alias), literal_of(left)) {
-        let value = literal_to_stat_scalar(lit)?;
+    if let (Some(column), Some(value)) = (
+        property_column_for_alias(right, alias),
+        scalar_bound_of(left),
+    ) {
         return predicate_for_binary(op, column, value, /*literal_on_right=*/ false);
     }
     None
@@ -145,6 +149,28 @@ fn literal_of(expr: &Expression) -> Option<&Literal> {
         ExpressionKind::Literal(lit) => Some(lit),
         _ => None,
     }
+}
+
+/// A literal bound, folding a unary minus over a numeric literal.
+///
+/// `WHERE n.idx < -5` parses the sign as a unary operator, not as part of the
+/// literal, so a bare [`literal_of`] sees no literal at all and the whole
+/// predicate stays a residual filter. Every negative bound — a temperature, a
+/// delta, a debit — was therefore invisible to pushdown.
+fn scalar_bound_of(expr: &Expression) -> Option<StatScalar> {
+    if let ExpressionKind::Unary { op, expr: operand } = &expr.kind {
+        if *op == UnaryOp::Neg {
+            return match literal_of(operand)? {
+                // `-i64::MIN` has no i64: leave it to the residual filter
+                // rather than wrapping into a positive bound.
+                Literal::Integer(n) => n.checked_neg().map(StatScalar::Int64),
+                Literal::Float(f) => Some(StatScalar::Float64(-*f)),
+                _ => None,
+            };
+        }
+        return None;
+    }
+    literal_to_stat_scalar(literal_of(expr)?)
 }
 
 /// Pluck a list of literals out of `[1, 2, 3]`-style expressions for

--- a/crates/namidb-query/tests/numeric_range_route.rs
+++ b/crates/namidb-query/tests/numeric_range_route.rs
@@ -1,0 +1,225 @@
+//! Item 80: a range predicate on an indexed numeric property must be served
+//! by the posting index, and must return exactly what the scan returns.
+//!
+//! Measured on 160,000 rows with `idx` indexed, before and after:
+//!
+//! | query | before | after |
+//! |---|---|---|
+//! | `WHERE t.idx > 999999` (0 rows) | 0.311 s | 0.000068 s |
+//! | `WHERE t.idx < -5` (0 rows) | 0.399 s | 0.000053 s |
+//! | `WHERE t.idx > 159990` (9 rows) | 0.292 s | 0.000109 s |
+//! | `WHERE t.idx > 80000` (79,999 rows) | 0.340 s | scan, declined |
+//!
+//! Two halves, both load-bearing, same as the equality suite:
+//!
+//!   1. EQUIVALENCE against an UNINDEXED twin holding identical values. The
+//!      scan is already right, so this passes before the change; its job is
+//!      to guard the new route, whose candidate set is deliberately a
+//!      superset (a lossy key above 2^53, stale postings, and raw String
+//!      keys inside the numeric byte window).
+//!   2. NON-INERT: the route counter must actually move, or the agreement is
+//!      the trivial kind where everything declined to the scan.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use namidb_core::id::{NamespaceId, NodeId};
+use namidb_core::value::Value as CoreValue;
+use namidb_storage::{route_telemetry, NamespacePaths, NodeWriteRecord, WriterSession};
+use object_store::memory::InMemory;
+use object_store::ObjectStore;
+
+use namidb_query::{execute, lower, optimize, parse, Params, Row, RuntimeValue, StatsCatalog};
+
+const ROWS: i64 = 3_000;
+
+fn thing(idx: i64, tag: &str) -> NodeWriteRecord {
+    NodeWriteRecord {
+        properties: BTreeMap::from([
+            // `idx` is indexed; `uidx` carries the SAME values with no index,
+            // so its spelling is always served by the scan.
+            ("idx".to_string(), CoreValue::I64(idx)),
+            ("uidx".to_string(), CoreValue::I64(idx)),
+            ("tag".to_string(), CoreValue::Str(tag.to_string())),
+        ]),
+        schema_version: 1,
+        ..Default::default()
+    }
+}
+
+fn odd(idx: CoreValue, uidx: CoreValue, tag: &str) -> NodeWriteRecord {
+    NodeWriteRecord {
+        properties: BTreeMap::from([
+            ("idx".to_string(), idx),
+            ("uidx".to_string(), uidx),
+            ("tag".to_string(), CoreValue::Str(tag.to_string())),
+        ]),
+        schema_version: 1,
+        ..Default::default()
+    }
+}
+
+async fn corpus(name: &str) -> WriterSession {
+    let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    let paths = NamespacePaths::new("tenants", NamespaceId::new(name).unwrap());
+    let mut writer = WriterSession::open(store, paths).await.unwrap();
+
+    for ordinal in 0..ROWS {
+        writer
+            .upsert_node("T", NodeId::new(), &thing(ordinal, &format!("r{ordinal}")))
+            .unwrap();
+    }
+    // The values a key-window walk can pick up by accident, or miss.
+    for (value, tag) in [
+        (CoreValue::F64(10.5), "fractional"),
+        (CoreValue::F64(20.0), "integral-float"),
+        (CoreValue::F64(-3.25), "negative-float"),
+        (CoreValue::I64(-7), "negative-int"),
+        (CoreValue::Str("500".into()), "string-on-numeric"),
+        (CoreValue::Null, "null"),
+        (CoreValue::I64(9_007_199_254_740_992), "big-low"),
+        (CoreValue::I64(9_007_199_254_740_993), "big-high"),
+    ] {
+        writer
+            .upsert_node("T", NodeId::new(), &odd(value.clone(), value, tag))
+            .unwrap();
+    }
+    writer.commit_batch().await.unwrap();
+    writer.create_property_index("T", "idx").await.unwrap();
+    let schema = writer.snapshot().manifest().manifest.schema.clone();
+    writer.flush(schema.clone()).await.unwrap();
+    writer.compact_l0(&schema).await.unwrap();
+    writer
+}
+
+fn render(v: &RuntimeValue) -> String {
+    match v {
+        RuntimeValue::Null => "null".into(),
+        RuntimeValue::String(s) => s.clone(),
+        RuntimeValue::Integer(n) => n.to_string(),
+        RuntimeValue::Float(f) => format!("{f:?}"),
+        RuntimeValue::Bool(b) => b.to_string(),
+        other => format!("{other:?}"),
+    }
+}
+
+fn multiset(rows: &[Row]) -> Vec<String> {
+    let mut out: Vec<String> = rows
+        .iter()
+        .map(|r| {
+            r.bindings
+                .iter()
+                .map(|(k, v)| format!("{k}={}", render(v)))
+                .collect::<Vec<_>>()
+                .join(",")
+        })
+        .collect();
+    out.sort();
+    out
+}
+
+async fn run(writer: &WriterSession, query: &str) -> Vec<String> {
+    let snapshot = writer.snapshot();
+    let catalog = StatsCatalog::from_manifest(&snapshot.manifest().manifest);
+    let parsed = parse(query).unwrap_or_else(|e| panic!("parse `{query}`: {e:?}"));
+    let plan = optimize(
+        lower(&parsed).unwrap_or_else(|e| panic!("lower `{query}`: {e:?}")),
+        &catalog,
+    );
+    let rows = execute(&plan, &snapshot, &Params::new())
+        .await
+        .unwrap_or_else(|e| panic!("execute `{query}`: {e:?}"));
+    multiset(&rows)
+}
+
+/// `(name, predicate on the indexed property)`. The twin is derived by
+/// swapping `idx` for the unindexed `uidx`.
+fn shapes() -> Vec<(&'static str, &'static str)> {
+    vec![
+        ("a narrow tail", "t.IDX > 2990"),
+        ("inclusive tail", "t.IDX >= 2990"),
+        ("a narrow head", "t.IDX < 5"),
+        ("inclusive head", "t.IDX <= 5"),
+        ("a band spanning the floats", "t.IDX > 10 AND t.IDX < 25"),
+        ("a band that is one value", "t.IDX >= 20 AND t.IDX <= 20"),
+        ("spanning the negatives", "t.IDX > -10 AND t.IDX < 1"),
+        ("a negative bound", "t.IDX < -5"),
+        ("matching nothing, low", "t.IDX < -100"),
+        ("matching nothing, high", "t.IDX > 100000"),
+        ("beyond 2^53", "t.IDX > 9007199254740992"),
+        ("float bounds", "t.IDX > 10.4 AND t.IDX < 10.6"),
+        ("an inverted band", "t.IDX > 2999 AND t.IDX < 2991"),
+        ("a bound reversed", "2990 < t.IDX"),
+        ("negated", "NOT t.IDX <= 2990"),
+        (
+            "with an unrelated conjunct",
+            "t.IDX > 2990 AND t.tag IS NOT NULL",
+        ),
+        ("ORed with another property", "t.IDX > 2995 OR t.tag = 'r1'"),
+    ]
+}
+
+#[tokio::test]
+async fn numeric_ranges_agree_with_the_scan_and_use_the_index() {
+    let writer = corpus("range-route").await;
+
+    let mut served = 0_usize;
+    for (name, shape) in shapes() {
+        let indexed = format!(
+            "MATCH (t:T) WHERE {} RETURN t.tag AS tag",
+            shape.replace("IDX", "idx")
+        );
+        let unindexed = format!(
+            "MATCH (t:T) WHERE {} RETURN t.tag AS tag",
+            shape.replace("IDX", "uidx")
+        );
+
+        let before = route_telemetry::snapshot();
+        let got = run(&writer, &indexed).await;
+        let after = route_telemetry::snapshot();
+        let expected = run(&writer, &unindexed).await;
+
+        assert!(
+            got == expected,
+            "\n{name}: the indexed range disagreed with its unindexed twin.\n  \
+             {indexed}\n    -> {got:?}\n  {unindexed}\n    -> {expected:?}\n"
+        );
+        if after.property_native > before.property_native {
+            served += 1;
+        }
+    }
+
+    // Agreement is trivial if every shape declined. Most of these are narrow
+    // windows over 3,000 rows and must take the index.
+    assert!(
+        served >= 8,
+        "only {served} of {} range shapes took the index route",
+        shapes().len()
+    );
+}
+
+/// A range wider than the label's own share must hand the query back rather
+/// than read every posting AND hydrate every row.
+#[tokio::test]
+async fn a_range_matching_most_of_the_label_stays_on_the_scan() {
+    let writer = corpus("range-wide").await;
+
+    let before = route_telemetry::snapshot();
+    let wide = run(
+        &writer,
+        "MATCH (t:T) WHERE t.idx > -1000000 RETURN t.tag AS tag",
+    )
+    .await;
+    let after = route_telemetry::snapshot();
+    let twin = run(
+        &writer,
+        "MATCH (t:T) WHERE t.uidx > -1000000 RETURN t.tag AS tag",
+    )
+    .await;
+
+    assert_eq!(wide, twin, "declining must not change the answer");
+    assert_eq!(
+        after.property_native, before.property_native,
+        "a range matching nearly the whole label must not take the index route"
+    );
+}

--- a/crates/namidb-storage/src/read.rs
+++ b/crates/namidb-storage/src/read.rs
@@ -1296,6 +1296,192 @@ impl<'mt> Snapshot<'mt> {
         )
     }
 
+    /// Live node ids satisfying a conjunction of RANGE predicates on one
+    /// indexed numeric property, served from the equality sidecar instead of
+    /// scanning the label.
+    ///
+    /// `Some(ids)` is authoritative and already confirmed. `None` means the
+    /// caller must run its exact scan — the property is not indexed, a
+    /// sidecar in scope has no numeric coverage or no range-readable body,
+    /// the predicates are not all numeric bounds on this property, a write
+    /// transaction is open, or the matching window is larger than
+    /// `max_candidates` and the scan is the better route anyway.
+    ///
+    /// Candidates are confirmed with [`crate::sst::eval_against_value`] — the
+    /// SAME evaluator the scan uses — so the two routes cannot disagree about
+    /// what the predicate means. That matters more than usual here: the key
+    /// is lossy above 2^53, a posting can be stale, and a raw String key can
+    /// fall inside the numeric byte window. All three are conservative extra
+    /// candidates that the confirm step removes.
+    pub async fn indexed_node_ids_by_numeric_range(
+        &self,
+        label: &str,
+        property: &str,
+        predicates: &[crate::sst::ScanPredicate],
+        max_candidates: usize,
+    ) -> Result<Option<Vec<NodeId>>> {
+        namidb_core::profile_scope!("Snapshot::indexed_node_ids_by_numeric_range");
+        if predicates.is_empty() || max_candidates == 0 {
+            return Ok(None);
+        }
+        // The transactional overlay keys its candidates with
+        // `unique_index::key_part`, which has no ordering across types and no
+        // range support at all. A scan there sees the same staged writes.
+        if self.transactional_property_index.is_some() {
+            return Ok(None);
+        }
+        let Some((start_key, end_key)) = numeric_range_key_bounds(property, predicates) else {
+            return Ok(None);
+        };
+        if start_key > end_key {
+            return Ok(Some(Vec::new()));
+        }
+
+        let indexed = if label.is_empty() {
+            self.manifest.manifest.schema.labels.values().any(|def| {
+                def.properties
+                    .iter()
+                    .find(|p| p.name == property)
+                    .is_some_and(|p| p.indexed || p.unique)
+            })
+        } else {
+            self.manifest
+                .manifest
+                .schema
+                .label(label)
+                .and_then(|def| def.properties.iter().find(|p| p.name == property))
+                .is_some_and(|p| p.indexed || p.unique)
+        };
+        if !indexed {
+            return Ok(None);
+        }
+
+        let all_node_ssts: Vec<usize> = self.manifest.index.node_descriptors();
+        let sst_idxs: Vec<usize> = all_node_ssts
+            .into_iter()
+            .filter(|idx| {
+                label.is_empty() || node_sst_can_contain_label(&self.manifest.manifest, *idx, label)
+            })
+            .collect();
+
+        let mut candidates: Vec<NodeId> = Vec::new();
+        for idx in &sst_idxs {
+            let Some(descriptor) = self.manifest.manifest.ssts[*idx]
+                .equality_property_indices
+                .iter()
+                .find(|desc| {
+                    desc.property == property && desc.mixed_type_complete && desc.numeric_complete
+                })
+            else {
+                crate::route_telemetry::record_property(false);
+                return Ok(None);
+            };
+            let Some(paged) = &descriptor.paged else {
+                // A legacy-only body cannot be positioned by key without
+                // decoding the whole object, which is the cost this route
+                // exists to avoid.
+                crate::route_telemetry::record_property(false);
+                return Ok(None);
+            };
+            let paged_absolute =
+                format!("{}/{}", self.paths.namespace_prefix().as_ref(), paged.path);
+            let source = match self
+                .pinned_sidecar_source(&paged_absolute, Some(paged.size_bytes))
+                .await
+            {
+                Ok(source) => source,
+                Err(error) if optional_accelerator_fallback(&error) => {
+                    crate::route_telemetry::record_property(false);
+                    return Ok(None);
+                }
+                Err(error) => return Err(error),
+            };
+            let remaining = max_candidates.saturating_sub(candidates.len());
+            let page = match crate::sst::paged_index::equality_range_from_source(
+                &source,
+                start_key.as_bytes(),
+                end_key.as_bytes(),
+                remaining.saturating_add(1),
+            )
+            .await
+            {
+                Ok(page) => page,
+                Err(error) if optional_accelerator_fallback(&error) => {
+                    crate::route_telemetry::record_property(false);
+                    return Ok(None);
+                }
+                Err(error) => return Err(error),
+            };
+            if page.stats.index_entries != descriptor.distinct_values {
+                tracing::warn!(
+                    path = %paged.path,
+                    expected_entries = descriptor.distinct_values,
+                    actual_entries = page.stats.index_entries,
+                    "paged equality accelerator is stale/partial; declining the range route"
+                );
+                crate::route_telemetry::record_property(false);
+                return Ok(None);
+            }
+            if let Some(cache) = &self.property_index_cache {
+                cache.record_equality_index_bytes_read(page.stats.bytes_read);
+            }
+            if page.more_in_range {
+                // Too wide to be worth an index: the scan reads the same rows
+                // once, without also paying the posting reads.
+                crate::route_telemetry::record_property(false);
+                return Ok(None);
+            }
+            for ids in page.postings.into_values() {
+                for id in ids {
+                    candidates.push(NodeId::from_uuid(Uuid::from_bytes(id)));
+                }
+            }
+            if candidates.len() > max_candidates {
+                crate::route_telemetry::record_property(false);
+                return Ok(None);
+            }
+        }
+
+        // The committed/staged memtable delta, which no sidecar covers yet.
+        let memtable = self.memtable_property_claimants(label, property)?;
+        for (key, ids) in memtable.iter() {
+            if key.as_str() < start_key.as_str() || key.as_str() > end_key.as_str() {
+                continue;
+            }
+            for id in ids {
+                candidates.push(*id);
+            }
+            if candidates.len() > max_candidates {
+                crate::route_telemetry::record_property(false);
+                return Ok(None);
+            }
+        }
+
+        candidates.sort_unstable();
+        candidates.dedup();
+
+        let mut confirmed = Vec::with_capacity(candidates.len());
+        const CONFIRM_BATCH: usize = 256;
+        for batch in candidates.chunks(CONFIRM_BATCH) {
+            if let Some(cache) = &self.property_index_cache {
+                cache.record_equality_confirmation_candidates(batch.len());
+            }
+            let views = self.batch_lookup_nodes(label, batch).await?;
+            for (id, view) in batch.iter().zip(views) {
+                let Some(view) = view else { continue };
+                let value = view.properties.get(property);
+                if predicates
+                    .iter()
+                    .all(|predicate| crate::sst::eval_against_value(predicate, value))
+                {
+                    confirmed.push(*id);
+                }
+            }
+        }
+        crate::route_telemetry::record_property(true);
+        Ok(Some(confirmed))
+    }
+
     /// Return the live node ids matching EVERY member of a declared
     /// composite equality index.
     ///
@@ -5858,6 +6044,19 @@ impl<'mt> Snapshot<'mt> {
             return Ok(Vec::new());
         }
 
+        // A bare `LIMIT` over a selective range still benefits: the scan has
+        // to walk until it has found `limit` matches, which for a rare value
+        // is the whole label. The route returns the confirmed set in id order
+        // — the same order the scan produces — so truncating here picks the
+        // same rows the scan would have.
+        if let Some(mut rows) = self
+            .try_scan_numeric_range_index(label, predicates, projection)
+            .await?
+        {
+            rows.truncate(limit);
+            return Ok(rows);
+        }
+
         // Predicate columns are semantically required even when a direct
         // storage caller supplies a narrower output projection. The optimizer
         // already includes them, but widening here keeps this API exact on its
@@ -6113,12 +6312,136 @@ impl<'mt> Snapshot<'mt> {
     /// filter optional here ensures both routes perform exactly one
     /// memtable+SST reconciliation and cannot drift in predicate/projection
     /// semantics.
+    /// Widest matching window the numeric range index will serve before
+    /// handing the query back to the scan.
+    ///
+    /// The index route reads the postings AND hydrates every candidate; the
+    /// scan reads each row once. So the index wins only while the window is
+    /// SMALL RELATIVE TO THE LABEL, and the cap is what enforces that.
+    ///
+    /// Relative on purpose. A fixed cap is wrong in both directions: on a
+    /// small label it lets the route read most of the corpus through the
+    /// slower path, and on a 10M-row label it declines windows the index
+    /// would have won by two orders of magnitude. The manifest already
+    /// carries live per-label counts, so the estimate costs no I/O.
+    ///
+    /// The cap also bounds the WASTED work of a decline: exceeding it stops
+    /// the leaf walk, so an unselective range pays a bounded posting read
+    /// before falling back, not a full one.
+    ///
+    /// `NAMIDB_NUMERIC_RANGE_MAX_CANDIDATES` overrides the absolute ceiling.
+    fn numeric_range_candidate_cap(&self, label: &str) -> usize {
+        const DEFAULT_CEILING: usize = 65_536;
+        /// A window under an eighth of the label is worth an index lookup;
+        /// beyond that the scan reads the same rows once and wins.
+        const LABEL_FRACTION: u64 = 8;
+
+        let ceiling = std::env::var("NAMIDB_NUMERIC_RANGE_MAX_CANDIDATES")
+            .ok()
+            .and_then(|raw| raw.parse::<usize>().ok())
+            .unwrap_or(DEFAULT_CEILING);
+
+        let mut live: u64 = 0;
+        for idx in self.manifest.index.node_descriptors() {
+            let desc = &self.manifest.manifest.ssts[idx];
+            if !desc.scope.is_empty() {
+                if desc.scope == label || label.is_empty() {
+                    live = live.saturating_add(desc.row_count);
+                }
+                continue;
+            }
+            let Some(index) = &desc.label_index else {
+                // No per-label counts to estimate from; the whole SST is an
+                // upper bound, which keeps the cap conservative rather than
+                // accidentally tiny.
+                live = live.saturating_add(desc.row_count);
+                continue;
+            };
+            if label.is_empty() || index.per_label_counts.is_empty() {
+                live = live.saturating_add(desc.row_count);
+                continue;
+            }
+            if let Some(label_id) = self.manifest.manifest.label_dict.id(label) {
+                live = live.saturating_add(
+                    index
+                        .per_label_counts
+                        .iter()
+                        .filter(|(id, _)| *id == label_id.get())
+                        .map(|(_, count)| *count)
+                        .sum::<u64>(),
+                );
+            }
+        }
+        if live == 0 {
+            return ceiling;
+        }
+        usize::try_from(live / LABEL_FRACTION)
+            .unwrap_or(ceiling)
+            .clamp(1, ceiling)
+    }
+
+    /// Serve a label scan from the numeric range index when every predicate
+    /// is a bound on one indexed numeric property and the matching window is
+    /// small enough to be worth it.
+    ///
+    /// `None` means "not applicable" and the caller runs its ordinary scan.
+    /// This sits in front of the scan rather than in the planner because the
+    /// optimizer has already pushed these predicates down: the plan does not
+    /// change, only the way the same predicate is satisfied.
+    async fn try_scan_numeric_range_index(
+        &self,
+        label: Option<&str>,
+        predicates: &[ScanPredicate],
+        projection: Option<&[String]>,
+    ) -> Result<Option<Vec<NodeView>>> {
+        if predicates.is_empty() {
+            return Ok(None);
+        }
+        let property = predicates[0].column();
+        if predicates
+            .iter()
+            .any(|predicate| predicate.column() != property)
+        {
+            return Ok(None);
+        }
+        let label = label.unwrap_or("");
+        let Some(ids) = self
+            .indexed_node_ids_by_numeric_range(
+                label,
+                property,
+                predicates,
+                self.numeric_range_candidate_cap(label),
+            )
+            .await?
+        else {
+            return Ok(None);
+        };
+        // Already confirmed against the predicate and sorted by id, which is
+        // the order the scan returns rows in.
+        let views = self.batch_lookup_nodes(label, &ids).await?;
+        let mut rows: Vec<NodeView> = views.into_iter().flatten().collect();
+        if let Some(requested) = projection {
+            let keep: BTreeSet<&str> = requested.iter().map(String::as_str).collect();
+            for row in &mut rows {
+                row.properties
+                    .retain(|name, _| keep.contains(name.as_str()));
+            }
+        }
+        Ok(Some(rows))
+    }
+
     async fn scan_nodes_with_optional_label(
         &self,
         label: Option<&str>,
         predicates: &[ScanPredicate],
         projection: Option<&[String]>,
     ) -> Result<Vec<NodeView>> {
+        if let Some(rows) = self
+            .try_scan_numeric_range_index(label, predicates, projection)
+            .await?
+        {
+            return Ok(rows);
+        }
         let dict = &self.manifest.manifest.label_dict;
         // Row-group predicate pruning happens before the LSM winner is known.
         // It is therefore sound only when the manifest proves that every
@@ -9734,6 +10057,64 @@ fn equality_sidecar_key(
             _ => None,
         },
     }
+}
+
+/// Byte bounds over the ScalarV1 key space for a conjunction of numeric
+/// predicates on `property`, or `None` when this route does not apply.
+///
+/// Bounds are always INCLUSIVE at the key level even for a strict `<` / `>`:
+/// the numeric key is lossy above 2^53, so the boundary key can be shared by
+/// values that do and do not satisfy the predicate. Including it and letting
+/// the confirm step decide is the only safe direction — excluding it could
+/// drop a row.
+///
+/// The window is clamped to the numeric key space (`n:` + 16 hex), which
+/// keeps the leaf walk off the raw-String keys that share the sidecar.
+fn numeric_range_key_bounds(
+    property: &str,
+    predicates: &[crate::sst::ScanPredicate],
+) -> Option<(String, String)> {
+    use crate::sst::{ScanPredicate as P, StatScalar as S};
+
+    const NUMERIC_LOW: &str = "n:0000000000000000";
+    const NUMERIC_HIGH: &str = "n:ffffffffffffffff";
+
+    fn numeric_value(scalar: &S) -> Option<Value> {
+        match scalar {
+            S::Int32(v) => Some(Value::I64(i64::from(*v))),
+            S::Int64(v) => Some(Value::I64(*v)),
+            S::Float32(v) if !v.is_nan() => Some(Value::F64(f64::from(*v))),
+            S::Float64(v) if !v.is_nan() => Some(Value::F64(*v)),
+            _ => None,
+        }
+    }
+
+    let mut low = NUMERIC_LOW.to_string();
+    let mut high = NUMERIC_HIGH.to_string();
+    let mut bounded = false;
+    for predicate in predicates {
+        if predicate.column() != property {
+            return None;
+        }
+        let (scalar, is_lower, is_upper) = match predicate {
+            P::Gt { value, .. } | P::GtEq { value, .. } => (value, true, false),
+            P::Lt { value, .. } | P::LtEq { value, .. } => (value, false, true),
+            P::Eq { value, .. } => (value, true, true),
+            // IN could be served as a multi-probe, IS NULL / IS NOT NULL not
+            // at all from a sidecar that files no key for an absent value.
+            P::In { .. } | P::IsNull { .. } | P::IsNotNull { .. } => return None,
+        };
+        let key = crate::cache::encode_equality_property_value(&numeric_value(scalar)?)?;
+        if is_lower && key > low {
+            low = key.clone();
+        }
+        if is_upper && key < high {
+            high = key;
+        }
+        bounded = true;
+    }
+    // An unbounded window is the whole label: the scan is the better route.
+    bounded.then_some((low, high))
 }
 
 /// A probe value Cypher compares numerically, and which therefore requires

--- a/crates/namidb-storage/src/sst/paged_index.rs
+++ b/crates/namidb-storage/src/sst/paged_index.rs
@@ -2665,6 +2665,224 @@ pub fn decode_all_equality(body: &Bytes) -> Result<BTreeMap<String, Vec<[u8; 16]
     Ok(out)
 }
 
+/// One bounded window of an equality sidecar's postings, in key order.
+#[derive(Debug, Default)]
+pub struct EqualityRangePage {
+    /// Postings whose key lies within the requested bounds.
+    pub postings: BTreeMap<String, Vec<[u8; 16]>>,
+    pub stats: PagedProbeStats,
+    /// A key inside the bounds was left unread because `max_postings` was
+    /// reached. The caller must widen or fall back; treating this page as the
+    /// complete answer would drop rows.
+    pub more_in_range: bool,
+}
+
+/// Postings whose keys lie in `[start, end]`, in key order, bounded by
+/// `max_postings` NodeIds.
+///
+/// The ordered twin of [`probe_equality`]: instead of descending once per
+/// exact key, it descends once to the leaf holding `start` and then walks the
+/// chained leaf level forward. That is what makes a range predicate over an
+/// indexed property cost the matching keys rather than the whole label — and
+/// it is only sound because the scalar key encoding is ORDER-PRESERVING
+/// (`cache::encode_equality_property_value`), so key order IS value order.
+///
+/// Bounds are INCLUSIVE and compared as raw bytes. A caller wanting a strict
+/// `>` encodes the boundary value and drops it at confirm time; the returned
+/// NodeIds are candidates in every case, because a posting can be stale and
+/// the numeric key is deliberately lossy above 2^53.
+///
+/// Keys outside the caller's type — a raw String sharing the key space with
+/// the tagged scalars — can fall inside the byte range. They are conservative
+/// extra candidates, exactly as they are for an exact probe, and the caller's
+/// confirm step removes them.
+pub async fn equality_range_from_source(
+    source: &PinnedObjectRangeSource,
+    start: &[u8],
+    end: &[u8],
+    max_postings: usize,
+) -> Result<EqualityRangePage> {
+    equality_range_with_source(source, start, end, max_postings).await
+}
+
+/// Store-addressed [`equality_range_from_source`]. Test-only, mirroring
+/// [`equality_prefix`]: production callers read through a pinned generation.
+#[cfg(test)]
+pub async fn equality_range(
+    store: Arc<dyn ObjectStore>,
+    path: Path,
+    start: &[u8],
+    end: &[u8],
+    max_postings: usize,
+) -> Result<EqualityRangePage> {
+    let source = LegacyObjectRangeSource { store, path };
+    equality_range_with_source(&source, start, end, max_postings).await
+}
+
+async fn equality_range_with_source(
+    source: &dyn PagedRangeSource,
+    start: &[u8],
+    end: &[u8],
+    max_postings: usize,
+) -> Result<EqualityRangePage> {
+    type SelectedPosting = (Vec<u8>, u64, usize, usize, Option<u32>);
+
+    crate::cancel::check()?;
+    let header_bytes = source.read_range(0..HEADER_SIZE as u64).await?;
+    let header = Header::decode(&header_bytes, PagedIndexKind::Equality)?;
+    header.require_authoritative_integrity()?;
+    let mut stats = PagedProbeStats {
+        index_entries: header.entry_count,
+        bytes_read: header_bytes.len(),
+        ..Default::default()
+    };
+    if max_postings == 0 || start > end {
+        return Ok(EqualityRangePage {
+            stats,
+            ..Default::default()
+        });
+    }
+
+    // Descend to the leaf that would hold `start`. An internal entry's key is
+    // the MAXIMUM key in its subtree, so the first child whose max is >= start
+    // is the one to enter; falling back to the last child keeps a start beyond
+    // every key on the rightmost path, where the forward walk finds nothing.
+    let mut page_id = header.root_page;
+    loop {
+        crate::cancel::check()?;
+        if page_id >= header.page_count {
+            return Err(Error::invariant(
+                "equality range child points outside page region",
+            ));
+        }
+        let page = source.read_range(page_range(page_id)).await?;
+        stats.pages_read += 1;
+        stats.bytes_read = stats.bytes_read.saturating_add(page.len());
+        if page.len() != PAGE_SIZE {
+            return Err(Error::invariant(format!(
+                "short paged-index page {page_id}"
+            )));
+        }
+        match page[0] {
+            PAGE_LEAF => break,
+            PAGE_INTERNAL => {
+                let children = parse_internal(&page, header.format)?;
+                page_id = children
+                    .iter()
+                    .find(|(max, _)| start <= max.as_slice())
+                    .or_else(|| children.last())
+                    .map(|(_, child)| *child)
+                    .ok_or_else(|| Error::invariant("empty paged-index internal page"))?;
+            }
+            other => {
+                return Err(Error::invariant(format!(
+                    "invalid paged-index page kind {other}"
+                )));
+            }
+        }
+    }
+
+    let mut selected: Vec<SelectedPosting> = Vec::new();
+    let mut postings = 0usize;
+    let mut more_in_range = false;
+    'leaves: while page_id != NO_PAGE {
+        crate::cancel::check()?;
+        let page = source.read_range(page_range(page_id)).await?;
+        stats.pages_read += 1;
+        stats.bytes_read += page.len();
+        let next = read_u32(&page, 8)?;
+        let entries = parse_leaf(&page, PagedIndexKind::Equality, header.format)?;
+        stats.leaf_entries_examined += entries.len();
+        for entry in entries {
+            if entry.key.as_slice() < start {
+                continue;
+            }
+            if entry.key.as_slice() > end {
+                break 'leaves;
+            }
+            if postings >= max_postings {
+                more_in_range = true;
+                break 'leaves;
+            }
+            let LeafValue::External(offset, len, checksum) = entry.value else {
+                return Err(Error::invariant("equality range found inline value"));
+            };
+            if len as usize % 16 != 0 {
+                return Err(Error::invariant("unaligned equality range posting"));
+            }
+            let full_ids = len as usize / 16;
+            let take_ids = full_ids.min(max_postings.saturating_sub(postings));
+            stats.matched_value_bytes = stats.matched_value_bytes.saturating_add(len as u64);
+            // A partially-read posting is itself "more in range": the caller
+            // has not seen every NodeId for this key either.
+            more_in_range |= take_ids < full_ids;
+            stats.values_truncated |= take_ids < full_ids;
+            selected.push((entry.key, offset, len as usize, take_ids * 16, checksum));
+            postings += take_ids;
+        }
+        page_id = next;
+    }
+
+    let external: Vec<(usize, Range<u64>)> = selected
+        .iter()
+        .enumerate()
+        .filter_map(|(index, (_, offset, _, read_len, _))| {
+            if *read_len == 0 {
+                return None;
+            }
+            Some(
+                external_value_range(header.values_offset, *offset, *read_len)
+                    .map(|range| (index, range)),
+            )
+        })
+        .collect::<Result<Vec<_>>>()?;
+    let ranges: Vec<Range<u64>> = external.iter().map(|(_, range)| range.clone()).collect();
+    let values = source.read_ranges(&ranges).await?;
+    if values.len() != ranges.len() {
+        return Err(Error::invariant(format!(
+            "paged equality range source returned {} values for {} ranges",
+            values.len(),
+            ranges.len()
+        )));
+    }
+    stats.bytes_read += values.iter().map(Bytes::len).sum::<usize>();
+    let mut fetched: BTreeMap<usize, Bytes> = external
+        .into_iter()
+        .zip(values)
+        .map(|((index, _), value)| (index, value))
+        .collect();
+    let mut postings_out = BTreeMap::new();
+    for (index, (key, _, full_len, _, checksum)) in selected.into_iter().enumerate() {
+        let value = fetched.remove(&index).unwrap_or_default();
+        // Only a COMPLETE value can be checked against its CRC; a truncated
+        // one is reported through `more_in_range` instead, exactly as the
+        // ordered prefix reports it through `values_truncated`.
+        if value.len() == full_len
+            && checksum.is_some_and(|expected| crc32fast::hash(&value) != expected)
+        {
+            return Err(Error::invariant(
+                "equality range external-value checksum mismatch",
+            ));
+        }
+        let mut ids = Vec::with_capacity(value.len() / 16);
+        for chunk in value.chunks_exact(16) {
+            let mut id = [0; 16];
+            id.copy_from_slice(chunk);
+            ids.push(id);
+        }
+        postings_out.insert(
+            String::from_utf8(key)
+                .map_err(|e| Error::invariant(format!("equality range key utf8: {e}")))?,
+            ids,
+        );
+    }
+    Ok(EqualityRangePage {
+        postings: postings_out,
+        stats,
+        more_in_range,
+    })
+}
+
 /// Read the smallest equality keys until at least `min_postings` NodeIds have
 /// been returned. Leaf `next` links make `ORDER BY ... SKIP/LIMIT` proportional
 /// to its requested prefix instead of total distinct keys.
@@ -3709,6 +3927,103 @@ mod tests {
         }
         assert!(stats.leaf_entries_examined < ids.len() / 2);
         assert!(stats.bytes_read < body.len() / 2);
+    }
+
+    #[tokio::test]
+    async fn equality_range_agrees_with_the_ordered_prefix_and_reads_only_its_window() {
+        // 10k distinct keys, five ids each. The range read must return exactly
+        // the keys in its window — no more, no fewer — and must not read the
+        // whole index to do it.
+        let index: BTreeMap<String, Vec<[u8; 16]>> = (0..10_000u128)
+            .map(|n| {
+                (
+                    format!("v-{n:08}"),
+                    (0..5).map(|m| id(n * 10 + m)).collect(),
+                )
+            })
+            .collect();
+        let body = build_equality(&index).unwrap();
+        let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+        let path = Path::from("eq.pidx");
+        store
+            .put(&path, PutPayload::from(body.clone()))
+            .await
+            .unwrap();
+
+        // A narrow window in the middle: keys v-00004000 ..= v-00004009.
+        let page = equality_range(
+            Arc::clone(&store),
+            path.clone(),
+            b"v-00004000",
+            b"v-00004009",
+            usize::MAX,
+        )
+        .await
+        .unwrap();
+        let got: Vec<&String> = page.postings.keys().collect();
+        let want: Vec<String> = (4_000..=4_009u128).map(|n| format!("v-{n:08}")).collect();
+        assert_eq!(got, want.iter().collect::<Vec<_>>());
+        for (n, key) in (4_000..=4_009u128).zip(&want) {
+            assert_eq!(
+                page.postings[key],
+                (0..5).map(|m| id(n * 10 + m)).collect::<Vec<_>>()
+            );
+        }
+        assert!(!page.more_in_range);
+        // Positioning by key must cost a search path plus the window, not the
+        // corpus. The ordered prefix would have had to walk 4,000 keys first.
+        assert!(
+            page.stats.bytes_read < body.len() / 20,
+            "a windowed range read {} bytes of a {}-byte index",
+            page.stats.bytes_read,
+            body.len()
+        );
+
+        // A range covering everything must equal the ordered prefix over
+        // everything: the two leaf walks may not drift apart.
+        let all = equality_range(
+            Arc::clone(&store),
+            path.clone(),
+            b"",
+            b"v-zzzzzzzz",
+            usize::MAX,
+        )
+        .await
+        .unwrap();
+        let (prefix, _) = equality_prefix(Arc::clone(&store), path.clone(), usize::MAX)
+            .await
+            .unwrap();
+        assert_eq!(all.postings, prefix);
+        assert_eq!(all.postings.len(), index.len());
+        assert!(!all.more_in_range);
+
+        // The cap must REPORT that it stopped, or the caller would treat a
+        // partial window as the complete answer and drop rows.
+        let capped = equality_range(
+            Arc::clone(&store),
+            path.clone(),
+            b"v-00004000",
+            b"v-00004009",
+            7,
+        )
+        .await
+        .unwrap();
+        assert!(capped.more_in_range, "a capped range must say so");
+        assert!(capped.postings.values().map(Vec::len).sum::<usize>() <= 7);
+
+        // Bounds outside every key, both sides, and an inverted range.
+        let above = equality_range(Arc::clone(&store), path.clone(), b"w", b"z", usize::MAX)
+            .await
+            .unwrap();
+        assert!(above.postings.is_empty() && !above.more_in_range);
+        let below = equality_range(Arc::clone(&store), path.clone(), b"a", b"b", usize::MAX)
+            .await
+            .unwrap();
+        assert!(below.postings.is_empty() && !below.more_in_range);
+        let inverted = equality_range(store, path, b"v-00005000", b"v-00004000", usize::MAX)
+            .await
+            .unwrap();
+        assert!(inverted.postings.is_empty() && !inverted.more_in_range);
     }
 
     #[tokio::test]

--- a/crates/namidb-storage/tests/numeric_range_index.rs
+++ b/crates/namidb-storage/tests/numeric_range_index.rs
@@ -1,0 +1,324 @@
+//! Item 80: a range predicate on an indexed numeric property must be served
+//! from the equality sidecar, and must agree EXACTLY with the flat scan.
+//!
+//! Measured before this route existed, on 160,000 rows with `idx` indexed:
+//! `WHERE t.idx > 999999` (matching nothing) cost 0.311 s, and
+//! `WHERE t.idx > 80000` (matching half) cost 0.340 s — completely
+//! insensitive to selectivity, because nothing in the node layout carries
+//! property statistics to prune on.
+//!
+//! The route is only sound because the numeric key is order-preserving, so a
+//! key window IS a value window. Three things make its candidate set a
+//! SUPERSET of the answer rather than a subset, and each is removed by the
+//! confirm step:
+//!
+//!   * the key is lossy above 2^53, so distinct integers share a posting;
+//!   * a posting can name a node whose current version no longer matches;
+//!   * a raw String key can fall inside the numeric byte window.
+//!
+//! A subset would be a silent wrong answer, so every case here is checked
+//! against a flat scan filtered with the SAME evaluator the scan route uses.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use namidb_core::id::{NamespaceId, NodeId};
+use namidb_core::value::Value;
+use namidb_storage::sst::{eval_against_value, ScanPredicate, StatScalar};
+use namidb_storage::{NamespacePaths, NodeWriteRecord, WriterSession};
+use object_store::memory::InMemory;
+use object_store::ObjectStore;
+
+const ROWS: i64 = 2_000;
+
+fn node(props: Vec<(&str, Value)>) -> NodeWriteRecord {
+    NodeWriteRecord {
+        properties: props
+            .into_iter()
+            .map(|(k, v)| (k.to_string(), v))
+            .collect::<BTreeMap<_, _>>(),
+        schema_version: 1,
+        ..Default::default()
+    }
+}
+
+/// `idx` is Int64 and indexed. The corpus also carries rows that are NOT
+/// plain integers on that property, because those are exactly what a
+/// key-window walk can pick up by accident:
+///
+///   * floats, including one equal to an integer already present;
+///   * a legacy String value on the numeric property;
+///   * a NULL and an absent property;
+///   * two i64 beyond 2^53 that share one key.
+async fn corpus(name: &str, flush: bool, compact: bool) -> WriterSession {
+    let store: Arc<dyn ObjectStore> = Arc::new(InMemory::new());
+    let paths = NamespacePaths::new("tenants", NamespaceId::new(name).unwrap());
+    let mut writer = WriterSession::open(store, paths).await.unwrap();
+
+    for ordinal in 0..ROWS {
+        writer
+            .upsert_node(
+                "T",
+                NodeId::new(),
+                &node(vec![
+                    ("idx", Value::I64(ordinal)),
+                    ("tag", Value::Str(format!("row-{ordinal}"))),
+                ]),
+            )
+            .unwrap();
+    }
+    for (value, tag) in [
+        (Value::F64(10.5), "fractional"),
+        (Value::F64(20.0), "integral-float"),
+        (Value::F64(-3.25), "negative-float"),
+        (Value::I64(-7), "negative-int"),
+        (Value::Str("500".into()), "string-on-numeric-prop"),
+        (Value::Str("n:0000000000000000".into()), "string-shaped-key"),
+        (Value::Null, "null"),
+        (Value::I64(9_007_199_254_740_992), "big-low"),
+        (Value::I64(9_007_199_254_740_993), "big-high"),
+    ] {
+        writer
+            .upsert_node(
+                "T",
+                NodeId::new(),
+                &node(vec![("idx", value), ("tag", Value::Str(tag.into()))]),
+            )
+            .unwrap();
+    }
+    // No `idx` at all.
+    writer
+        .upsert_node(
+            "T",
+            NodeId::new(),
+            &node(vec![("tag", Value::Str("absent".into()))]),
+        )
+        .unwrap();
+    writer.commit_batch().await.unwrap();
+    writer.create_property_index("T", "idx").await.unwrap();
+
+    if flush {
+        let schema = writer.snapshot().manifest().manifest.schema.clone();
+        writer.flush(schema.clone()).await.unwrap();
+        if compact {
+            writer.compact_l0(&schema).await.unwrap();
+        }
+    }
+    writer
+}
+
+fn gt(v: i64) -> ScanPredicate {
+    ScanPredicate::Gt {
+        column: "idx".into(),
+        value: StatScalar::Int64(v),
+    }
+}
+fn gte(v: i64) -> ScanPredicate {
+    ScanPredicate::GtEq {
+        column: "idx".into(),
+        value: StatScalar::Int64(v),
+    }
+}
+fn lt(v: i64) -> ScanPredicate {
+    ScanPredicate::Lt {
+        column: "idx".into(),
+        value: StatScalar::Int64(v),
+    }
+}
+fn lte(v: i64) -> ScanPredicate {
+    ScanPredicate::LtEq {
+        column: "idx".into(),
+        value: StatScalar::Int64(v),
+    }
+}
+fn gt_f(v: f64) -> ScanPredicate {
+    ScanPredicate::Gt {
+        column: "idx".into(),
+        value: StatScalar::Float64(v),
+    }
+}
+fn lt_f(v: f64) -> ScanPredicate {
+    ScanPredicate::Lt {
+        column: "idx".into(),
+        value: StatScalar::Float64(v),
+    }
+}
+
+fn families() -> Vec<(&'static str, Vec<ScanPredicate>)> {
+    vec![
+        ("> 1990 (a narrow tail)", vec![gt(1_990)]),
+        (">= 1990", vec![gte(1_990)]),
+        ("< 5 (a narrow head)", vec![lt(5)]),
+        ("<= 5", vec![lte(5)]),
+        ("> 10 AND < 25 (spans the floats)", vec![gt(10), lt(25)]),
+        (
+            ">= 20 AND <= 20 (the integral float)",
+            vec![gte(20), lte(20)],
+        ),
+        ("> -10 AND < 1 (spans the negatives)", vec![gt(-10), lt(1)]),
+        ("< -100 (matches nothing)", vec![lt(-100)]),
+        ("> 100000 (above every plain row)", vec![gt(100_000)]),
+        (
+            "> 2^53 (the two colliding integers)",
+            vec![gt(9_007_199_254_740_992)],
+        ),
+        (
+            ">= 2^53 (both colliding integers)",
+            vec![gte(9_007_199_254_740_992)],
+        ),
+        (
+            "> 10.4 AND < 10.6 (float bounds)",
+            vec![gt_f(10.4), lt_f(10.6)],
+        ),
+        ("> 1999 AND < 1991 (inverted)", vec![gt(1_999), lt(1_991)]),
+    ]
+}
+
+/// What the scan route returns: every live node of the label whose current
+/// `idx` satisfies every predicate, by the same evaluator.
+async fn by_scan(writer: &WriterSession, predicates: &[ScanPredicate]) -> Vec<NodeId> {
+    let snapshot = writer.snapshot();
+    let mut ids: Vec<NodeId> = snapshot
+        .scan_label("T")
+        .await
+        .unwrap()
+        .into_iter()
+        .filter(|view| {
+            let value = view.properties.get("idx");
+            predicates
+                .iter()
+                .all(|predicate| eval_against_value(predicate, value))
+        })
+        .map(|view| view.id)
+        .collect();
+    ids.sort_unstable();
+    ids
+}
+
+#[tokio::test]
+async fn numeric_range_lookup_agrees_with_the_scan() {
+    for (flush, compact, stage) in [
+        (false, false, "memtable"),
+        (true, false, "flushed"),
+        (true, true, "compacted"),
+    ] {
+        let writer = corpus(&format!("range-{stage}"), flush, compact).await;
+        let snapshot = writer.snapshot();
+        let mut served = 0_usize;
+
+        for (name, predicates) in families() {
+            let expected = by_scan(&writer, &predicates).await;
+            let got = snapshot
+                .indexed_node_ids_by_numeric_range("T", "idx", &predicates, 4_096)
+                .await
+                .unwrap();
+            let Some(mut got) = got else {
+                // Declining is always allowed — the caller scans, which is
+                // correct. What is never allowed is answering WRONG.
+                continue;
+            };
+            served += 1;
+            got.sort_unstable();
+            assert_eq!(
+                got, expected,
+                "[{stage}] {name}: the index route disagreed with the scan"
+            );
+        }
+
+        // …and it must actually serve something, or the agreement above is
+        // the trivial kind: every family declined.
+        if flush {
+            assert!(
+                served >= families().len() - 2,
+                "[{stage}] only {served} of {} families took the index route",
+                families().len()
+            );
+        }
+    }
+}
+
+#[tokio::test]
+async fn an_unselective_range_declines_rather_than_paying_twice() {
+    let writer = corpus("range-cap", true, true).await;
+    let snapshot = writer.snapshot();
+
+    // Matching (almost) the whole label: reading every posting AND hydrating
+    // every row costs strictly more than the scan that reads each row once.
+    let wide = vec![gt(-1_000_000)];
+    assert!(
+        snapshot
+            .indexed_node_ids_by_numeric_range("T", "idx", &wide, 16)
+            .await
+            .unwrap()
+            .is_none(),
+        "a window wider than the cap must decline"
+    );
+
+    // The same window with a cap above the corpus is servable, and still has
+    // to agree with the scan.
+    let expected = by_scan(&writer, &wide).await;
+    let got = snapshot
+        .indexed_node_ids_by_numeric_range("T", "idx", &wide, 1 << 20)
+        .await
+        .unwrap()
+        .expect("a generous cap must serve");
+    let mut got = got;
+    got.sort_unstable();
+    assert_eq!(got, expected);
+}
+
+#[tokio::test]
+async fn shapes_this_route_must_refuse() {
+    let writer = corpus("range-refuse", true, true).await;
+    let snapshot = writer.snapshot();
+
+    let refused: Vec<(&str, Vec<ScanPredicate>)> = vec![
+        (
+            "a predicate on another property",
+            vec![ScanPredicate::Gt {
+                column: "tag".into(),
+                value: StatScalar::Int64(1),
+            }],
+        ),
+        (
+            "IS NULL — the sidecar files no key for an absent value",
+            vec![ScanPredicate::IsNull {
+                column: "idx".into(),
+            }],
+        ),
+        (
+            "IS NOT NULL — unbounded, and the scan reads the same rows once",
+            vec![ScanPredicate::IsNotNull {
+                column: "idx".into(),
+            }],
+        ),
+        (
+            "a String bound is not a numeric window",
+            vec![ScanPredicate::Gt {
+                column: "idx".into(),
+                value: StatScalar::Utf8("5".into()),
+            }],
+        ),
+        ("no predicates at all", vec![]),
+    ];
+    for (name, predicates) in refused {
+        assert!(
+            snapshot
+                .indexed_node_ids_by_numeric_range("T", "idx", &predicates, 4_096)
+                .await
+                .unwrap()
+                .is_none(),
+            "{name}: this route must decline, not guess"
+        );
+    }
+
+    // An UNINDEXED property has no sidecar to read.
+    assert!(
+        snapshot
+            .indexed_node_ids_by_numeric_range("T", "tag", &[gt(1)], 4_096)
+            .await
+            .unwrap()
+            .is_none(),
+        "an unindexed property must decline"
+    );
+}

--- a/docs/testing/25tb-readiness.md
+++ b/docs/testing/25tb-readiness.md
@@ -1442,98 +1442,101 @@ If an exact-answer fast path is ever wanted, it needs a per-label
 sets when it recomputes from survivors. That does not exist today, and
 inventing it is a manifest format change.
 
-### 80. [PARTLY FIXED in 2.6.14 — equality; ranges are a missing capability, not a wiring bug] Filtered scans prune nothing
+### 80. [FIXED for indexed properties in 2.6.15; unindexed ranges remain a missing capability] Filtered scans prune nothing
 
-Re-measured on 2.6.14, same 160,000-node fixture, `idx` declared as an
-index, one projected column:
+Measured on the same 160,000-node fixture, `idx` declared as an index, one
+projected column:
 
-| query | rows | 2.6.13 | 2.6.14 | route |
+| query | rows | 2.6.13 | 2.6.15 | route |
 |---|---|---|---|---|
 | `WHERE t.idx = 12345` | 1 | 0.375 s | **0.000078 s** | index |
-| `{idx: 12345}` | 1 | — | **0.000060 s** | index |
-| `WHERE t.idx > 999999` (matches nothing) | 0 | 0.377 s | 0.311 s | scan |
-| `WHERE t.idx < -5` (matches nothing) | 0 | 0.468 s | 0.399 s | scan |
-| `WHERE t.idx > 159990` | 9 | 0.412 s | 0.292 s | scan |
-| `WHERE t.idx > 80000` | 79,999 | 0.417 s | 0.340 s | scan |
+| `WHERE t.idx > 999999` (matches nothing) | 0 | 0.377 s | **0.000068 s** | index |
+| `WHERE t.idx < -5` (matches nothing) | 0 | 0.468 s | **0.000053 s** | index |
+| `WHERE t.idx > 159990` | 9 | 0.412 s | **0.000109 s** | index |
+| `WHERE t.idx > 1000 AND t.idx < 1100` | 99 | ~0.4 s | **0.000527 s** | index |
+| `WHERE t.idx > 80000` | 79,999 | 0.417 s | 0.398 s | scan, declined |
 | no filter (manifest fast path) | 160,000 | 0.001 s | 0.000030 s | — |
 
-**Equality is fixed** — by item 81, not by anything done here. What remains
-is RANGE predicates, and they are still completely insensitive to
-selectivity: a predicate matching nothing costs the same as one matching
-half the store.
+Equality was closed by item 81. Ranges are closed here, for an INDEXED
+property: 2,700x to 7,500x on the selective shapes, and a deliberate
+decline once the window stops being selective.
 
-**THE DIAGNOSIS IN THE TWO PREVIOUS VERSIONS OF THIS ENTRY WAS WRONG, TWICE.**
-Both said this was a wiring problem — "two implemented features that are not
-wired". It is not. Recorded in full, because the wrong version would have
-sent someone to do work that cannot help:
+**Why this was possible without the storage-format change the previous
+version of this entry called for.** The equality sidecar is a
+range-readable B+tree, and item 81 made the numeric key order-preserving —
+so a key window IS a value window. `equality_range_from_source` descends
+once to the leaf holding the lower bound and walks the chained leaf level
+forward; a ten-key window over a 10k-key index reads under 5% of the body.
+No new plan node and no optimizer rule: the optimizer already pushes these
+predicates onto `NodeScan`, so the route sits in front of the scan and
+changes how the same predicate is satisfied, not what the plan is.
+
+**The candidate set is deliberately a SUPERSET**, for three reasons, each
+removed by confirming every candidate with `eval_against_value` — the same
+evaluator the scan uses, so the two routes cannot disagree about what the
+predicate means:
+
+* the numeric key is lossy above 2^53, so distinct integers share a key;
+* a posting can name a node whose current version no longer matches;
+* a raw String key can fall inside the numeric byte window.
+
+A subset would be a silent wrong answer. A superset is a wasted candidate.
+Verified non-inert by removing the confirm step and watching `> 1990`
+disagree with the scan immediately.
+
+**The cap is relative to the label, and that matters in both directions.**
+The index route reads postings AND hydrates candidates; the scan reads each
+row once. A fixed cap is wrong twice over: on a small label it lets the
+route read most of the corpus the slow way, and on a 10M-row label it
+declines windows the index would win by two orders of magnitude. The
+manifest already carries live per-label counts, so the estimate costs no
+I/O. The first draft used a fixed 65,536 and made the declining case SLOWER
+than before (0.475 s against a 0.340 s baseline) purely from postings read
+and thrown away.
+
+**A pushdown gap found on the way, and fixed.** `WHERE n.idx < -5` was not
+reaching storage as a predicate at all: Cypher parses the sign as a unary
+operator, and the pushdown's literal extractor accepted only literals. Every
+negative bound — a temperature, a delta, a debit — was invisible. Folding a
+unary minus over a numeric literal fixes it (with `checked_neg`, so
+`-i64::MIN` stays a residual filter rather than wrapping into a positive
+bound). That gap predates this work and also affected the legacy
+label-scoped row-group pruning path.
+
+**What remains, and it is genuinely a missing capability.** A range on an
+UNINDEXED property still reads every row, and nothing short of a format
+change fixes it. Recorded because two earlier versions of this entry
+prescribed work that cannot help:
 
 1. *"Wire the predicates into the projected-scan branch."* There is nothing
-   to wire them into. A node SST is written with an **empty LabelDef** and
-   therefore has **no `prop_*` columns at all** — flush.rs states it
-   outright: *"one identity-partitioned SST spanning every label, built with
-   an empty LabelDef (fixed layout — no prop_* columns; every property rides
-   in `__overflow_json`)"*. `node_arrow_schema` of an empty LabelDef is six
-   engine columns and nothing else, and
-   `scan_with_predicates_and_projection_async` rejects any file that does
-   not match it exactly. So there are no per-row-group property statistics
-   for `eval_row_group` to read: `node_scan_plan` resolves no column,
+   to wire them into. Node SSTs are written with an empty LabelDef and have
+   **no `prop_*` columns at all** — flush.rs says so outright: *"fixed
+   layout — no prop_* columns; every property rides in `__overflow_json`"*.
+   With no property column there are no per-row-group property statistics,
    `PropertyColumnStats::empty` has `min`/`max` of `None`, and every arm of
-   `eval_row_group` answers `MaybePresent` when the bound is absent. Passing
-   the predicates through would prune exactly zero row groups.
-
-   (The `eval_row_group` / `synthesize_property_stats` machinery is not dead
-   code — it serves LEGACY label-scoped SSTs, whose `scope` names a single
-   label and whose LabelDef therefore does carry properties. The current
-   writer no longer produces those.)
-
+   `eval_row_group` answers `MaybePresent`. (That machinery is not dead —
+   it serves LEGACY label-scoped SSTs, which the current writer no longer
+   produces.)
 2. *"Wire `NodePropertyPageReader::filter_node_ids`."* Its predicate IR is
-   `EqString`, `InString`, `EqBool`, `InBool`, and an explicit
-   `Unsupported` — **no range predicates of any kind**. It could not serve a
-   single one of the slow queries above, and for the equality shapes it does
-   support, the equality posting sidecar already does the job better.
+   `EqString`, `InString`, `EqBool`, `InBool` and an explicit `Unsupported`
+   — no range forms. The `.npp` pages carry size limits, not value
+   statistics.
 
-   The `.npp` pages also carry no per-property `min`/`max`: their page
-   metadata is size limits (`max_value_bytes`, `max_page_decoded_bytes`, …),
-   not value statistics.
+An earlier same-day correction was also wrong: it blamed
+`label_def_for_node_sst` returning an empty property list, and proposed
+resolving the predicate column against the manifest schema. That empty
+LabelDef faithfully describes the file layout; resolving a column name with
+no Parquet column would find nothing.
 
-**An earlier same-day correction in this entry was also wrong** — it said
-the blocker was `label_def_for_node_sst` returning an empty property list
-for id-primary SSTs, and proposed resolving the predicate column against the
-manifest schema instead. That empty LabelDef is a faithful description of
-the file layout, not an oversight: resolving a column name that has no
-Parquet column would find nothing.
-
-**So this is a MISSING CAPABILITY.** Node properties have no value
-statistics anywhere in the current format — not in Parquet, not in the
-property pages. No layer can answer "this page cannot contain a value
-> 999999", so every range predicate reads every row.
-
-**The path that does exist, and why 2.6.14 opened it.** The equality
-sidecar is a range-readable B+tree keyed by the encoded scalar, and
-`ordered_node_ids_by_string_property` already positions by value within it
-for `ORDER BY <string prop> LIMIT k`. Item 81's numeric key was made
-ORDER-PRESERVING for exactly this reason: `sortable_f64_bits` maps an f64
-onto a u64 whose unsigned order is the number's order, so the same B+tree
-can be positioned at `> x` for numbers too. Raw IEEE-754 bits would have
-sorted negatives backwards — which costs an equality probe nothing, and
-would have foreclosed every ordered read over those postings without anyone
-noticing until the format was already in the wild.
-
-Order of work, corrected:
-1. An ordered/range numeric read over the equality sidecar — the twin of
-   `ordered_node_ids_by_string_property`, using the order-preserving key.
-   This serves `WHERE n.amount > x` on an INDEXED property, which is the
-   case operators actually declare an index for.
-2. Only then consider value statistics in the property pages, for ranges on
-   UNINDEXED properties. That is a storage-format change and wants its own
-   design.
-3. Separately, and still true from the original entry: the cost is per-ROW,
-   not per-byte — `count(t.pad)` over a 900-byte string column costs the
-   same as `count(t.idx)` over an 8-byte integer, and two columns cost more
-   than one. That is `Row`/`RuntimeValue` materialisation dominating, and it
-   is what caps every scalar aggregate at ~0.3 s regardless of the column.
-   Vectorised aggregation over the decoded Arrow column is the fix, and it
-   is independent of everything above.
+Order of work from here:
+1. Value statistics in the property pages, for ranges on unindexed
+   properties. A storage-format change, wanting its own design.
+2. Independently, and still true from the original entry: the cost is
+   per-ROW, not per-byte. `count(t.pad)` over a 900-byte string column costs
+   the same as `count(t.idx)` over an 8-byte integer, and two columns cost
+   more than one. That is `Row`/`RuntimeValue` materialisation dominating,
+   and it caps every scalar aggregate at ~0.3 s regardless of the column.
+   Vectorised aggregation over the decoded Arrow column is the fix.
 
 **A note for whoever picks this up**: the default row group is 128Ki rows,
 so any fixture under ~500k rows has too few row groups to show row-group


### PR DESCRIPTION
Item 80's remaining half. A range predicate on an **indexed** numeric property read every row of the label, with no sensitivity to selectivity at all.

On 160,000 rows with `idx` indexed:

| query | rows | before | after | route |
|---|---|---|---|---|
| `WHERE t.idx > 999999` | 0 | 0.311 s | **0.000068 s** | index |
| `WHERE t.idx < -5` | 0 | 0.399 s | **0.000053 s** | index |
| `WHERE t.idx > 159990` | 9 | 0.292 s | **0.000109 s** | index |
| `WHERE t.idx > 1000 AND t.idx < 1100` | 99 | ~0.4 s | **0.000527 s** | index |
| `WHERE t.idx > 80000` | 79,999 | 0.340 s | 0.398 s | scan, declined |

2,700x–7,500x on the selective shapes, and a deliberate decline once the window stops being selective. These are the shapes a retail or clinical schema is built on: amounts, dates, stock levels, thresholds.

## How, and why no planner change

Nothing in the node layout carries property statistics to prune on — node SSTs have **no `prop_*` columns** (properties ride in `__overflow_json`) and the `.npp` pages store size limits, not values. The previous version of item 80 called for a storage-format change on that basis.

But the equality sidecar is a range-readable B+tree, and #184 made its numeric key order-preserving — so a key window **is** a value window. `equality_range_from_source` descends once to the leaf holding the lower bound and walks the chained leaf level forward: a ten-key window over a 10k-key index reads under 5% of the body.

The optimizer already pushes these predicates onto `NodeScan`, so the route sits in front of the scan. The plan does not change; only how the same predicate is satisfied.

## Why the candidate set is a superset, on purpose

Three things can put a non-matching id in the window:

* the numeric key is lossy above 2^53, so distinct integers share a key;
* a posting can name a node whose current version no longer matches;
* a raw String key can fall inside the numeric byte window.

Every candidate is confirmed with `eval_against_value` — **the same evaluator the scan uses** — so the two routes cannot disagree about what the predicate means. A subset would be a silent wrong answer; a superset is a wasted candidate.

## The cap scales with the label

The index route reads postings *and* hydrates candidates; the scan reads each row once. A fixed cap is wrong in both directions: on a small label it reads most of the corpus the slow way, on a 10M-row label it declines windows the index would win by two orders of magnitude. The manifest already carries live per-label counts, so the estimate costs no I/O.

Worth recording: the first draft used a fixed 65,536 and made the **declining** case slower than the baseline it was meant to beat (0.475 s against 0.340 s), purely from postings read and thrown away.

## Found on the way, and fixed

`WHERE n.amount < -5` never reached storage as a predicate at all. Cypher parses the sign as a unary operator, and the pushdown's literal extractor accepted only bare literals — so **every negative bound** (a temperature, a delta, a debit) was left entirely to the residual filter. `-i64::MIN` still is, rather than wrapping into a positive bound. The gap predates this work and also affected the legacy label-scoped row-group pruning path.

## Where it declines

An unindexed property, a sidecar without numeric coverage or a range-readable body, a stale accelerator, an open write transaction (whose overlay has no ordering across types), a non-numeric or unbounded predicate set, or a window wider than the cap.

## Coverage

- `crates/namidb-storage/tests/numeric_range_index.rs` — every family against a flat scan at memtable, flushed and compacted, plus the shapes the route must refuse and the cap behaviour. Verified non-inert by removing the confirm step and watching `> 1990` disagree.
- `crates/namidb-query/tests/numeric_range_route.rs` — seventeen shapes against an unindexed twin holding identical values, with a floor on how many take the index route (agreement is trivial if everything declines) and a wide range that must stay on the scan.

Full workspace suite green; clippy clean with and without `--features vector-index,text-index`.

## Still open, with the reason verified

A range on an **unindexed** property still reads every row, and nothing short of value statistics in the property pages fixes it. Item 80 is updated with that, and with a correction: two earlier versions of the entry (including one written yesterday) prescribed wiring work that cannot help.