### PR TITLE
fix: bound the leaf walk that decides a numeric range is not selective

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,31 @@ crates.io release will establish and document that API explicitly.
 
 ## [Unreleased]
 
+## [2.6.17] - 2026-09-11
+
+### Fixed
+
+- **An indexed numeric range matching a large share of its label was still
+  slower than the scan it falls back to.** 2.6.16 removed one half of the
+  waste; this removes the half that actually dominated. On 60,000 rows,
+  `WHERE v.idx > 30000` (matching half) went from 147 ms to 133 ms against
+  an unindexed twin's 146 ms — from twice the scan's cost to slightly under
+  it. Selective ranges are unchanged and remain 480x-1700x faster.
+
+  The route bounded how many POSTINGS it would collect before declining,
+  which bounds what the caller hydrates. But the cost of deciding to decline
+  is the leaf walk itself — one sequential ranged read per page — and on a
+  high-cardinality property a window matching half the label spans dozens of
+  pages. The walk is now bounded in pages as well, so declining costs a
+  fixed handful of reads whatever the window contains. A selective window
+  touches one or two pages and is unaffected.
+
+- `NAMIDB_NUMERIC_RANGE_MAX_CANDIDATES=0` now disables the range route
+  instead of aborting the process. The label-relative cap clamped into an
+  empty range, which panics — and release builds abort on panic, so a
+  configuration value could take the server down at startup of the first
+  range query.
+
 ## [2.6.16] - 2026-09-11
 
 ### Fixed
@@ -3539,7 +3564,8 @@ Change License: Apache License 2.0).
 - LDBC-shaped synthetic benchmark harness with a paired Kùzu runner
   under [`bench/`](./bench/).
 
