### PR TITLE
fix: bound the numeric range route by the memtable it can see

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,31 @@ crates.io release will establish and document that API explicitly.
 
 ## [Unreleased]
 
+## [2.6.18] - 2026-09-11
+
+### Fixed
+
+- **A numeric range over a label that has not been flushed yet was served by
+  the index and hydrated row by row, at twice the cost of the scan.** On
+  60,000 memtable-resident rows, `WHERE v.idx > 30000` (matching half) took
+  130.7 ms against the scan's 69.0 ms. It now declines and costs 66.8 ms.
+  Selective windows are unaffected: 6.0 ms against 42.2 ms for nine rows.
+
+  The route decides whether a window is selective enough by comparing it to
+  the label's live row count, which it summed from SST descriptors. Before
+  the first flush there are none, so the sum was zero — and zero was read as
+  "no information, allow it" rather than "no information, be careful". That
+  is not a rare state: it is every store between a bulk load and its first
+  flush, which is exactly when the first query tends to arrive.
+
+  The memtable's own size now bounds the route. Scanning a memtable is
+  cheaper than scanning SSTs — it is already decoded and in memory — so the
+  bar for using an index there is higher, not lower.
+
+- `NAMIDB_NUMERIC_RANGE_MAX_CANDIDATES=0` now disables the range route
+  instead of aborting the process (2.6.17 shipped this; recorded here
+  because the release notes for it were incomplete).
+
 ## [2.6.17] - 2026-09-11
 
 ### Fixed
@@ -3564,7 +3589,8 @@ Change License: Apache License 2.0).
 - LDBC-shaped synthetic benchmark harness with a paired Kùzu runner
   under [`bench/`](./bench/).
 
