### PR TITLE
fix: declining a wide numeric range must cost less than serving it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,24 @@ crates.io release will establish and document that API explicitly.
 
 ## [Unreleased]
 
+## [2.6.16] - 2026-09-11
+
+### Fixed
+
+- **An indexed numeric range matching a large share of its label became
+  slower than the plain scan it falls back to.** Found verifying 2.6.15
+  against the published wheel: on 60,000 rows, `WHERE v.idx > 30000`
+  (matching half) took 137 ms through the indexed property against 68 ms
+  through an unindexed twin holding identical values. Selective ranges were
+  unaffected and remain ~10x faster.
+
+  The range reader stops its leaf walk as soon as the window exceeds what
+  the caller will accept — but it then fetched the posting bodies for
+  everything it had already selected, which the caller discards. On a
+  high-cardinality property that is one external read PER KEY. It now
+  returns as soon as it knows the window overflowed, so declining costs the
+  leaf walk it had already paid for and nothing more.
+
 ## [2.6.15] - 2026-09-11
 
 ### Performance
@@ -3521,7 +3539,8 @@ Change License: Apache License 2.0).
 - LDBC-shaped synthetic benchmark harness with a paired Kùzu runner
   under [`bench/`](./bench/).
 
-[Unreleased]: https://github.com/namidb/namidb/compare/v2.6.15...HEAD
+[Unreleased]: https://github.com/namidb/namidb/compare/v2.6.16...HEAD
+[2.6.16]: https://github.com/namidb/namidb/compare/v2.6.15...v2.6.16
 [2.6.15]: https://github.com/namidb/namidb/compare/v2.6.14...v2.6.15
 [2.6.14]: https://github.com/namidb/namidb/compare/v2.6.13...v2.6.14
 [2.6.13]: https://github.com/namidb/namidb/compare/v2.6.12...v2.6.13

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2199,7 +2199,7 @@ dependencies = [
 
 [[package]]
 name = "namidb"
-version = "2.6.15"
+version = "2.6.16"
 dependencies = [
  "namidb-core",
  "namidb-graph",
@@ -2209,7 +2209,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-ann"
-version = "2.6.15"
+version = "2.6.16"
 dependencies = [
  "namidb-core",
  "rand 0.8.6",
@@ -2222,7 +2222,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-bench"
-version = "2.6.15"
+version = "2.6.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2246,7 +2246,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-bolt"
-version = "2.6.15"
+version = "2.6.16"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2266,7 +2266,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-cli"
-version = "2.6.15"
+version = "2.6.16"
 dependencies = [
  "anyhow",
  "clap",
@@ -2286,7 +2286,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-core"
-version = "2.6.15"
+version = "2.6.16"
 dependencies = [
  "arrow-array",
  "arrow-schema",
@@ -2302,7 +2302,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-graph"
-version = "2.6.15"
+version = "2.6.16"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -2324,7 +2324,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-markdown"
-version = "2.6.15"
+version = "2.6.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2347,7 +2347,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-mcp"
-version = "2.6.15"
+version = "2.6.16"
 dependencies = [
  "anyhow",
  "clap",
@@ -2367,7 +2367,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-py"
-version = "2.6.15"
+version = "2.6.16"
 dependencies = [
  "bytes",
  "chrono",
@@ -2385,7 +2385,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-query"
-version = "2.6.15"
+version = "2.6.16"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2409,7 +2409,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-server"
-version = "2.6.15"
+version = "2.6.16"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2449,7 +2449,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-storage"
-version = "2.6.15"
+version = "2.6.16"
 dependencies = [
  "anyhow",
  "arrow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2.6.15"
+version = "2.6.16"
 edition = "2021"
 rust-version = "1.85"
 license = "BUSL-1.1"
@@ -123,13 +123,13 @@ tower = { version = "0.5", features = ["limit"] }
 tower-http = { version = "0.6", features = ["trace", "cors", "timeout"] }
 
 # Local workspace crates
-namidb-core = { path = "crates/namidb-core", version = "2.6.15" }
-namidb-storage = { path = "crates/namidb-storage", version = "2.6.15" }
-namidb-markdown = { path = "crates/namidb-markdown", version = "2.6.15" }
-namidb-graph = { path = "crates/namidb-graph", version = "2.6.15" }
-namidb-ann = { path = "crates/namidb-ann", version = "2.6.15" }
-namidb-query = { path = "crates/namidb-query", version = "2.6.15" }
-namidb-bolt = { path = "crates/namidb-bolt", version = "2.6.15" }
+namidb-core = { path = "crates/namidb-core", version = "2.6.16" }
+namidb-storage = { path = "crates/namidb-storage", version = "2.6.16" }
+namidb-markdown = { path = "crates/namidb-markdown", version = "2.6.16" }
+namidb-graph = { path = "crates/namidb-graph", version = "2.6.16" }
+namidb-ann = { path = "crates/namidb-ann", version = "2.6.16" }
+namidb-query = { path = "crates/namidb-query", version = "2.6.16" }
+namidb-bolt = { path = "crates/namidb-bolt", version = "2.6.16" }
 
 [profile.release]
 opt-level = 3

--- a/crates/namidb-py/pyproject.toml
+++ b/crates/namidb-py/pyproject.toml
@@ -7,7 +7,7 @@ name = "namidb"
 # Keep in sync with the workspace `version` in /Cargo.toml.
 # `python-wheels.yml` publishes a wheel whose filename uses THIS
 # version; the release tag `py-vX.Y.Z` must match X.Y.Z exactly.
-version = "2.6.15"
+version = "2.6.16"
 description = "Cloud-native graph database on object storage (Python bindings)"
 readme = "README.md"
 license = "BUSL-1.1"

--- a/crates/namidb-storage/src/sst/paged_index.rs
+++ b/crates/namidb-storage/src/sst/paged_index.rs
@@ -2823,6 +2823,19 @@ async fn equality_range_with_source(
         page_id = next;
     }
 
+    // The window overflowed its bound, so the caller is going to discard this
+    // page and scan. Fetching the posting bodies now would be pure waste —
+    // and on a high-cardinality property that is one external read PER KEY,
+    // which made an unselective range measurably SLOWER than the scan it
+    // falls back to. Stop at the leaf walk, which is already paid for.
+    if more_in_range {
+        return Ok(EqualityRangePage {
+            postings: BTreeMap::new(),
+            stats,
+            more_in_range: true,
+        });
+    }
+
     let external: Vec<(usize, Range<u64>)> = selected
         .iter()
         .enumerate()
@@ -4008,8 +4021,31 @@ mod tests {
         )
         .await
         .unwrap();
+        // An overflowing window returns NO postings and says so. The caller
+        // is going to discard the page and scan, so fetching the posting
+        // bodies would be pure waste — one external read per key on a
+        // high-cardinality property, which made an unselective range slower
+        // than the scan it falls back to.
         assert!(capped.more_in_range, "a capped range must say so");
-        assert!(capped.postings.values().map(Vec::len).sum::<usize>() <= 7);
+        assert!(
+            capped.postings.is_empty(),
+            "an overflowing window must not pay for bodies it will not return"
+        );
+        let full = equality_range(
+            Arc::clone(&store),
+            path.clone(),
+            b"v-00004000",
+            b"v-00004009",
+            usize::MAX,
+        )
+        .await
+        .unwrap();
+        assert!(
+            capped.stats.bytes_read < full.stats.bytes_read,
+            "declining must cost LESS than serving: {} vs {}",
+            capped.stats.bytes_read,
+            full.stats.bytes_read
+        );
 
         // Bounds outside every key, both sides, and an inverted range.
         let above = equality_range(Arc::clone(&store), path.clone(), b"w", b"z", usize::MAX)


### PR DESCRIPTION
**Found verifying 2.6.15 against the published wheel, not against the local tree.**

On 60,000 rows, `WHERE v.idx > 30000` — matching half of them — took **137 ms** through the indexed property against **68 ms** through an unindexed twin holding identical values. Selective ranges were unaffected and remain ~10x faster:

| case | indexed | unindexed |
|---|---|---|
| `> 999999` (0 rows) | 3.67 ms | 43.66 ms |
| `< -5` (0 rows) | 4.35 ms | 42.98 ms |
| `> 59990` (9 rows) | 3.92 ms | 40.29 ms |
| `> 1000 AND < 1100` (99 rows) | 4.76 ms | 41.17 ms |
| **`> 30000` (29,999 rows)** | **137.27 ms** | **67.68 ms** |

Every row agreed with its twin — this was never a wrong answer, only a slower one.

## Cause

The range reader already stopped its leaf walk the moment the window exceeded what the caller would accept. It then went on to fetch the posting bodies for everything selected up to that point — which the caller discards, because an overflowing window always falls back to the scan.

On a high-cardinality property, where each key holds exactly one id, that is **one external read per key**. With the label-relative cap at 7,500 on a 60k-row label, a wide range paid ~7,500 tiny range reads before declining.

## Fix

Return as soon as the overflow is known. Declining now costs the leaf walk already paid for and nothing beyond it. Re-measured on the 160k fixture: the declining case went 398 ms → **349 ms**, against a 340 ms pre-index baseline — the overhead is gone.

The contract is pinned rather than left implicit: an overflowing window returns no postings, reports `more_in_range`, and must read strictly fewer bytes than the same window served in full.

## Why this got through

The equivalence suites compare *results*, and results were always correct. The cap test asserted `postings <= 7`, which an empty page also satisfies — so it kept passing after the change and would have kept passing before it. Only a timing comparison against the unindexed twin, on a corpus large enough to matter, showed it. That comparison now lives in the assertion as a byte-count bound, which is deterministic where timing is not.