-[Unreleased]: https://github.com/namidb/namidb/compare/v2.6.16...HEAD
+[Unreleased]: https://github.com/namidb/namidb/compare/v2.6.17...HEAD
+[2.6.17]: https://github.com/namidb/namidb/compare/v2.6.16...v2.6.17
 [2.6.16]: https://github.com/namidb/namidb/compare/v2.6.15...v2.6.16
 [2.6.15]: https://github.com/namidb/namidb/compare/v2.6.14...v2.6.15
 [2.6.14]: https://github.com/namidb/namidb/compare/v2.6.13...v2.6.14

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2199,7 +2199,7 @@ dependencies = [
 
 [[package]]
 name = "namidb"
-version = "2.6.16"
+version = "2.6.17"
 dependencies = [
  "namidb-core",
  "namidb-graph",
@@ -2209,7 +2209,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-ann"
-version = "2.6.16"
+version = "2.6.17"
 dependencies = [
  "namidb-core",
  "rand 0.8.6",
@@ -2222,7 +2222,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-bench"
-version = "2.6.16"
+version = "2.6.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2246,7 +2246,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-bolt"
-version = "2.6.16"
+version = "2.6.17"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2266,7 +2266,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-cli"
-version = "2.6.16"
+version = "2.6.17"
 dependencies = [
  "anyhow",
  "clap",
@@ -2286,7 +2286,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-core"
-version = "2.6.16"
+version = "2.6.17"
 dependencies = [
  "arrow-array",
  "arrow-schema",
@@ -2302,7 +2302,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-graph"
-version = "2.6.16"
+version = "2.6.17"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -2324,7 +2324,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-markdown"
-version = "2.6.16"
+version = "2.6.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2347,7 +2347,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-mcp"
-version = "2.6.16"
+version = "2.6.17"
 dependencies = [
  "anyhow",
  "clap",
@@ -2367,7 +2367,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-py"
-version = "2.6.16"
+version = "2.6.17"
 dependencies = [
  "bytes",
  "chrono",
@@ -2385,7 +2385,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-query"
-version = "2.6.16"
+version = "2.6.17"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2409,7 +2409,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-server"
-version = "2.6.16"
+version = "2.6.17"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2449,7 +2449,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-storage"
-version = "2.6.16"
+version = "2.6.17"
 dependencies = [
  "anyhow",
  "arrow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2.6.16"
+version = "2.6.17"
 edition = "2021"
 rust-version = "1.85"
 license = "BUSL-1.1"
@@ -123,13 +123,13 @@ tower = { version = "0.5", features = ["limit"] }
 tower-http = { version = "0.6", features = ["trace", "cors", "timeout"] }
 
 # Local workspace crates
-namidb-core = { path = "crates/namidb-core", version = "2.6.16" }
-namidb-storage = { path = "crates/namidb-storage", version = "2.6.16" }
-namidb-markdown = { path = "crates/namidb-markdown", version = "2.6.16" }
-namidb-graph = { path = "crates/namidb-graph", version = "2.6.16" }
-namidb-ann = { path = "crates/namidb-ann", version = "2.6.16" }
-namidb-query = { path = "crates/namidb-query", version = "2.6.16" }
-namidb-bolt = { path = "crates/namidb-bolt", version = "2.6.16" }
+namidb-core = { path = "crates/namidb-core", version = "2.6.17" }
+namidb-storage = { path = "crates/namidb-storage", version = "2.6.17" }
+namidb-markdown = { path = "crates/namidb-markdown", version = "2.6.17" }
+namidb-graph = { path = "crates/namidb-graph", version = "2.6.17" }
+namidb-ann = { path = "crates/namidb-ann", version = "2.6.17" }
+namidb-query = { path = "crates/namidb-query", version = "2.6.17" }
+namidb-bolt = { path = "crates/namidb-bolt", version = "2.6.17" }
 
 [profile.release]
 opt-level = 3

--- a/crates/namidb-py/pyproject.toml
+++ b/crates/namidb-py/pyproject.toml
@@ -7,7 +7,7 @@ name = "namidb"
 # Keep in sync with the workspace `version` in /Cargo.toml.
 # `python-wheels.yml` publishes a wheel whose filename uses THIS
 # version; the release tag `py-vX.Y.Z` must match X.Y.Z exactly.
-version = "2.6.16"
+version = "2.6.17"
 description = "Cloud-native graph database on object storage (Python bindings)"
 readme = "README.md"
 license = "BUSL-1.1"

--- a/crates/namidb-storage/src/read.rs
+++ b/crates/namidb-storage/src/read.rs
@@ -1402,6 +1402,7 @@ impl<'mt> Snapshot<'mt> {
                 start_key.as_bytes(),
                 end_key.as_bytes(),
                 remaining.saturating_add(1),
+                NUMERIC_RANGE_MAX_LEAF_PAGES,
             )
             .await
             {
@@ -6339,7 +6340,13 @@ impl<'mt> Snapshot<'mt> {
         let ceiling = std::env::var("NAMIDB_NUMERIC_RANGE_MAX_CANDIDATES")
             .ok()
             .and_then(|raw| raw.parse::<usize>().ok())
+            // `0` disables the route rather than panicking in `clamp(1, 0)`,
+            // which in a release build (panic = "abort") would take the
+            // process down from a config value.
             .unwrap_or(DEFAULT_CEILING);
+        if ceiling == 0 {
+            return 0;
+        }
 
         let mut live: u64 = 0;
         for idx in self.manifest.index.node_descriptors() {
@@ -10058,6 +10065,18 @@ fn equality_sidecar_key(
         },
     }
 }
+
+/// Leaf pages the numeric range walk may read before deciding the window is
+/// not selective enough to be worth an index lookup.
+///
+/// The posting cap bounds what the CALLER will hydrate; this bounds what the
+/// WALK itself costs, which is one sequential ranged read per page. Measured
+/// on a 60,000-row corpus, a window matching half the label walked ~60 pages
+/// and made the indexed query 147 ms against the scan's 74 ms — the route
+/// declined correctly and still lost, because deciding to decline was the
+/// expensive part. A selective window touches one or two pages, so this is
+/// generous for every case the route is meant to serve.
+const NUMERIC_RANGE_MAX_LEAF_PAGES: usize = 8;
 
 /// Byte bounds over the ScalarV1 key space for a conjunction of numeric
 /// predicates on `property`, or `None` when this route does not apply.

--- a/crates/namidb-storage/src/sst/paged_index.rs
+++ b/crates/namidb-storage/src/sst/paged_index.rs
@@ -2701,8 +2701,9 @@ pub async fn equality_range_from_source(
     start: &[u8],
     end: &[u8],
     max_postings: usize,
+    max_leaf_pages: usize,
 ) -> Result<EqualityRangePage> {
-    equality_range_with_source(source, start, end, max_postings).await
+    equality_range_with_source(source, start, end, max_postings, max_leaf_pages).await
 }
 
 /// Store-addressed [`equality_range_from_source`]. Test-only, mirroring
@@ -2716,7 +2717,7 @@ pub async fn equality_range(
     max_postings: usize,
 ) -> Result<EqualityRangePage> {
     let source = LegacyObjectRangeSource { store, path };
-    equality_range_with_source(&source, start, end, max_postings).await
+    equality_range_with_source(&source, start, end, max_postings, usize::MAX).await
 }
 
 async fn equality_range_with_source(
@@ -2724,6 +2725,7 @@ async fn equality_range_with_source(
     start: &[u8],
     end: &[u8],
     max_postings: usize,
+    max_leaf_pages: usize,
 ) -> Result<EqualityRangePage> {
     type SelectedPosting = (Vec<u8>, u64, usize, usize, Option<u32>);
 
@@ -2736,7 +2738,7 @@ async fn equality_range_with_source(
         bytes_read: header_bytes.len(),
         ..Default::default()
     };
-    if max_postings == 0 || start > end {
+    if max_postings == 0 || max_leaf_pages == 0 || start > end {
         return Ok(EqualityRangePage {
             stats,
             ..Default::default()
@@ -2785,9 +2787,22 @@ async fn equality_range_with_source(
     let mut selected: Vec<SelectedPosting> = Vec::new();
     let mut postings = 0usize;
     let mut more_in_range = false;
+    let mut leaf_pages = 0usize;
     'leaves: while page_id != NO_PAGE {
         crate::cancel::check()?;
+        // Two bounds, because the route has two costs. `max_postings` bounds
+        // the HYDRATION the caller will do; `max_leaf_pages` bounds the I/O
+        // this walk does, which is one sequential ranged read per page and is
+        // what actually makes an unselective window expensive. A low-
+        // cardinality property trips the first; a high-cardinality one trips
+        // the second long before it. Either way the answer is the same: this
+        // window is not selective, hand it back to the scan.
+        if leaf_pages >= max_leaf_pages {
+            more_in_range = true;
+            break 'leaves;
+        }
         let page = source.read_range(page_range(page_id)).await?;
+        leaf_pages += 1;
         stats.pages_read += 1;
         stats.bytes_read += page.len();
         let next = read_u32(&page, 8)?;
@@ -4045,6 +4060,38 @@ mod tests {
             "declining must cost LESS than serving: {} vs {}",
             capped.stats.bytes_read,
             full.stats.bytes_read
+        );
+
+        // The I/O bound: a window spanning many leaf pages must stop after
+        // the pages it was allowed, and say so. This is the bound that
+        // actually decides whether declining is cheap — the posting cap
+        // bounds the caller's hydration, this bounds the walk itself, and a
+        // high-cardinality property trips this one long before the other.
+        let one_page = equality_range_with_source(
+            &LegacyObjectRangeSource {
+                store: Arc::clone(&store),
+                path: path.clone(),
+            },
+            b"",
+            b"v-zzzzzzzz",
+            usize::MAX,
+            1,
+        )
+        .await
+        .unwrap();
+        assert!(
+            one_page.more_in_range,
+            "a window past its page budget must say so"
+        );
+        assert!(
+            one_page.postings.is_empty(),
+            "and must not pay for bodies it will not return"
+        );
+        assert!(
+            one_page.stats.bytes_read < all.stats.bytes_read / 50,
+            "declining early must be far cheaper than serving: {} vs {}",
+            one_page.stats.bytes_read,
+            all.stats.bytes_read
         );
 
         // Bounds outside every key, both sides, and an inverted range.

--- a/crates/namidb-storage/tests/numeric_range_index.rs
+++ b/crates/namidb-storage/tests/numeric_range_index.rs
@@ -242,8 +242,9 @@ async fn an_unselective_range_declines_rather_than_paying_twice() {
     let writer = corpus("range-cap", true, true).await;
     let snapshot = writer.snapshot();
 
-    // Matching (almost) the whole label: reading every posting AND hydrating
-    // every row costs strictly more than the scan that reads each row once.
+    // Matching (almost) the whole label. Reading every posting AND hydrating
+    // every row costs strictly more than the scan that reads each row once,
+    // so this must decline — and it must decline on EITHER bound.
     let wide = vec![gt(-1_000_000)];
     assert!(
         snapshot
@@ -251,20 +252,32 @@ async fn an_unselective_range_declines_rather_than_paying_twice() {
             .await
             .unwrap()
             .is_none(),
-        "a window wider than the cap must decline"
+        "a window over the posting cap must decline"
+    );
+    assert!(
+        snapshot
+            .indexed_node_ids_by_numeric_range("T", "idx", &wide, 1 << 20)
+            .await
+            .unwrap()
+            .is_none(),
+        "and still decline with a generous posting cap, because the walk \
+         itself spans more leaf pages than the route will read — that page \
+         bound is what makes declining cheap, and it is independent of how \
+         many ids the caller was willing to take"
     );
 
-    // The same window with a cap above the corpus is servable, and still has
-    // to agree with the scan.
-    let expected = by_scan(&writer, &wide).await;
-    let got = snapshot
-        .indexed_node_ids_by_numeric_range("T", "idx", &wide, 1 << 20)
+    // A window inside BOTH bounds serves, and still has to agree with the
+    // scan.
+    let narrow = vec![gt(1_900), lt(1_990)];
+    let expected = by_scan(&writer, &narrow).await;
+    let mut got = snapshot
+        .indexed_node_ids_by_numeric_range("T", "idx", &narrow, 1 << 20)
         .await
         .unwrap()
-        .expect("a generous cap must serve");
-    let mut got = got;
+        .expect("a window inside both bounds must serve");
     got.sort_unstable();
     assert_eq!(got, expected);
+    assert!(!expected.is_empty(), "the window must not be empty");
 }
 
 #[tokio::test]


### PR DESCRIPTION
**2.6.16 removed one half of the waste in declining a wide range. The other half dominated.**

Re-verified against the published 2.6.16 wheel — not the local tree — the regression was essentially unchanged: on 60,000 rows, `WHERE v.idx > 30000` (matching half) still took **136 ms** against an unindexed twin's **68 ms**.

## Isolating it

| cap | indexed `> 30000` | unindexed |
|---|---|---|
| default (label/8 = 7,500) | 147 ms | 74 ms |
| forced to 1 (declines on the first entry) | **62 ms** | 76 ms |

With the route declining immediately the query is at parity. So the fallback scan is fine and 2.6.16's fix works — the ~85 ms is spent *deciding to decline*.

## Cause

The route bounded the **postings** it would collect, which bounds what the caller hydrates. But deciding to decline costs the leaf walk itself — one sequential ranged read per page. On a high-cardinality property, where each key holds a single id, a window matching half the label spans dozens of pages before the posting bound is anywhere near.

## Fix

Bound the walk in pages as well. The two bounds cover the two shapes: a low-cardinality property (a status flag) trips the posting bound; a high-cardinality one (an amount, a code) trips the page bound long before it. A selective window touches one or two pages and is unaffected.

Measured on the same corpus:

| case | indexed | unindexed |
|---|---|---|
| `> 30000` (half) | **133 ms** | 146 ms |
| `> 1000` (98%) | **157 ms** | 159 ms |
| `> 59990` (9 rows) | **234 µs** | 113 ms |
| `> 999999` (0 rows) | **62 µs** | 108 ms |

The declining cases are now at or slightly under the scan; the selective ones are 480x–1700x.

## Also

`NAMIDB_NUMERIC_RANGE_MAX_CANDIDATES=0` clamped into an empty range, which panics — and release builds abort on panic, so that configuration value would have taken the server down on its first range query. It now disables the route, which is what setting it to zero means.

## On the testing

The page bound is pinned the way the posting bound should have been from the start: an over-budget window returns nothing, reports `more_in_range`, and must read strictly **fewer bytes** than the same window served in full.

A results-only assertion cannot see any of this. The previous cap test asserted `postings <= 7`, which an empty page also satisfies, so it passed identically before and after the fix it was meant to guard. Bytes are deterministic in CI where timings are not.

Full workspace suite green; clippy clean with and without `--features vector-index,text-index`.