-[Unreleased]: https://github.com/namidb/namidb/compare/v2.6.17...HEAD
+[Unreleased]: https://github.com/namidb/namidb/compare/v2.6.18...HEAD
+[2.6.18]: https://github.com/namidb/namidb/compare/v2.6.17...v2.6.18
 [2.6.17]: https://github.com/namidb/namidb/compare/v2.6.16...v2.6.17
 [2.6.16]: https://github.com/namidb/namidb/compare/v2.6.15...v2.6.16
 [2.6.15]: https://github.com/namidb/namidb/compare/v2.6.14...v2.6.15

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2199,7 +2199,7 @@ dependencies = [
 
 [[package]]
 name = "namidb"
-version = "2.6.17"
+version = "2.6.18"
 dependencies = [
  "namidb-core",
  "namidb-graph",
@@ -2209,7 +2209,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-ann"
-version = "2.6.17"
+version = "2.6.18"
 dependencies = [
  "namidb-core",
  "rand 0.8.6",
@@ -2222,7 +2222,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-bench"
-version = "2.6.17"
+version = "2.6.18"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2246,7 +2246,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-bolt"
-version = "2.6.17"
+version = "2.6.18"
 dependencies = [
  "async-trait",
  "bytes",
@@ -2266,7 +2266,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-cli"
-version = "2.6.17"
+version = "2.6.18"
 dependencies = [
  "anyhow",
  "clap",
@@ -2286,7 +2286,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-core"
-version = "2.6.17"
+version = "2.6.18"
 dependencies = [
  "arrow-array",
  "arrow-schema",
@@ -2302,7 +2302,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-graph"
-version = "2.6.17"
+version = "2.6.18"
 dependencies = [
  "arrow",
  "arrow-array",
@@ -2324,7 +2324,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-markdown"
-version = "2.6.17"
+version = "2.6.18"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2347,7 +2347,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-mcp"
-version = "2.6.17"
+version = "2.6.18"
 dependencies = [
  "anyhow",
  "clap",
@@ -2367,7 +2367,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-py"
-version = "2.6.17"
+version = "2.6.18"
 dependencies = [
  "bytes",
  "chrono",
@@ -2385,7 +2385,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-query"
-version = "2.6.17"
+version = "2.6.18"
 dependencies = [
  "arrow",
  "async-trait",
@@ -2409,7 +2409,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-server"
-version = "2.6.17"
+version = "2.6.18"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2449,7 +2449,7 @@ dependencies = [
 
 [[package]]
 name = "namidb-storage"
-version = "2.6.17"
+version = "2.6.18"
 dependencies = [
  "anyhow",
  "arrow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ members = [
 ]
 
 [workspace.package]
-version = "2.6.17"
+version = "2.6.18"
 edition = "2021"
 rust-version = "1.85"
 license = "BUSL-1.1"
@@ -123,13 +123,13 @@ tower = { version = "0.5", features = ["limit"] }
 tower-http = { version = "0.6", features = ["trace", "cors", "timeout"] }
 
 # Local workspace crates
-namidb-core = { path = "crates/namidb-core", version = "2.6.17" }
-namidb-storage = { path = "crates/namidb-storage", version = "2.6.17" }
-namidb-markdown = { path = "crates/namidb-markdown", version = "2.6.17" }
-namidb-graph = { path = "crates/namidb-graph", version = "2.6.17" }
-namidb-ann = { path = "crates/namidb-ann", version = "2.6.17" }
-namidb-query = { path = "crates/namidb-query", version = "2.6.17" }
-namidb-bolt = { path = "crates/namidb-bolt", version = "2.6.17" }
+namidb-core = { path = "crates/namidb-core", version = "2.6.18" }
+namidb-storage = { path = "crates/namidb-storage", version = "2.6.18" }
+namidb-markdown = { path = "crates/namidb-markdown", version = "2.6.18" }
+namidb-graph = { path = "crates/namidb-graph", version = "2.6.18" }
+namidb-ann = { path = "crates/namidb-ann", version = "2.6.18" }
+namidb-query = { path = "crates/namidb-query", version = "2.6.18" }
+namidb-bolt = { path = "crates/namidb-bolt", version = "2.6.18" }
 
 [profile.release]
 opt-level = 3

--- a/crates/namidb-py/pyproject.toml
+++ b/crates/namidb-py/pyproject.toml
@@ -7,7 +7,7 @@ name = "namidb"
 # Keep in sync with the workspace `version` in /Cargo.toml.
 # `python-wheels.yml` publishes a wheel whose filename uses THIS
 # version; the release tag `py-vX.Y.Z` must match X.Y.Z exactly.
-version = "2.6.17"
+version = "2.6.18"
 description = "Cloud-native graph database on object storage (Python bindings)"
 readme = "README.md"
 license = "BUSL-1.1"

--- a/crates/namidb-storage/src/read.rs
+++ b/crates/namidb-storage/src/read.rs
@@ -1444,7 +1444,26 @@ impl<'mt> Snapshot<'mt> {
         }
 
         // The committed/staged memtable delta, which no sidecar covers yet.
+        // The committed/staged memtable delta, which no sidecar covers yet.
+        //
+        // Its own size is part of the selectivity question, not just a source
+        // of ids. Before any flush there are NO SST descriptors to estimate
+        // the label from, and a caller-supplied cap derived only from
+        // descriptors is then meaningless — which is how a window covering
+        // half a memtable-resident label got served and hydrated row by row,
+        // at twice the cost of the scan it was supposed to beat.
         let memtable = self.memtable_property_claimants(label, property)?;
+        let memtable_rows: usize = memtable.values().map(|ids| ids.len()).sum();
+        let budget = max_candidates.min(
+            memtable_rows
+                .checked_div(MEMTABLE_RANGE_FRACTION)
+                .unwrap_or(max_candidates)
+                .max(MIN_RANGE_CANDIDATES),
+        );
+        if candidates.len() > budget {
+            crate::route_telemetry::record_property(false);
+            return Ok(None);
+        }
         for (key, ids) in memtable.iter() {
             if key.as_str() < start_key.as_str() || key.as_str() > end_key.as_str() {
                 continue;
@@ -1452,7 +1471,7 @@ impl<'mt> Snapshot<'mt> {
             for id in ids {
                 candidates.push(*id);
             }
-            if candidates.len() > max_candidates {
+            if candidates.len() > budget {
                 crate::route_telemetry::record_property(false);
                 return Ok(None);
             }
@@ -10065,6 +10084,20 @@ fn equality_sidecar_key(
         },
     }
 }
+
+/// Share of a memtable-resident label a numeric range may match and still be
+/// worth an index lookup.
+///
+/// Scanning a memtable is cheap — it is already decoded and in memory — so
+/// the bar is higher there than for SSTs. A window over this share is served
+/// by the scan, which reads each row once instead of hydrating every
+/// candidate the postings named.
+const MEMTABLE_RANGE_FRACTION: usize = 8;
+
+/// Floor under every derived candidate budget, so a tiny label (or a tiny
+/// memtable) does not make the route decline windows it would answer in
+/// microseconds.
+const MIN_RANGE_CANDIDATES: usize = 256;
 
 /// Leaf pages the numeric range walk may read before deciding the window is
 /// not selective enough to be worth an index lookup.

--- a/crates/namidb-storage/tests/numeric_range_index.rs
+++ b/crates/namidb-storage/tests/numeric_range_index.rs
@@ -280,6 +280,50 @@ async fn an_unselective_range_declines_rather_than_paying_twice() {
     assert!(!expected.is_empty(), "the window must not be empty");
 }
 
+/// The hole the flushed-corpus cap test did not cover: BEFORE any flush
+/// there are no SST descriptors, so a budget derived only from them has no
+/// information at all.
+///
+/// That is not a rare state — it is every store between a bulk load and its
+/// first flush, which is exactly when someone runs their first query. A
+/// window covering half a memtable-resident label was being served and
+/// hydrated row by row, at twice the cost of the scan it was meant to beat
+/// (measured: 130.7 ms against 69.0 ms on 60,000 rows).
+#[tokio::test]
+async fn a_wide_window_over_a_memtable_resident_label_declines_too() {
+    let writer = corpus("range-memtable", false, false).await;
+    let snapshot = writer.snapshot();
+
+    // Half the label, with no SSTs in existence.
+    assert!(
+        snapshot.manifest().manifest.ssts.is_empty(),
+        "this test is only meaningful before a flush"
+    );
+    let wide = vec![gt(ROWS / 2)];
+    assert!(
+        snapshot
+            .indexed_node_ids_by_numeric_range("T", "idx", &wide, usize::MAX)
+            .await
+            .unwrap()
+            .is_none(),
+        "a window over half a memtable-resident label must decline, whatever \
+         cap the caller offers: scanning a memtable is cheap, and hydrating \
+         every candidate the postings named is not"
+    );
+
+    // A narrow one is still served, and still agrees.
+    let narrow = vec![gt(ROWS - 10)];
+    let expected = by_scan(&writer, &narrow).await;
+    let mut got = snapshot
+        .indexed_node_ids_by_numeric_range("T", "idx", &narrow, usize::MAX)
+        .await
+        .unwrap()
+        .expect("a narrow window must still be served from the memtable");
+    got.sort_unstable();
+    assert_eq!(got, expected);
+    assert!(!expected.is_empty());
+}
+
 #[tokio::test]
 async fn shapes_this_route_must_refuse() {
     let writer = corpus("range-refuse", true, true).await;


### PR DESCRIPTION
Reopened from a clean base — #188 was cut from the 2.6.17 branch before it merged, so CI never triggered on it.

---

**Third attempt at the same regression, and the first that reproduces it.**

On 60,000 **memtable-resident** rows, `WHERE v.idx > 30000` (matching half) took **130.7 ms** against the scan's **69.0 ms**.

The previous two fixes assumed the route was declining and paying too much for the decision. It was not declining at all — it was **serving**, and hydrating 29,999 nodes to answer a query the scan counts without hydrating anything.

## Cause

The route decides whether a window is selective enough by comparing it to the label's live row count, summed from SST descriptors. Before the first flush there are none, so the sum was zero — and zero was read as *"no information, allow it"* instead of *"no information, be careful"*. Exactly backwards.

That is not a rare state. It is every store between a bulk load and its first flush, which is precisely when the first query arrives.

## Fix

The memtable's own claimant count bounds the route. Scanning a memtable is cheaper than scanning SSTs — it is already decoded and in memory — so the bar for preferring an index there is **higher**, not lower.

| case | before | after |
|---|---|---|
| `> 30000` memtable-resident (29,999 rows) | 130.7 ms, **served** | **66.8 ms**, declined (scan: 66.4 ms) |
| `> 59990` memtable-resident (9 rows) | — | **6.0 ms** (scan: 42.2 ms) |
| `> 30000` compacted | parity | parity |
| `> 59990` compacted | — | **330 µs** (scan: 150 ms) |

## Why the previous two attempts missed it

Every reproduction I wrote called `flush` explicitly, so every one had SST descriptors to estimate from and behaved correctly — my Rust measurements showed parity while the published wheel did not. The Python harness that first surfaced it never flushed.

The difference was in the test setup, not in the engine. What finally separated them was forcing the cap through `NAMIDB_NUMERIC_RANGE_MAX_CANDIDATES`: with the route off the query took 71 ms, matching 2.6.13, which established that the fallback scan was fine and the route was the entire cost.

## Coverage

The existing cap test asserted against a flushed and compacted store, so the branch that was wrong was never reached. The new test uses an un-flushed corpus and asserts the wide window declines *whatever cap the caller offers*. Verified non-inert by removing the bound and watching it fail.

Full workspace suite green; clippy clean with and without `--features vector-index,text-index`.